### PR TITLE
docs: restructure tool_ideas.md to backlog-only; add 8 new proposals

### DIFF
--- a/docs/tool_ideas.md
+++ b/docs/tool_ideas.md
@@ -1,137 +1,47 @@
 # Tool Ideas for `pythodds`
 
-This document outlines candidate tools for future addition to `pythodds`. Each entry describes the proposed command name, its statistical/mathematical architecture, practical application, and target user base — contextualised against the existing `binom` and `birthday` tools.
+This document tracks **proposed tools not yet implemented** in `pythodds`. Each entry describes the proposed command name, its mathematical architecture, practical application, and target user base.
+
+For the full list of implemented tools and their CLI entry points, see `README.md` and the `[project.scripts]` section in `pyproject.toml`.
 
 ---
 
-## Existing Tools (Reference Baseline)
+## Implemented Tools (Reference)
 
-| Command    | What it does | Core user |
-|------------|--------------|-----------|
-| `binom`    | PMF, CDF, and survival function for a Binomial(n, p) distribution | Analysts testing pass/fail rates, A/B testers, QA engineers |
-| `birthday` | Collision probability for uniform and non-uniform pools; range tables; JSON/CSV output | Security researchers, data engineers checking ID uniqueness, statisticians |
-
-All existing tools are pure-Python, zero-dependency, CLI-first, with optional use as an importable library. Proposed tools follow the same constraints and conventions.
-
----
-
-## 1. `poisson` — Distribution Calculator
-
-### Application
-The Poisson distribution models the probability of a given number of rare, independent events occurring in a fixed interval of time or space. Natural companion to `binom` for low-probability / high-trial-count scenarios (e.g. "given 3 server errors per hour on average, what is the probability of seeing 7 or more in the next hour?").
-
-### Target User Base
-- DevOps / SREs: _monitoring error rates, alert thresholds, and incident frequency_
-- Actuaries and risk analysts: _modeling claim arrival rates_
-- Scientists and researchers: _already using `binom` for discrete probability problems_
-- Directly adjacent to the existing audience: anyone comfortable with `binom -n 100 -k 3 -p 0.03` will immediately understand `poisson -k 3 -l 3.0`
-
----
-
-## 2. `normal` — Gaussian Distribution Calculator
-
-### Application
-The normal distribution is the most widely used continuous distribution. Covers z-score calculations, confidence interval boundary checks, standardisation questions, and quality control (Six Sigma-style defect rate estimation).
-
-### Target User Base
-- Students and educators: _verifying z-table lookups without needing scipy_
-- QA engineers and manufacturing analysts: _checking whether process measurements fall within tolerance bands_
-- Data scientists: _who want a quick sanity-check tool without spinning up a Python REPL_
-- Broader than `binom`/`birthday` — the most universally accessible addition to the suite
+| Command | Description |
+|---------|-------------|
+| `bayes` | Bayesian posterior update |
+| `binom` | PMF, CDF, and survival function for Binomial(n, p) |
+| `birthday` | Collision probability for uniform and non-uniform ID pools |
+| `bootci` | Bootstrap confidence intervals |
+| `collatz` | Collatz conjecture / hailstone sequences |
+| `confint` | Confidence interval calculator |
+| `expected` | Expected value and variance for discrete distributions |
+| `forecast` | Time series forecasting with prediction intervals |
+| `jevons` | Jevons paradox / rebound effect modeling |
+| `linreg` | Simple linear regression |
+| `normal` | Gaussian PDF, CDF, and quantile |
+| `pearson` | Pearson correlation coefficient |
+| `poisson` | Poisson PMF, CDF, and survival |
+| `prime` | Prime number tools and factorization |
+| `pvalue` | p-value and hypothesis test calculator |
+| `pythag` | Pythagorean win expectation |
+| `sample` | Sample size calculator |
+| `simulate` | Monte Carlo probability simulator |
+| `spearman` | Spearman rank correlation |
+| `streak` | Consecutive success/failure streak probability |
+| `ttest` | One- and two-sample t-tests |
+| `zscore` | Z-score calculator |
 
 ---
 
-## 3. `zscore` — Z-Score Calculator
+## Proposed Tools
 
-### Architecture
-- **Core functions:** `zscore(x, mu, sigma)`, `zscore_to_prob(z, tail)`, `prob_to_zscore(p, tail)`
-- Implemented via `math.erf` — no external dependencies; shares internals with `normal`
-- CLI flags: `-x`/`--value`, `-m`/`--mean`, `-s`/`--std`, `--tail {lower,upper,two}`, `--reverse` (given a probability, return the critical z-score), `--precision`
-- Output: z-score, corresponding tail probability, and percentile rank
-
-### Application
-Standardises a raw observation to its distance from the mean in standard-deviation units, and converts between z-scores and tail probabilities. Ubiquitous in quality control (Six Sigma), academic grading, financial return normalisation, and any scenario where "how unusual is this value?" is the core question.
-
-```bash
-# Z-score for a value of 75 from a distribution with mean 70, std 5
-zscore -x 75 -m 70 -s 5
-
-# Two-tailed probability for z = 1.96
-zscore -x 1.96 -m 0 -s 1 --tail two
-
-# Find the critical z-score at the 97.5th percentile
-zscore --reverse --prob 0.975 --tail lower
-```
-
-### Target User Base
-- Students and educators: _standardizing exam scores or verifying z-table lookups_
-- QA engineers: _computing how many standard deviations a measurement falls from spec_
-- Financial analysts: _normalizing asset returns for cross-security comparison_
-- A focused companion to `normal` — where `normal` computes full PDF/CDF/quantile for arbitrary distributions, `zscore` answers the single question: "how many sigmas away is this value, and how unusual is that?"
+All tools below are pure-Python unless a `Dependencies` section is noted. Dependency-optional tools degrade gracefully to plain-text output when the library is not installed.
 
 ---
 
-## 4. `sample` — Sample Size Calculator
-
-<!-- ### Architecture
-- **Core functions:** `sample_size_proportion(p, margin, alpha)`, `sample_size_mean(sigma, delta, alpha, power)`, `sample_size_comparison(p1, p2, alpha, power)`
-- z/t quantiles via `math.erf` — no external dependencies
-- CLI flags: `--type {proportion,mean,comparison}`, `-p`/`--prop`, `--delta`, `--std`, `--margin`, `--alpha`, `--power`, `--sided {one,two}`, `--sweep` (table of n vs. achieved power)
-- Output: minimum sample size, achieved power or margin of error at that n -->
-
-### Application
-Answers _"how many observations do I need?"_ before running a study, experiment, or audit. Whether sizing an A/B test, planning a clinical trial, or determining how many items to inspect in a batch, sample size calculation is prerequisite to every inferential analysis.
-
-<!-- ```bash
-# Minimum n to estimate a proportion within ±3% at 95% confidence
-sample --type proportion --p 0.5 --margin 0.03
-
-# Minimum n to detect a mean shift of 5 units (std=12) with 80% power
-sample --type mean --delta 5 --std 12 --power 0.80
-
-# Sweep: show achieved power across n = 50–300 for a two-proportion comparison
-sample --type comparison --p1 0.40 --p2 0.50 --alpha 0.05 --sweep 50 300
-``` -->
-
-### Target User Base
-- A/B testers, product analysts: _sizing experiments before launch_
-- Clinical researchers: _meeting pre-specified sample size requirements_
-- Auditors: _determining how many records to sample for a given detection sensitivity_
-- Natural prerequisite companion to `confint` and `pvalue` — the "before" step to those tools' "after" analyses
-
----
-
-## 5. `ttest` — t-Test Calculator
-
-### Architecture
-- **Core functions:** `one_sample_t(mean, mu0, std, n)`, `two_sample_t(mean1, mean2, std1, std2, n1, n2, equal_var)`, `paired_t(differences)`
-- t-distribution CDF approximated via regularised incomplete beta (`math.lgamma`) — no external dependencies
-- CLI flags: `--type {one-sample,two-sample,paired}`, `-n`/`--n1`/`--n2`, `--mean`/`--mean1`/`--mean2`, `--std`/`--std1`/`--std2`, `--mu0`, `--alpha`, `--sided {one,two}`, `--equal-var`
-- Output: t-statistic, degrees of freedom, p-value, decision at `--alpha`, confidence interval for the mean difference
-
-### Application
-The workhorse of small-sample inference. One-tailed tests answer directional questions ("is the treated group _faster_?"); two-tailed tests answer symmetric questions ("is there _any_ difference?"). Covers one-sample, independent two-sample (Welch and equal-variance), and paired designs.
-
-```bash
-# One-sample, two-tailed: is the mean different from 100? (n=20, mean=97.3, std=8.1)
-ttest --type one-sample -n 20 --mean 97.3 --std 8.1 --mu0 100 --sided two
-
-# One-tailed: does the treatment group score higher than control?
-ttest --type two-sample --n1 25 --mean1 54.2 --std1 9.3 --n2 28 --mean2 49.8 --std2 11.1 --sided one
-
-# Paired t-test from before/after differences
-ttest --type paired --diffs 2.1,-0.3,4.5,1.8,3.2,-1.1,2.9
-```
-
-### Target User Base
-- Students and educators: _working through hypothesis-testing exercises_
-- Product and UX researchers: _comparing metric means between two variants_
-- Lab scientists: _analyzing small-n experiments where z-tests are inappropriate_
-- The "small-sample" counterpart to `zscore` and `normal` — users who know their n is small will reach for `ttest` first
-
----
-
-## 6. `chisq` — Chi-Square Test Calculator
+## 1. `chisq` — Chi-Square Test Calculator
 
 ### Architecture
 - **Core functions:** `chisq_gof(observed, expected)`, `chisq_independence(table)`, `chisq_cdf(x, df)`
@@ -161,33 +71,7 @@ chisq --test gof --observed 52,48 --expected 50,50 --alpha 0.10
 
 ---
 
-## 7. `linreg` — Simple Linear Regression
-
-### Application
-Quantifies the linear relationship between two continuous variables and makes predictions with uncertainty bounds. Applicable across domains: calibration curves in lab science, price-versus-demand modeling, performance-versus-load curves in engineering, and trend lines in operations.
-
-### Target User Base
-- Scientists and engineers: _fitting calibration curves or modeling physical relationships_
-- Economists and analysts: _estimating demand or trend lines from tabular data_
-- Students _learning regression who want a no-setup CLI alternative to Excel or a notebook_
-- Extends the suite into predictive modeling — the natural destination after summarising data with `expected` and testing with `ttest` or `chisq`
-
----
-
-## 8. `expected` — Expected Value and Variance Calculator
-
-### Application
-A general-purpose tool for computing summary statistics of any user-defined discrete distribution. Useful for analysing custom payout tables, lottery structures, card game odds, or any scenario where the user supplies raw outcomes and weights — complementing `birthday`'s `--weights` flag philosophy.
-
-### Target User Base
-- Game designers and odds analysts: _modeling prize tables or betting structures_
-- Educators: _teaching probability theory who want a quick computation tool_
-- Researchers: _exploring custom distributions before committing to a full scipy/numpy setup_
-- Power users of `birthday --weights` who want deeper summary statistics on their custom pools
-
----
-
-## 9. `hypergeo` — Hypergeometric Distribution Calculator
+## 2. `hypergeo` — Hypergeometric Distribution Calculator
 
 ### Architecture
 - **Core functions:** `hypergeo_pmf(k, N, K, n)`, `hypergeo_cdf_le(k, N, K, n)`, `hypergeo_cdf_ge(k, N, K, n)`
@@ -214,39 +98,7 @@ hypergeo -N 100 -K 10 -n 15 -k 2
 
 ---
 
-## 10. `streak` — Consecutive Success/Failure Streak Probability
-
-### Application
-Answers questions like "In 162 baseball games with a .320 batting average, what is the probability of a hitting streak of at least 10 games?" or "In 50 sales calls with a 10% close rate, what is the probability of getting 3 consecutive closes?". Streak/run probability is a common question in sports analytics, quality control (consecutive defects), and trading (win/loss streaks).
-
-### Target User Base
-- Sports analysts and bettors: _evaluating hot/cold streaks_
-- Traders and quants: _assessing drawdown streaks in a strategy's win/loss record_
-- QA engineers: _monitoring consecutive failures in automated test suites_
-- Users comfortable with `binom` who want to reason about sequential structure, not just aggregate counts
-
----
-
-## 11. `bayes` — Bayesian Probability Updater
-
-### Application
-Bayesian updating underpins medical testing (sensitivity/specificity), spam filtering, and iterative belief revision. This tool provides an accessible, step-by-step command-line interface for P(H|E) calculations without requiring a full probabilistic programming library.
-
-### Target User Base
-- Medical and public health analysts: _interpreting diagnostic test results_
-- Security analysts: _updating threat probability as evidence accumulates_
-- Students: _learning Bayesian reasoning who need a tactile, command-line walkthrough_
-- A natural complement to the frequentist tools (`binom`, `poisson`) already in the suite — giving `pythodds` both frequentist and Bayesian perspectives
-
----
-
-## ⚙️ Extended Tool Ideas (Dependency-Optional, Dynamic Input)
-
-The tools below may introduce optional or required third-party dependencies — primarily for visualisation (`matplotlib`, `rich`) or numerical computation (`numpy`). Where dependencies are optional, tools degrade gracefully to plain-text output when the library is not installed. All tools continue to accept dynamic user-supplied variables to scale computation to real input.
-
----
-
-## 12. `plotdist` — Distribution Visualiser
+## 3. `plotdist` — Distribution Visualiser
 
 ### Dependencies
 - **Required:** `matplotlib` (plot rendering)
@@ -281,20 +133,7 @@ plotdist --dist binomial --params n=10 p=0.3 --text
 
 ---
 
-## 13. `simulate` — Monte Carlo Probability Simulator
-
-### Target User Base
-- Students and educators: _verifying analytical results through simulation_
-- Researchers: _stress-testing edge cases where closed-form approximations may lose accuracy_
-- Power users: _of existing tools who want to validate outputs empirically_
-- The `--scale` flag is especially valuable for users who don't know how many trials are "enough" for a given precision target
-
----
-
-## 14. `oddsconv` — Odds Format Converter
-
-### Dependencies
-- None (pure Python)
+## 4. `oddsconv` — Odds Format Converter
 
 ### Architecture
 - Converts between all major odds formats: **decimal**, **fractional**, **American (moneyline)**, **implied probability**, and **Hong Kong / Malay / Indonesian** odds
@@ -322,72 +161,10 @@ oddsconv --vig --prob 0.526 0.526
 
 ---
 
-## 15. `confint` — Confidence Interval Calculator
-
-### Dependencies
-- None (pure Python via `math.erf` and lookup tables for t-distribution)
-
-### Architecture
-- Computes confidence intervals for proportions, means, and count data
-- Modes: `--method {wilson,clopper-pearson,normal,t,poisson}`
-- Dynamic user variables: `--n` (sample size), `--k` or `--p` (successes or proportion), `--mean`, `--std`, `--alpha` (significance level, default 0.05), `--sided {one,two}`
-- Includes a `--sweep` flag to print a table of intervals across a range of sample sizes (e.g. `--sweep 10 500 --step 10`), useful for study design / power planning
-- Output: lower bound, upper bound, width, midpoint; optionally formatted as `[LB, UB]` or `midpoint ± margin`
-
-```bash
-# Wilson confidence interval for 47 successes in 120 trials
-confint --method wilson --n 120 --k 47
-
-# t-interval for a small sample mean
-confint --method t --n 15 --mean 23.4 --std 4.1
-
-# Sweep: how does interval width shrink as n grows from 50 to 500?
-confint --method wilson --p 0.4 --sweep 50 500 --step 50
-```
-
-### Target User Base
-- A/B testers and product analysts: _reporting conversion rate confidence intervals_
-- Clinical and public health researchers: _computing prevalence estimates_
-- Students: _learning inferential statistics who want a CLI alternative to lookup tables_
-- The `--sweep` flag is particularly useful for researchers planning sample sizes — a direct extension of `birthday`'s range-table philosophy applied to inference
-
----
-
-## 16. `pvalue` — p-value and Hypothesis Test Calculator
-
-### Dependencies
-- None (pure Python; t, chi-squared, and F quantiles via numerical approximation using `math`)
-
-### Architecture
-- Supports one-sample and two-sample tests: z-test, t-test, chi-squared goodness-of-fit, binomial exact test
-- Dynamic inputs: `--test {z,t,chi2,binom-exact}`, `--stat VALUE` (observed test statistic) or raw data flags (`--n`, `--k`, `--p0`, `--mean`, `--std`), `--alpha`, `--sided {one,two}`
-- Output: test statistic, p-value, decision (reject / fail to reject at `--alpha`), effect size where applicable
-- Optional `--sweep-alpha` to print decision boundaries across a range of α values
-
-```bash
-# One-sample z-test: is a coin fair? (480 heads in 1000 flips)
-pvalue --test z --n 1000 --k 480 --p0 0.5
-
-# Two-sided binomial exact test
-pvalue --test binom-exact --n 30 --k 22 --p0 0.60
-
-# Chi-squared goodness of fit
-pvalue --test chi2 --observed 18,22,20,15,25 --expected 20,20,20,20,20
-```
-
-### Target User Base
-- Data analysts and scientists: _conducting quick hypothesis tests from summary statistics_
-- Students: _in introductory statistics courses who want a CLI calculator for assignments_
-- QA/software teams: _running statistical tests on experiment results_
-- Natural follow-on to `binom` for users who reach _"I have a result — is it significant?"_ — the logical next step after PMF/CDF queries
-
----
-
-## 17. `sensitivity` — Parameter Sensitivity / Tornado Chart
+## 5. `sensitivity` — Parameter Sensitivity / Tornado Chart
 
 ### Dependencies
 - **Optional:** `matplotlib` (tornado/bar chart output); degrades to a ranked plain-text table
-- None for core computation
 
 ### Architecture
 - Takes a target formula or pythodds function (`--func {binom-pmf,poisson-pmf,normal-cdf,...}`) and a set of base-case parameters, then sweeps each parameter independently across a user-specified range
@@ -414,7 +191,7 @@ sensitivity --func normal-cdf --params x=1.5 mu=0 sigma=1 --range-pct 30 --outpu
 
 ---
 
-## 18. `randforest` — Random Forest Classifier / Regressor
+## 6. `randforest` — Random Forest Classifier / Regressor
 
 ### Dependencies
 - **Required:** `scikit-learn` (decision tree and ensemble fitting, feature importances)
@@ -424,11 +201,8 @@ sensitivity --func normal-cdf --params x=1.5 mu=0 sigma=1 --range-pct 30 --outpu
 - Wraps `sklearn.ensemble.RandomForestClassifier` / `RandomForestRegressor` behind a consistent CLI interface, keeping the same data-in → metrics-out philosophy as the rest of the suite
 - Detects task type automatically from `--target-type {auto,classify,regress}` (default `auto`: classifies if the target column has ≤ 20 unique values)
 - User-supplied variables: `--file CSV`, `--target COLUMN`, `--features COL [...]` (default: all non-target columns), `--trees N` (default 100), `--max-depth INT`, `--test-size F` (train/test split fraction, default 0.2), `--seed INT`, `--cv K` (k-fold cross-validation folds, default disabled)
-- Output:
-  - **Classification:** accuracy, precision, recall, F1, confusion matrix (plain-text), top-N feature importances
-  - **Regression:** RMSE, MAE, R², top-N feature importances
-  - `--format {table,json,csv}` for importances and metrics
-  - `--predict-file CSV` to score new observations after fitting
+- Output: Classification: accuracy, precision, recall, F1, confusion matrix, top-N feature importances; Regression: RMSE, MAE, R², top-N feature importances
+- `--format {table,json,csv}` for importances and metrics; `--predict-file CSV` to score new observations after fitting
 
 ```bash
 # Classify from a CSV file, auto-detect task type
@@ -452,42 +226,7 @@ randforest --file train.csv --target outcome --predict-file new_obs.csv
 
 ---
 
-## 19. `forecast` — Time Series Forecasting with Prediction Intervals
-
-<!-- ### Dependencies
-- **Optional:** `statsmodels` (Holt-Winters / ETS models with optimised smoothing parameters); falls back to pure-Python simple and double exponential smoothing
-- **Optional:** `numpy` (faster array operations for large series) -->
-
-### Architecture
-- Fits an exponential smoothing model to a user-supplied time series and generates point forecasts with symmetric prediction intervals derived from in-sample residual variance
-- Methods: `--method {simple,double,holt-winters}` — simple (level only), double (level + trend), Holt-Winters (level + trend + seasonal)
-- User-supplied variables: `--data CSV_OR_VALUES`, `--periods INT` (steps to forecast), `--alpha F` (confidence level, default 0.95), `--seasonal-period INT` (Holt-Winters only), `--format {table,json,csv}`
-- Outputs: fitted values, forecast values, lower and upper prediction interval bounds, residual standard deviation
-- `--backtest K` flag holds out the last K observations and reports RMSE/MAE on the holdout set
-
-```bash
-# Simple exponential smoothing, 6-period forecast
-forecast --data 120,135,148,130,142,155,160 --method simple --periods 6
-
-# Holt-Winters with weekly seasonality (period=7), 14-day forecast
-forecast --data sales.csv --method holt-winters --seasonal-period 7 --periods 14
-
-# Backtest: evaluate accuracy on the last 4 observations
-forecast --data counts.csv --method double --periods 4 --backtest 4 --format json
-```
-
-### Target User Base
-- Operations and supply-chain analysts - _projecting demand with uncertainty bounds_
-- Finance and business analysts - _building revenue or cost forecasts with explicit variance_
-- DevOps / SREs: _forecasting queue depths, error rates, or resource utilisation ahead of capacity planning_
-- The natural "what happens next?" complement to `poisson` and `expected` — users who model a current rate will want to project it forward
-
----
-
-## 20. `ewma` — Exponentially Weighted Moving Average & Control Limits
-
-### Dependencies
-- None (pure Python)
+## 7. `ewma` — Exponentially Weighted Moving Average & Control Limits
 
 ### Architecture
 - Computes an EWMA (exponentially weighted moving average) of a series and derives upper/lower control limits (UCL/LCL) from the rolling variance estimate — the statistical basis of real-time anomaly detection and EWMA control charts
@@ -514,16 +253,14 @@ ewma --data error_counts.csv --lambda 0.3 --format json
 
 ---
 
-## 21. `vartest` — Variance Equality Tests
-
-### Dependencies
-- None (pure Python via `math.lgamma` for F and chi-square CDFs)
+## 8. `vartest` — Variance Equality Tests
 
 ### Architecture
 - Tests whether two or more samples have equal variances — a critical prerequisite for `ttest --equal-var` and many ANOVA-based analyses
 - Tests: `--test {f,levene,bartlett}` — F-test (two samples), Levene (robust, 2+ samples), Bartlett (2+ samples, assumes normality)
 - CLI flags: `--data GROUP1 GROUP2 [...]` (comma-separated values per group), `--file CSV --group-col COL --value-col COL`, `--alpha F`, `--sided {one,two}`
 - Output: test statistic, degrees of freedom, p-value, decision; sample variances and ratio for the F-test
+- Pure Python via `math.lgamma` for F and chi-square CDFs
 
 ```bash
 # F-test for equality of variances between two groups
@@ -544,37 +281,7 @@ vartest --test bartlett --data "1.2,1.5,1.3" "2.1,2.4,2.2,2.0" --alpha 0.01
 
 ---
 
-## 22. `bootci` — Bootstrap Confidence Intervals
-
-<!-- ### Dependencies
-- **Optional:** `numpy` (vectorised resampling for large `--samples`; falls back to `random.choices` from the standard library) -->
-
-### Architecture
-- Estimates confidence intervals for any sample statistic via non-parametric bootstrap resampling — no distributional assumptions required
-- Statistics: `--stat {mean,median,std,var,skewness,kurtosis,p5,p95,custom}`; `--custom-expr` allows user-defined statistics (e.g. `"sorted(x)[len(x)//2] / sum(x) * len(x)"`)
-- CLI flags: `--data CSV_OR_VALUES`, `--stat STAT`, `--samples INT` (bootstrap replicates, default 10 000), `--alpha F` (default 0.05), `--method {percentile,bca}` (basic percentile or bias-corrected accelerated), `--seed INT`, `--format {table,json}`
-- Output: observed statistic, bootstrap SE, lower and upper CI bounds, bootstrap distribution summary (mean, SD of replicates)
-
-<!-- ```bash
-# 95% bootstrap CI for the mean of a small sample
-bootci --data 14.2,13.8,15.1,14.5,13.9,15.3 --stat mean --samples 10000
-
-# BCa CI for the median (more accurate for skewed data)
-bootci --data measurements.csv --stat median --method bca --seed 42
-
-# CI for variance, exported as JSON
-bootci --data sensor_readings.csv --stat var --samples 50000 --format json
-``` -->
-
-### Target User Base
-- Researchers and statisticians: _who need variance estimates without assuming a parametric distribution_
-- Data scientists: _validating model performance metrics (e.g. bootstrap CI for RMSE or R²) on small samples_
-- Students: _learning resampling methods as an alternative to closed-form interval formulas_
-- Complements `confint` (parametric) — when the user isn't sure their data is normal, `bootci` is the distribution-free alternative
-
----
-
-## 23. `mlreg` — Multiple Linear Regression with Prediction Intervals
+## 9. `mlreg` — Multiple Linear Regression with Prediction Intervals
 
 ### Dependencies
 - **Required:** `numpy` (matrix algebra for OLS: $(X^TX)^{-1}X^Ty$)
@@ -601,43 +308,11 @@ mlreg --file train.csv --target output --predict-file new_inputs.csv --alpha 0.1
 - Analysts and data scientists: _who need a CLI multiple regression tool without opening a notebook or statistical package_
 - Researchers: _reporting coefficient estimates with standard errors and prediction intervals_
 - Engineers: _modeling a response variable (yield, latency, defect rate) as a function of multiple controllable inputs_
-- Extends `linreg` to multiple predictors and adds the critical distinction between confidence intervals (mean response variance) and prediction intervals (individual response variance) — the correct tool when "how uncertain is a single new forecast?" matters
+- Extends `linreg` to multiple predictors and adds the critical distinction between confidence intervals (mean response variance) and prediction intervals (individual response variance)
 
 ---
 
-## 24. `pearson` — Pearson Correlation Coefficient
-
-### Application
-Measures the strength and direction of linear association between two continuous variables. Essential for feature selection in modeling, relationship analysis in research, and validation that predictor-response relationships are approximately linear before fitting regression. Applicable across economics (price vs demand), finance (asset correlation), psychology (test score relationships), and any domain requiring correlation analysis.
-
-### Target User Base
-- Data scientists and analysts: _quantifying feature-to-target relationships before modeling_
-- Researchers: _testing hypotheses about linear associations between measured variables_
-- Students: _learning correlation analysis without needing scipy/pandas_
-- A natural precursor to `linreg` — users wondering "should I fit a line?" first ask "is there a correlation?" via `pearson`
-
----
-
-## 25. `spearman` — Spearman Rank Correlation
-
-### Dependencies
-- `scipy`
-
-### Application
-Measures monotonic (not necessarily linear) association between variables, robust to outliers and non-normal distributions. Ideal for ordinal data (rankings, survey Likert scales), skewed continuous data, or when the relationship shape is unknown but suspected to be monotonic. Common in psychology, social sciences, quality ranking, and exploratory analysis where `pearson` assumptions may not hold.
-
-### Target User Base
-- Survey analysts and social scientists: _analyzing ordinal or Likert-scale relationships_
-- Data scientists: _performing robust correlation analysis on skewed or outlier-prone data_
-- Students: _learning non-parametric methods as an alternative to Pearson_
-- Complements `pearson` — _when data violate normality/linearity assumptions, or when measuring rank concordance vs. linear fit, `spearman` is the go-to choice_
-
----
-
-## 26. `taylor` — Taylor Series Approximation
-
-### Dependencies
-- None (pure Python)
+## 10. `taylor` — Taylor Series Approximation
 
 ### Architecture
 - **Core functions:** `taylor_series(func, a, x, n)` → approximation value and coefficients; `taylor_error(func, a, x, n)` → actual value, approximation, absolute and relative error
@@ -645,9 +320,10 @@ Measures monotonic (not necessarily linear) association between variables, robus
 - Supported functions: `exp`, `sin`, `cos`, `tan`, `ln`, `sqrt`, `sinh`, `cosh`, and user-defined custom functions via `--custom "f(x) = ..."`
 - CLI flags: `--func {exp,sin,cos,ln,sqrt,sinh,cosh,custom}`, `--center A` (expansion point), `--eval X` (evaluation point), `--order N`, `--terms` (show individual terms), `--compare` (compare to true value), `--precision INT`, `--format {table,json}`
 - Output: series coefficients, partial sums (1st through n-th order), final approximation, comparison to actual function value with error metrics
+- Pure Python — no external dependencies
 
 ### Application
-Taylor series are fundamental for numerical approximation, understanding function behavior near a point, and deriving efficient computational methods. Applications include numerical analysis (algorithm design for sin/cos/exp in calculators), physics (linearizing equations of motion), signal processing (filter design), machine learning (second-order optimization via Hessian approximations), and teaching calculus concepts tactilely.
+Taylor series are fundamental for numerical approximation, understanding function behavior near a point, and deriving efficient computational methods. Applications include numerical analysis (algorithm design for sin/cos/exp in calculators), physics (linearizing equations of motion), signal processing (filter design), and teaching calculus concepts tactilely.
 
 ```bash
 # Approximate e^x at x=1 using 5th-order Taylor series around x=0
@@ -668,10 +344,7 @@ taylor --func ln --center 1 --eval 1.5 --order 10 --compare --format json
 
 ---
 
-## 27. `compound` — Compound Interest & Time Value of Money
-
-### Dependencies
-- None (pure Python)
+## 11. `compound` — Compound Interest & Time Value of Money
 
 ### Architecture
 - **Core functions:** `future_value(pv, r, n, t)`, `present_value(fv, r, n, t)`, `annuity(pmt, r, n, t)`, `pmt_from_pv(pv, r, n, t)`, `effective_rate(nom_rate, n)`, `continuous_compound(pv, r, t)`
@@ -679,9 +352,10 @@ taylor --func ln --center 1 --eval 1.5 --order 10 --compare --format json
 - Modes: `--mode {fv,pv,annuity,payment,effective,continuous}`
 - CLI flags: `--pv F` (present value), `--fv F` (future value), `--rate F` (interest rate per period), `--periods INT` (compounding periods per year), `--time F` (years), `--pmt F` (payment per period), `--precision INT`, `--format {table,json,csv}`, `--schedule` (amortization table)
 - Output: computed value, total interest earned/paid, effective annual rate; optional payment schedule with per-period interest/principal breakdown
+- Pure Python — no external dependencies
 
 ### Application
-Fundamental to personal finance (savings, loans, mortgages), investment analysis (NPV, IRR prerequisites), retirement planning (annuity valuation), and business finance (capital budgeting). Answers "how much will I have in 30 years?", "what monthly payment fits my budget?", "what is the effective APR given monthly compounding?". Ubiquitous across finance, economics, and real-world decision-making.
+Fundamental to personal finance (savings, loans, mortgages), investment analysis (NPV, IRR prerequisites), retirement planning (annuity valuation), and business finance (capital budgeting). Answers "how much will I have in 30 years?", "what monthly payment fits my budget?", "what is the effective APR given monthly compounding?".
 
 ```bash
 # Future value: $10,000 at 5% annual interest, compounded monthly, for 10 years
@@ -705,7 +379,7 @@ compound --mode payment --pv 50000 --rate 0.06 --periods 12 --time 5 --schedule
 
 ---
 
-## 28. `matrix` — Matrix Operations & Linear Algebra
+## 12. `matrix` — Matrix Operations & Linear Algebra
 
 ### Dependencies
 - **Optional:** `numpy` (efficient operations on large matrices, eigenvalues, SVD); falls back to pure-Python nested lists for small matrices
@@ -717,7 +391,7 @@ compound --mode payment --pv 50000 --rate 0.06 --periods 12 --time 5 --schedule
 - Output: result matrix/value, condition number (for inverse/solve), optional step-by-step algorithm trace
 
 ### Application
-Linear algebra underpins machine learning (PCA, neural network backprop), computer graphics (3D transformations), physics (quantum mechanics, classical mechanics matrix formulations), economics (input-output models, Markov chains), and engineering (control theory, structural analysis). Whether solving a system of equations, computing eigenvectors for dimensionality reduction, or checking matrix singularity, this tool provides CLI access without MATLAB/Octave.
+Linear algebra underpins machine learning (PCA, neural network backprop), computer graphics (3D transformations), physics (quantum mechanics, classical mechanics matrix formulations), economics (input-output models, Markov chains), and engineering (control theory, structural analysis). CLI access without MATLAB/Octave.
 
 ```bash
 # Matrix multiplication
@@ -732,9 +406,6 @@ matrix --op solve --matrix "[[3,1],[-1,2]]" --vector "[9,8]" --show-steps
 
 # Eigenvalues and eigenvectors (numpy required for large matrices)
 matrix --op eigen --matrix "[[6,-1],[2,3]]" --format json
-
-# SVD for dimensionality reduction inspection
-matrix --op svd --file data_matrix.csv
 ```
 
 ### Target User Base
@@ -745,34 +416,17 @@ matrix --op svd --file data_matrix.csv
 
 ---
 
-## 29. `prime` — Prime Number Tools & Factorization
-
-### Application
-Prime numbers are central to cryptography (RSA key generation, Diffie-Hellman), number theory research, coding theory, hashing algorithms, and mathematical puzzles. Prime factorization is used in simplifying fractions, LCM/GCD computation, and understanding multiplicative structure. Practical uses include checking if a number is suitable for a hash table size (prefer primes), generating test cases, and teaching modular arithmetic.
-
-### Target User Base
-- Cryptographers and security engineers: _generating or validating prime numbers for key generation_
-- Students and educators: _exploring number theory concepts, prime distributions, and factorization_
-- Programmers: _choosing prime-sized hash tables or moduli for algorithms_
-- Mathematicians and hobbyists: _investigating prime patterns, twin primes, or gaps_
-- A recreational and practical tool — spanning from teaching tool to production cryptography support
-
----
-
-## 30. `fibonacci` — Fibonacci Sequence & Golden Ratio
-
-### Dependencies
-- None (pure Python)
+## 13. `fibonacci` — Fibonacci Sequence & Golden Ratio
 
 ### Architecture
 - **Core functions:** `fib(n)` (n-th Fibonacci number), `fib_seq(n)` (first n terms), `golden_ratio()`, `fib_ratio(n)` (ratio F(n)/F(n-1) approaching φ), `lucas(n)` (Lucas numbers), `binet_formula(n)` (closed-form calculation)
-- Modes: `--nth N`, `--seq N`, `--ratio N`, `--lucas N`, `--golden`, `--approx N` (compare iterative vs. Binet formula), `--properties` (φ properties, φ² = φ + 1, etc.)
 - Uses matrix exponentiation for large n (O(log n) time), memoization for sequences
 - CLI flags: `--nth`, `--seq`, `--ratio`, `--lucas`, `--golden`, `--approx`, `--properties`, `--precision INT`, `--format {table,json,csv}`
 - Output: Fibonacci number(s), ratio, φ constant, comparison table (showing convergence of F(n)/F(n-1) → φ)
+- Pure Python — no external dependencies
 
 ### Application
-The Fibonacci sequence appears in nature (phyllotaxis, branching, spirals), art (golden rectangle, golden spiral in composition), finance (Fibonacci retracements in technical analysis), computer science (algorithm analysis, data structure performance), and mathematics (number theory, combinatorics). The golden ratio is ubiquitous in design, architecture, and aesthetics. Practical uses include algorithm complexity analysis (Fibonacci heap), teaching recursion/DP, and exploring growth patterns.
+The Fibonacci sequence appears in nature (phyllotaxis, branching, spirals), art (golden rectangle, golden spiral in composition), finance (Fibonacci retracements in technical analysis), and computer science (algorithm analysis, data structure performance). Practical uses include algorithm complexity analysis (Fibonacci heap), teaching recursion/DP, and exploring growth patterns.
 
 ```bash
 # The 50th Fibonacci number
@@ -786,12 +440,6 @@ fibonacci --ratio 30
 
 # Compare iterative vs. Binet formula accuracy
 fibonacci --approx 40
-
-# Properties of the golden ratio
-fibonacci --golden --properties --precision 15
-
-# Lucas numbers (related sequence)
-fibonacci --lucas 15
 ```
 
 ### Target User Base
@@ -799,17 +447,19 @@ fibonacci --lucas 15
 - Designers and artists: _using the golden ratio for layout, composition, or proportion calculations_
 - Traders: _applying Fibonacci retracement levels in technical analysis_
 - Computer scientists: _analyzing algorithm complexity or Fibonacci heap performance_
-- A blend of educational, aesthetic, and practical applications — one of the most recognizable mathematical sequences with wide interdisciplinary appeal
 
 ---
 
-## 31. `sigmoid` — Sigmoid Function and Curve
+## 14. `sigmoid` — Sigmoid Function and Curve
 
 ### Architecture
 - **Core functions:** `sigmoid(x)`, `sigmoid_derivative(x)`, `inverse_logit(p)`
 - Pure Python via `math.exp` — no external dependencies; shares internals with `logreg`
 - CLI flags: `-x`/`--value`, `--derivative` (return slope at x), `--range MIN MAX STEP` (table of values), `--plot` (Unicode sparkline; matplotlib curve if installed), `--precision`
 - Output: sigmoid value at x, optional derivative, optional range table
+
+### Application
+The sigmoid function maps any real number to (0, 1), making it the foundational activation function in neural networks and the link function in logistic regression. Used for probability squashing, S-curve growth modeling, dose-response curves, and anywhere a smooth transition between 0 and 1 is needed.
 
 ```bash
 # Sigmoid value at x = 2.0
@@ -825,9 +475,6 @@ sigmoid --range -5 5 1
 sigmoid --inverse --prob 0.75
 ```
 
-### Application
-The sigmoid function maps any real number to (0, 1), making it the foundational activation function in neural networks and the link function in logistic regression. Used for probability squashing, S-curve growth modeling, dose-response curves, and anywhere a smooth transition between 0 and 1 is needed.
-
 ### Target User Base
 - ML students and data scientists: _understanding neural network activations from first principles_
 - Statisticians: _exploring the logistic link function before fitting a `logreg` model_
@@ -836,13 +483,16 @@ The sigmoid function maps any real number to (0, 1), making it the foundational 
 
 ---
 
-## 32. `euler` — Euler's Constant and Related Functions
+## 15. `euler` — Euler's Constant and Related Functions
 
 ### Architecture
 - **Core functions:** `e_approx(n)` (limit definition `(1 + 1/n)^n`), `exp_series(x, n)` (Taylor expansion of e^x), `euler_identity()`, `natural_log(x, n)`, `euler_mascheroni()`
 - Pure Python via `math` — no external dependencies
 - CLI flags: `--approx N` (convergence to e via limit), `--exp X` (e^x via series), `--identity` (display Euler's identity), `--ln X` (natural log), `--mascheroni` (γ constant), `--precision INT`, `--format {table,json}`
 - Output: value, convergence table (for `--approx`), comparison to `math.e` / `math.log`
+
+### Application
+Euler's number e ≈ 2.71828 is the base of natural logarithms and the foundation of continuous compounding, exponential growth/decay, complex analysis, and information theory. Appearing in probability (normal distribution, Poisson), finance (continuous interest), and physics (radioactive decay), it is one of the five most important mathematical constants.
 
 ```bash
 # Approximate e using the limit definition with n = 1,000,000
@@ -858,9 +508,6 @@ euler --identity --precision 15
 euler --ln 10
 ```
 
-### Application
-Euler's number e ≈ 2.71828 is the base of natural logarithms and the foundation of continuous compounding, exponential growth/decay, complex analysis, and information theory. Appearing in probability (normal distribution, Poisson), finance (continuous interest), and physics (radioactive decay), it is one of the five most important constants in mathematics. This tool makes e and its properties tactile and interactive.
-
 ### Target User Base
 - Students and educators: _verifying convergence of the limit definition, exploring Taylor series for e^x_
 - Financial analysts: _computing continuous compounding values (complement to `compound`'s `--continuous` mode)_
@@ -869,13 +516,16 @@ Euler's number e ≈ 2.71828 is the base of natural logarithms and the foundatio
 
 ---
 
-## 33. `logreg` — Logistic Regression
+## 16. `logreg` — Logistic Regression
 
 ### Architecture
 - **Core functions:** `fit(X, y)` → coefficients, SE, z-stats, p-values, log-likelihood; `predict_proba(X, coeffs)` → probability; `predict_class(X, coeffs, threshold)` → binary label; `log_odds(p)` → logit
 - Gradient-descent or Newton-Raphson fitting via `math` — no required external dependencies; optional `numpy` for matrix operations on larger datasets
 - CLI flags: `--file CSV`, `--target COL`, `--features COL [...]` (default: all non-target), `--threshold F` (classification cutoff, default 0.5), `--alpha F` (significance level), `--predict-file CSV`, `--format {table,json,csv}`, `--max-iter INT`, `--precision INT`
 - Output: coefficient table (estimate, SE, z-stat, p-value, OR = exp(coeff)), model summary (log-likelihood, AIC, BIC, pseudo-R²), confusion matrix, accuracy/precision/recall/F1
+
+### Application
+Logistic regression is the workhorse binary classifier, directly modeling the probability of a binary outcome as a sigmoid function of linear predictors. Underpins medical diagnosis (disease yes/no), marketing (click/no-click), credit scoring (default/no-default), and any domain where the outcome is binary and interpretability matters. Coefficients as odds ratios make results directly communicable to non-technical stakeholders.
 
 ```bash
 # Fit logistic regression from CSV; default threshold 0.5
@@ -888,9 +538,6 @@ logreg --file churn.csv --target churned --features tenure spend logins --thresh
 logreg --file train.csv --target clicked --predict-file new_users.csv --format json
 ```
 
-### Application
-Logistic regression is the workhorse binary classifier, directly modeling the probability of a binary outcome as a sigmoid function of linear predictors. It underpins medical diagnosis (disease yes/no), marketing (click/no-click), credit scoring (default/no-default), and any domain where the outcome is binary and interpretability matters. Coefficients as odds ratios make results directly communicable to non-technical stakeholders.
-
 ### Target User Base
 - Data scientists and analysts: _baseline binary classifier before trying more complex models_
 - Medical and public health researchers: _odds ratio estimation and risk factor analysis_
@@ -899,13 +546,16 @@ Logistic regression is the workhorse binary classifier, directly modeling the pr
 
 ---
 
-## 34. `breakeven` — Break-Even Analysis
+## 17. `breakeven` — Break-Even Analysis
 
 ### Architecture
 - **Core functions:** `breakeven_units(fixed, price, variable)`, `breakeven_revenue(fixed, margin)`, `margin_of_safety(actual_units, breakeven_units)`, `target_profit_units(fixed, price, variable, profit)`
 - Pure Python — no external dependencies; optional `matplotlib` for a revenue/cost curve chart
 - CLI flags: `--fixed F` (total fixed costs), `--price F` (selling price per unit), `--variable F` (variable cost per unit), `--target-profit F` (optional: units needed for a profit target), `--margin` (compute contribution margin and ratio), `--sweep MIN MAX STEP` (table across price or unit range), `--chart` (text bar chart or matplotlib curve if available), `--format {table,json,csv}`, `--precision`
 - Output: break-even units, break-even revenue, contribution margin, margin of safety; optional profit/loss table across unit range
+
+### Application
+Break-even analysis is the foundational tool for business viability assessment: at what volume does a product, project, or business become profitable? Used in startup planning, product launches, pricing decisions, event budgeting, and investment threshold analysis. The `--sweep` flag and optional chart make it especially actionable for scenario planning and presentations.
 
 ```bash
 # Basic break-even: fixed costs $50k, price $25, variable cost $10 per unit
@@ -916,13 +566,7 @@ breakeven --fixed 50000 --price 25 --variable 10 --target-profit 20000
 
 # Sweep: profit/loss table from 0 to 8,000 units in steps of 500
 breakeven --fixed 50000 --price 25 --variable 10 --sweep 0 8000 500
-
-# Chart the revenue vs total-cost curves (matplotlib or text fallback)
-breakeven --fixed 50000 --price 25 --variable 10 --chart
 ```
-
-### Application
-Break-even analysis is the foundational tool for business viability assessment: at what volume does a product, project, or business become profitable? Used in startup planning, product launches, pricing decisions, event budgeting, and investment threshold analysis. The `--sweep` flag and optional chart make it especially actionable for scenario planning and presentations.
 
 ### Target User Base
 - Entrepreneurs and small business owners: _validating whether a product can be profitable before launch_
@@ -932,13 +576,16 @@ Break-even analysis is the foundational tool for business viability assessment: 
 
 ---
 
-## 35. `grover` — Grover's Quantum Search Algorithm Simulator
+## 18. `grover` — Grover's Quantum Search Algorithm Simulator
 
 ### Architecture
 - **Core functions:** `optimal_iterations(n)` → `floor(π/4 · √n)`; `success_probability(n, k, iterations)` → analytical amplitude calculation; `amplitude_evolution(n, k, t)` → probability at each step; `speedup_ratio(n)` → classical vs quantum step ratio
 - Pure Python — no external dependencies (quantum amplitudes computed analytically from trigonometry via `math`)
 - CLI flags: `-n`/`--items INT` (search space size), `-k`/`--targets INT` (number of marked items, default 1), `--iterations INT` (override optimal; default = optimal), `--compare` (side-by-side classical O(n) vs quantum O(√n) step counts), `--sweep` (table of success probability across iteration counts), `--format {table,json}`
 - Output: optimal iteration count, success probability at optimal iterations, amplitude evolution table, classical vs quantum step comparison
+
+### Application
+Grover's algorithm provides a provable quadratic speedup over classical unstructured search, finding a marked item in N elements with O(√N) oracle queries versus O(N) classically. A cornerstone result in quantum computing and cryptanalysis (implications for symmetric key security). This tool provides an analytical simulator — computing exact probabilities from amplitude equations — making the algorithm accessible without quantum hardware.
 
 ```bash
 # Optimal Grover search over 1,024 items (1 target)
@@ -949,13 +596,7 @@ grover -n 256 -k 3
 
 # Compare classical vs quantum steps across space sizes 2^4 through 2^20
 grover --compare --sweep 16 1048576
-
-# Show how success probability evolves over each iteration
-grover -n 512 --sweep
 ```
-
-### Application
-Grover's algorithm provides a provable quadratic speedup over classical unstructured search, finding a marked item in N elements with O(√N) oracle queries versus O(N) classically. It is a cornerstone result in quantum computing and cryptanalysis (implications for symmetric key security). This tool provides an analytical simulator — computing exact probabilities from amplitude equations — making the algorithm accessible without a quantum hardware or full quantum circuit simulator.
 
 ### Target User Base
 - CS and physics students: _visualizing quantum amplitude amplification and understanding the quadratic speedup_
@@ -965,90 +606,281 @@ Grover's algorithm provides a provable quadratic speedup over classical unstruct
 
 ---
 
-## 36. `collatz` — Collatz Conjecture *(implemented)*
+## 19. `anova` — One-Way Analysis of Variance
 
-> **Status:** Already implemented in `src/utils/collatz_conjecture.py`.
+### Architecture
+- **Core functions:** `anova_one_way(groups)` → F-stat, p-value, df_between, df_within, SS_between, SS_within, MS values; `tukey_hsd(groups)` → pairwise mean differences with adjusted p-values; `bonferroni(groups, alpha)` → corrected per-comparison α
+- F-distribution CDF via regularised incomplete beta (`math.lgamma`) — no external dependencies
+- CLI flags: `--data GROUP1 GROUP2 [...]` (comma-separated values per group), `--file CSV --group-col COL --value-col COL`, `--alpha F` (default 0.05), `--posthoc {tukey,bonferroni,none}`, `--format {table,json}`
+- Output: ANOVA table (SS, df, MS, F, p), decision at α; post-hoc pairwise comparison table with adjusted p-values and significance indicators
+
+```bash
+# One-way ANOVA across three treatment groups
+anova --data "12.1,11.8,12.5,11.9" "9.8,10.3,10.1,9.7" "15.2,14.9,15.5,16.0"
+
+# With Tukey HSD post-hoc comparisons
+anova --data "12.1,11.8,12.5" "9.8,10.3,10.1" "15.2,14.9,15.5" --posthoc tukey
+
+# From CSV with group and value columns
+anova --file experiment.csv --group-col treatment --value-col response --alpha 0.01
+```
 
 ### Application
-Applies the Collatz function iteratively: if n is even, divide by 2; if odd, multiply by 3 and add 1. The conjecture states every positive integer eventually reaches 1. The tool computes the full sequence, stopping time (number of steps to reach 1), and maximum value reached. A touchstone for recreational mathematics, algorithm complexity, and number theory education.
+Tests whether the means of three or more independent groups are equal — the natural generalization of the two-sample t-test to multiple groups. Used in clinical trials (multiple treatment arms), product testing (A/B/C/D experiments), and any designed experiment where more than two conditions are compared simultaneously, avoiding the inflated Type I error of running multiple pairwise t-tests.
 
 ### Target User Base
-- Students and educators: _exploring number theory and iterative processes_
-- Mathematicians and hobbyists: _investigating stopping times, hailstone sequences, and open conjectures_
-- Programmers: _using as a benchmark or teaching example for recursion and memoization_
+- Researchers and statisticians: _comparing means across multiple experimental conditions_
+- Product and UX analysts: _running multi-variant experiments with more than two arms_
+- Students: _learning the F-distribution and the relationship between ANOVA and t-tests_
+- The natural next step after `ttest` — users who outgrow two-group comparisons will reach for `anova` first
 
 ---
 
-## 37. `jevons` — Jevons Paradox *(implemented)*
+## 20. `geometric` — Geometric Distribution Calculator
 
-> **Status:** Already implemented in `src/utils/jevons_paradox.py`.
+### Architecture
+- **Core functions:** `geo_pmf(k, p)`, `geo_cdf(k, p)`, `geo_survival(k, p)`, `geo_mean(p)`, `geo_variance(p)`
+- Pure Python via `math` — no external dependencies
+- CLI flags: `-k INT` (trial number), `-p F` (success probability per trial), `--survival` (return P(X > k) instead of CDF), `--table MIN MAX` (range of PMF/CDF values), `--precision INT`
+- Output: PMF at k, CDF ≤ k, survival P(X > k), mean, variance
+
+```bash
+# P(first success on exactly the 5th trial, p=0.3)
+geometric -k 5 -p 0.3
+
+# P(needing more than 10 calls to close a sale with 20% close rate)
+geometric -k 10 -p 0.2 --survival
+
+# Range table: probability distribution for k = 1 to 15
+geometric -p 0.25 --table 1 15
+```
 
 ### Application
-Models the Jevons Paradox: increases in resource efficiency often lead to increased total resource consumption due to an increase in demand. Quantifies rebound effects given efficiency gain and demand elasticity. Applicable to energy economics, environmental policy analysis, and technology adoption modeling.
+Models "how many independent trials until the first success?" — the discrete-time analog of the exponential distribution. Common in quality control (how many items tested until first defect), sales (calls until first close), reliability (components tested until first failure), and network retransmission modeling.
 
 ### Target User Base
-- Economists and policy analysts: _modeling rebound effects in energy or resource efficiency programs_
-- Researchers and students: _studying sustainability, environmental economics, or technological change_
-- Data analysts: _quantifying whether efficiency gains translate to real resource reductions or are offset by demand growth_
+- QA and reliability engineers: _modeling failure and defect detection rates_
+- Sales and operations analysts: _estimating conversion trial counts_
+- Students: _learning discrete distributions adjacent to `binom` and `poisson`_
+- A natural sibling to `binom` and `poisson` — completing the classic trio of discrete distributions for count data
 
 ---
 
-## 38. `pythagorean` — Pythagorean Win Expectation *(implemented)*
+## 21. `exponential` — Exponential Distribution Calculator
 
-> **Status:** Already implemented in `src/utils/pythagorean_record.py`.
+### Architecture
+- **Core functions:** `exp_pdf(x, lam)`, `exp_cdf(x, lam)`, `exp_survival(x, lam)`, `exp_hazard(x, lam)`, `exp_quantile(p, lam)`
+- Pure Python via `math.exp` — no external dependencies
+- CLI flags: `-x F` (value), `--lambda F`/`-l F` (rate parameter), `--quantile F` (return x at given CDF probability), `--survival` (return 1 - CDF), `--table MIN MAX STEP`, `--mean` (print expected waiting time 1/λ), `--precision INT`
+- Output: PDF, CDF, survival probability, hazard rate, optional quantile or range table
+
+```bash
+# PDF and CDF at x=2 for lambda=0.5
+exponential -x 2.0 --lambda 0.5
+
+# 95th percentile of inter-arrival time (lambda=1/3 arrivals per minute)
+exponential --quantile 0.95 --lambda 0.333
+
+# Survival table from 0 to 10 in steps of 1
+exponential --lambda 0.5 --table 0 10 1 --survival
+```
 
 ### Application
-Applies the Pythagorean expectation formula from sports analytics — originally developed for baseball by Bill James — to estimate a team's expected win percentage from runs scored and runs allowed: `W% = RS² / (RS² + RA²)`. Generalized to other sports with adjustable exponents. Used for identifying over- and under-performing teams and projecting season records.
+The continuous analog of the geometric distribution; models waiting times between independent events in a Poisson process. Used for inter-arrival times (customer arrivals, network packets), component lifetimes (memoryless failure), and queueing theory. The unique "memoryless" property — knowing a component has survived to time t gives no information about its remaining lifetime — makes it the baseline model before considering `weibull` for wear-out effects.
 
 ### Target User Base
-- Sports analysts and statisticians: _benchmarking actual vs expected team performance_
-- Fantasy sports participants: _identifying regression candidates based on luck-adjusted records_
-- Educators: _teaching applied statistics and modeling in a sports context_
-- A domain-specific companion to `streak` and `binom` for the sports analytics corner of the suite
+- DevOps / SREs: _modeling inter-request intervals and timeout thresholds_
+- Reliability engineers: _baseline failure time modeling before fitting Weibull_
+- Operations researchers and queueing theorists: _arrival and service time distributions_
+- A continuous-distribution companion to `poisson` and `geometric` — completing the Poisson process family
+
+---
+
+## 22. `describe` — Descriptive Statistics
+
+### Architecture
+- **Core functions:** `describe(data)` → n, mean, median, mode, std, variance, min, max, q1, q3, iqr, skewness, kurtosis, range, cv (coefficient of variation)
+- Pure Python via `statistics` and `math` — no external dependencies
+- CLI flags: `--data CSV_OR_VALUES`, `--file CSV --col COL`, `--percentiles P [...]` (additional percentiles beyond quartiles), `--precision INT`, `--format {table,json,csv}`
+- Output: full summary statistics table with location, spread, and shape measures
+
+```bash
+# Full summary for a list of values
+describe --data 12.1,11.8,13.4,12.9,11.5,14.2,12.7
+
+# From CSV, specific column with additional percentiles
+describe --file sales.csv --col revenue --percentiles 10 25 75 90 99
+
+# JSON output for downstream processing
+describe --file measurements.csv --col weight --format json
+```
+
+### Application
+Produces a one-shot summary of a dataset's location, spread, shape, and outlier potential. Eliminates the need to open a notebook or import pandas for a quick look at raw data. The natural first step before running any inferential analysis — `describe` before you test or model.
+
+### Target User Base
+- Data analysts and scientists: _initial EDA before choosing a test or model_
+- QA engineers: _summarizing measurement distributions from automated test runs_
+- Students: _learning exploratory data analysis without needing pandas_
+- The universal entry point for any user with a column of numbers — the tool most likely to be reached for first
+
+---
+
+## 23. `entropy` — Information Entropy
+
+### Architecture
+- **Core functions:** `shannon_entropy(probs, base)` → bits (base 2) or nats (base e); `kl_divergence(p, q)` → KL(P‖Q); `cross_entropy(p, q)`; `mutual_information(joint)`; `conditional_entropy(joint)`
+- Pure Python via `math.log` — no external dependencies
+- CLI flags: `--probs CSV_OR_VALUES`, `--measure {entropy,kl,cross,mi,conditional}`, `--base {2,e,10}`, `--probs-p`, `--probs-q`, `--joint ROW [...]` (repeated flag for joint distribution rows), `--precision INT`, `--format {table,json}`
+- Output: entropy/divergence value with units (bits/nats/hartleys), interpretation note for KL divergence direction
+
+```bash
+# Shannon entropy of a six-sided die (should be ~2.585 bits)
+entropy --probs 0.167,0.167,0.167,0.167,0.167,0.167
+
+# KL divergence between a biased coin (0.7/0.3) and a fair coin (0.5/0.5)
+entropy --measure kl --probs-p 0.7,0.3 --probs-q 0.5,0.5
+
+# Mutual information from a 2x2 joint distribution
+entropy --measure mi --joint "0.25,0.25" --joint "0.25,0.25"
+```
+
+### Application
+Shannon entropy quantifies the uncertainty or information content of a probability distribution — the fundamental measure of information theory. Used in data compression, ML model evaluation (cross-entropy loss), feature selection (information gain / mutual information), communications engineering, and any domain where "how much information does this tell me?" is the core question.
+
+### Target User Base
+- ML engineers and data scientists: _feature selection via mutual information, model evaluation via cross-entropy_
+- Information theorists and communications engineers: _encoding efficiency and channel capacity analysis_
+- Students: _learning information theory concepts complementary to probability distributions_
+- A natural bridge from the probability tools to information-theoretic applications of those distributions
+
+---
+
+## 24. `effect` — Effect Size Calculator
+
+### Architecture
+- **Core functions:** `cohens_d(mean1, mean2, std1, std2, n1, n2)` → d and pooled SE; `eta_squared(ss_between, ss_total)` → η²; `omega_squared(ss_between, ms_within, k, n)` → ω²; `odds_ratio(a, b, c, d)` → OR and 95% CI; `risk_ratio(a, b, c, d)` → RR; `r_from_t(t, df)` → Pearson r
+- Pure Python — no external dependencies
+- CLI flags: `--measure {d,eta2,omega2,or,rr,r}`, `--mean1 F`, `--mean2 F`, `--std1 F`, `--std2 F`, `--n1 INT`, `--n2 INT`, `--ss-between F`, `--ss-total F`, `--ms-within F`, `--k INT`, `--table "A,B,C,D"`, `--t-stat F`, `--df INT`, `--interpret` (print Cohen's small/medium/large benchmarks), `--format {table,json}`
+- Output: effect size value with confidence interval where applicable, interpretation label when `--interpret` is passed
+
+```bash
+# Cohen's d for two group means
+effect --measure d --mean1 54.2 --std1 9.3 --n1 25 --mean2 49.8 --std2 11.1 --n2 28 --interpret
+
+# Eta-squared from ANOVA output
+effect --measure eta2 --ss-between 48.3 --ss-total 312.7
+
+# Odds ratio from a 2x2 contingency table (a, b, c, d)
+effect --measure or --table "40,20,30,50"
+```
+
+### Application
+p-values tell you whether an effect exists; effect sizes tell you how large it is. Cohen's d, eta-squared, and odds ratios are the standard language of practical significance in clinical research, social science, and A/B testing. Essential for power analysis, meta-analyses, and communicating results to stakeholders who need to know whether a statistically significant finding is also meaningfully large.
+
+### Target User Base
+- Clinical and social science researchers: _reporting standardised effect sizes alongside p-values_
+- Product analysts: _quantifying the magnitude of A/B test wins, not just their significance_
+- Students: _learning the distinction between statistical and practical significance_
+- A natural complement to `ttest`, `anova`, and `chisq` — the "how big?" follow-up to "is it real?"
+
+---
+
+## 25. `combinatorics` — Permutations, Combinations & Counting
+
+### Architecture
+- **Core functions:** `permutations(n, r)`, `combinations(n, r)` (via `math.comb`), `multinomial(n, *ks)`, `derangements(n)`, `catalan(n)`, `stirling2(n, k)` (Stirling numbers, second kind), `bell(n)` (Bell numbers)
+- Pure Python — no external dependencies; `math.comb` and `math.factorial` for exact integer arithmetic
+- CLI flags: `--func {perm,comb,multi,derange,catalan,stirling2,bell}`, `-n INT`, `-r INT`, `--ks INT [...]` (for multinomial), `--table N` (print first N values of the sequence), `--format {table,json}`
+- Output: exact integer result; optional sequence table
+
+```bash
+# How many ways to arrange 5 items chosen from 10?
+combinatorics --func perm -n 10 -r 5
+
+# How many ways to choose a committee of 4 from 12?
+combinatorics --func comb -n 12 -r 4
+
+# Multinomial: ways to assign 12 people to groups of 3, 4, and 5
+combinatorics --func multi -n 12 --ks 3 4 5
+
+# Number of derangements of 8 items (permutations with no fixed points)
+combinatorics --func derange -n 8
+
+# First 10 Catalan numbers
+combinatorics --func catalan --table 10
+```
+
+### Application
+Counting functions underpin probability calculations everywhere — the denominator in hypergeometric and binomial probabilities, the foundation of combinatorial proofs, and practical tools for scheduling, tournament bracket design, and resource allocation. A direct complement to `hypergeo` and `binom`, providing the explicit counting tools those distributions use internally.
+
+### Target User Base
+- Students: _computing combinatorial quantities for probability homework or math competitions_
+- Statisticians: _verifying denominators in hypergeometric and multinomial probability calculations_
+- Software engineers: _counting configurations, arrangements, or partitions in algorithm design_
+- Puzzle and game designers: _evaluating search spaces and strategy complexity_
+
+---
+
+## 26. `weibull` — Weibull Distribution Calculator
+
+### Architecture
+- **Core functions:** `weibull_pdf(x, k, lam)`, `weibull_cdf(x, k, lam)`, `weibull_survival(x, k, lam)`, `weibull_hazard(x, k, lam)`, `weibull_quantile(p, k, lam)`, `weibull_mean(k, lam)` (via `math.lgamma`)
+- Pure Python — no external dependencies
+- CLI flags: `-x F` (evaluation point), `-k F`/`--shape F` (shape parameter), `--lambda F`/`--scale F` (scale parameter), `--quantile F`, `--survival` (return 1 - CDF), `--table MIN MAX STEP`, `--precision INT`, `--format {table,json}`
+- Output: PDF, CDF, survival probability, hazard rate at x; optional quantile or range table
+
+### Application
+The Weibull distribution is the standard model for component lifetimes and failure analysis. The shape parameter k controls failure behaviour: k < 1 (decreasing hazard — infant mortality / early failure), k = 1 (constant hazard = exponential distribution), k > 1 (increasing hazard — wear-out). Used in reliability engineering, warranty data analysis, survival analysis, and materials science. A direct extension of `exponential` for non-constant hazard rates.
+
+```bash
+# Survival probability at t=500 hours, shape=2, scale=1000
+weibull -x 500 -k 2 --lambda 1000 --survival
+
+# 5th percentile of failure time (when have 5% of units failed?)
+weibull --quantile 0.05 -k 1.5 --lambda 800
+
+# Range table: CDF and survival from 0 to 2000 in steps of 200
+weibull -k 2.5 --lambda 1200 --table 0 2000 200
+```
+
+### Target User Base
+- Reliability engineers and QA analysts: _modeling component lifetime distributions and warranty periods_
+- Materials scientists and physicists: _fitting failure time data with non-constant hazard_
+- Actuaries: _survival analysis beyond the constant-hazard exponential assumption_
+- The natural follow-on to `exponential` — when "memoryless" is too simple and wear-out or burn-in effects matter
 
 ---
 
 ## Summary Table
 
-| Command | Distribution / Concept | Deps (optional*) | Zero-dep fallback? | Closest existing tool |
-|---|---|---|---|---|
-| `poisson`     | Poisson                              | None                      | N/A                | `binom`                       |
-| `normal`      | Normal / Gaussian                    | None                      | N/A                | `binom`                       |
-| `zscore`      | Z-score standardisation              | None                      | N/A                | `normal`                      |
-| `sample`      | Sample size calculation              | None                      | N/A                | `confint`                     |
-| `ttest`       | 1- & 2-sample t-tests                | None                      | N/A                | `pvalue`                      |
-| `chisq`       | Chi-square tests                     | None                      | N/A                | `pvalue`                      |
-| `linreg`      | Simple linear regression             | None                      | N/A                | `expected`                    |
-| `expected`    | Discrete EV / variance               | None                      | N/A                | `birthday --weights`          |
-| `hypergeo`    | Hypergeometric                       | None                      | N/A                | `binom`                       |
-| `streak`      | Run / streak probability             | None                      | N/A                | `binom`                       |
-| `bayes`       | Bayesian posterior update            | None                      | N/A                | `birthday`                    |
-| `plotdist`    | Distribution visualiser              | `matplotlib`, `numpy`*    | ✅ Unicode text    | `binom` / `birthday`         |
-| `simulate`    | Monte Carlo simulator                | `numpy`*                  | ✅ `random` module | `binom` / `birthday`         |
-| `oddsconv`    | Odds format converter + vig calc     | None                      | N/A                | `expected`                    |
-| `confint`     | Confidence interval calculator       | None                      | N/A                | `binom` / `normal`            |
-| `pvalue`      | p-value and hypothesis test          | None                      | N/A                | `binom`                       |
-| `sensitivity` | Parameter sensitivity / tornado      | `matplotlib`*             | ✅ ranked table    | all tools                    |
-| `randforest`  | Random forest classifier / regressor | `scikit-learn`, `numpy`*, `pandas`* | ✅ numpy/pandas | `linreg`              |
-| `forecast`    | Time series forecasting + pred. intervals | `statsmodels`*, `numpy`* | ✅ pure-Python ES | `poisson` / `expected`     |
-| `ewma`        | EWMA control chart + variance limits | None                      | N/A                | `forecast`                    |
-| `vartest`     | Variance equality tests (F, Levene, Bartlett) | None             | N/A                | `ttest`                       |
-| `bootci`      | Bootstrap confidence intervals       | `numpy`*                  | ✅ `random.choices` | `confint`                   |
-| `mlreg`       | Multiple linear regression + pred. intervals | `numpy`, `pandas`*  | N/A                | `linreg`                    |
-| `pearson`     | Pearson correlation coefficient              | None                      | N/A                | `linreg`              |
-| `spearman`    | Spearman rank correlation                    | None                      | N/A                | `pearson`             |
-| `taylor`      | Taylor series approximation                  | None                      | N/A                | N/A                   |
-| `compound`    | Compound interest & time value of money      | None                      | N/A                | `expected`            |
-| `matrix`      | Matrix operations & linear algebra           | `numpy`*                  | ✅ nested lists    | `mlreg`               |
-| `prime`       | Prime number tools & factorization           | None                      | N/A                | N/A                   |
-| `fibonacci`   | Fibonacci sequence & golden ratio            | None                      | N/A                | N/A                   |
-| `sigmoid`     | Sigmoid function and S-curve                         | None                      | N/A                | `normal`                      |
-| `euler`       | Euler's constant and related functions               | None                      | N/A                | `fibonacci` / `taylor`        |
-| `logreg`      | Logistic regression (binary classifier)              | `numpy`*                  | ✅ gradient descent | `linreg`                     |
-| `breakeven`   | Break-even analysis and cost-volume-profit           | `matplotlib`*             | ✅ text table       | `compound` / `expected`      |
-| `grover`      | Grover's quantum search algorithm simulator          | None                      | N/A                | `prime` / `fibonacci`         |
-| `collatz`     | Collatz conjecture / hailstone sequences *(impl.)*  | None                      | N/A                | `fibonacci`                   |
-| `jevons`      | Jevons paradox / rebound effect modeling *(impl.)*  | None                      | N/A                | `expected`                    |
-| `pythagorean` | Pythagorean win expectation *(impl.)*                | None                      | N/A                | `streak` / `binom`            |
+| Command | Distribution / Concept | Deps (optional*) | Zero-dep fallback? | Closest existing tool | Issue |
+|---|---|---|---|---|---|
+| `chisq`        | Chi-square tests                             | None                               | N/A                | `pvalue`                  | #6  |
+| `hypergeo`     | Hypergeometric                               | None                               | N/A                | `binom`                   | #18 |
+| `plotdist`     | Distribution visualiser                      | `matplotlib`, `numpy`*             | ✅ Unicode text    | `binom` / `birthday`     | #7  |
+| `oddsconv`     | Odds format converter + vig calc             | None                               | N/A                | `expected`                | #19 |
+| `sensitivity`  | Parameter sensitivity / tornado              | `matplotlib`*                      | ✅ ranked table    | all tools                 | #20 |
+| `randforest`   | Random forest classifier / regressor         | `scikit-learn`, `numpy`*, `pandas`*| ✅ numpy/pandas    | `linreg`                  | #21 |
+| `ewma`         | EWMA control chart + variance limits         | None                               | N/A                | `forecast`                | #22 |
+| `vartest`      | Variance equality tests (F, Levene, Bartlett)| None                               | N/A                | `ttest`                   | #23 |
+| `mlreg`        | Multiple linear regression + pred. intervals | `numpy`, `pandas`*                 | N/A                | `linreg`                  | #3  |
+| `taylor`       | Taylor series approximation                  | None                               | N/A                | N/A                       | #24 |
+| `compound`     | Compound interest & time value of money      | None                               | N/A                | `expected`                | #25 |
+| `matrix`       | Matrix operations & linear algebra           | `numpy`*                           | ✅ nested lists    | `mlreg`                   | #26 |
+| `fibonacci`    | Fibonacci sequence & golden ratio            | None                               | N/A                | N/A                       | #27 |
+| `sigmoid`      | Sigmoid function and S-curve                 | None                               | N/A                | `normal`                  | #8  |
+| `euler`        | Euler's constant and related functions       | None                               | N/A                | `fibonacci` / `taylor`    | #9  |
+| `logreg`       | Logistic regression (binary classifier)      | `numpy`*                           | ✅ gradient descent| `linreg`                  | #10 |
+| `breakeven`    | Break-even analysis and cost-volume-profit   | `matplotlib`*                      | ✅ text table      | `compound` / `expected`   | #14 |
+| `grover`       | Grover's quantum search algorithm simulator  | None                               | N/A                | `prime` / `fibonacci`     | #16 |
+| `anova`        | One-way ANOVA + post-hoc tests               | None                               | N/A                | `ttest`                   | #28 |
+| `geometric`    | Geometric distribution                       | None                               | N/A                | `binom` / `poisson`       | #29 |
+| `exponential`  | Exponential distribution                     | None                               | N/A                | `poisson` / `geometric`   | #30 |
+| `describe`     | Descriptive statistics summary               | None                               | N/A                | all tools                 | #31 |
+| `entropy`      | Information entropy and KL divergence        | None                               | N/A                | `birthday`                | #32 |
+| `effect`       | Effect size (Cohen's d, eta², odds ratio)    | None                               | N/A                | `ttest` / `chisq`         | #33 |
+| `combinatorics`| Permutations, combinations, counting         | None                               | N/A                | `hypergeo` / `binom`      | #35 |
+| `weibull`      | Weibull distribution (reliability/survival)  | None                               | N/A                | `exponential`             | #34 |
 
 \* _Optional dependency: functionality exists but reduced output capability without the package._


### PR DESCRIPTION
Removed all implemented tools from the ideas doc (they are documented in README.md and pyproject.toml). Added a compact implemented-tools reference table at the top. Renumbered remaining 18 unimplemented entries and added 8 new tool proposals: anova, geometric, exponential, describe, entropy, effect, combinatorics, weibull. Created GitHub issues #18-35 for all proposed tools that lacked one; updated summary table with issue numbers.