### PR TITLE
feat: add sigmoid and euler tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.20.0] — 2026-06-13
+
+### Added
+- Gini coefficient tool (`gini`) — inequality measurement from raw data, weighted samples, grouped shares, Lorenz curve, and multi-dataset comparison
+- Sunzi's Theorem tool (`crt`) — simultaneous congruence solver supporting coprime and non-coprime moduli
+
+---
+
 ## [0.19.0] — 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.19.0] — 2026-06-12
+
+### Added
+- Sigmoid function tool (`sigmoid`) — σ(x), derivative, inverse logit, and Unicode sparkline
+- Euler's number tool (`euler`) — limit convergence, e^x Taylor series, ln(x) series, Euler's identity, and Euler-Mascheroni constant
+
+---
+
 ## [0.18.0] — 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Sigmoid Function** | Evaluate σ(x) = 1/(1+e^(−x)), its derivative, and the inverse logit; range tables and Unicode sparkline |
 | **Euler's Number** | Explore e via limit convergence, Taylor series for e^x and ln(x), Euler's identity, and the Euler-Mascheroni constant |
 | **Monte Carlo Simulator** | Empirically estimate probabilities for `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, `linboot` experiments with confidence intervals and analytical comparison |
-| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, and `euler` commands |
+| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, and `crt` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
 
@@ -87,6 +87,8 @@ pip install -e .
 | `jevons` | Rebound effect and backfire analysis for resource efficiency improvements |
 | `sigmoid` | Sigmoid σ(x), derivative σ'(x), inverse logit, range tables, and Unicode sparkline |
 | `euler` | Euler's number via limit/series, e^x Taylor series, ln(x) series, Euler's identity, and γ constant |
+| `gini` | Gini coefficient and Lorenz curve from raw data, weighted samples, or grouped shares |
+| `crt` | Sunzi's Theorem solver for systems of simultaneous congruences |
 | `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
 
 ---
@@ -1351,6 +1353,8 @@ simulate --experiment linboot --params x=1,2,3,4,5 y=2.1,3.9,6.2,7.8,10.1 predic
 | Forecast | `src.utils.forecast_time_series` | `simple_exponential_smoothing`, `double_exponential_smoothing`, `holt_winters` |
 | Collatz | `src.utils.collatz_conjecture` | `CollatzChecker`, `collatz_next` |
 | Jevons | `src.utils.jevons_paradox` | `analyze`, `expected_savings`, `rebound_consumption`, `net_consumption`, `is_backfire` |
+| Gini | `src.utils.gini` | `gini_coefficient`, `lorenz_curve`, `relative_mad`, `gini_grouped` |
+| CRT | `src.utils.crt` | `extended_gcd`, `mod_inverse`, `crt` |
 | Monte Carlo | `src.utils.monte_carlo` | `simulate_binomial`, `simulate_birthday`, `simulate_streak`, `simulate_poisson`, `simulate_power`, `simulate_permutation`, `simulate_bayes`, `simulate_season`, `simulate_linboot` |
 
 ---
@@ -2205,6 +2209,56 @@ ci = wilson_ci(p_hat, len(results))
 
 </details>
 
+<details>
+<summary><strong><code>gini</code></strong> — Gini Coefficient and Lorenz Curve</summary>
+
+Computes the Gini coefficient and Lorenz curve for inequality measurement. Supports raw observations, optional positive weights for weighted samples, and pre-aggregated population/income share pairs (grouped mode). Groups are sorted internally by ascending per-capita income before constructing the Lorenz curve. Includes relative mean absolute difference (RMAD = 2 × Gini) and an optional n/(n−1) small-sample bias correction. Multi-dataset mode ranks all datasets by Gini from most equal to least equal.
+
+```bash
+# Single dataset — point estimate
+gini --data 1 2 3 4 5
+
+# Weighted samples
+gini --data 10 30 50 80 --weights 4 3 2 1
+
+# Lorenz curve coordinates
+gini --data 1 2 3 4 5 --lorenz --precision 4
+
+# With bias correction
+gini --data 1 2 3 4 5 --correct
+
+# Grouped (population share / income share pairs)
+gini --groups 0.2 0.05 0.3 0.15 0.5 0.80
+
+# Compare multiple datasets
+gini --data 1 2 3 --data 5 5 90 --data 30 35 35
+
+# JSON output
+gini --data 1 2 3 4 5 --format json
+```
+
+</details>
+
+<details>
+<summary><strong><code>crt</code></strong> — Sunzi's Theorem Solver</summary>
+
+Solves systems of simultaneous congruences using Sunzi's Theorem (general CRT). Handles both coprime and non-coprime moduli via pairwise merging (solution exists iff aᵢ ≡ aⱼ mod gcd(nᵢ, nⱼ) for all pairs). Remainders are normalized to [0, n) automatically. Returns the unique solution x in [0, N) and the combined modulus N = lcm(n₁, ..., nₖ). Supports listing all solutions up to a user-specified bound.
+
+```bash
+# Solve x≡2(mod 3), x≡3(mod 5), x≡2(mod 7) → 23 (mod 105)
+crt --solve 2 3 3 5 2 7
+
+# Non-coprime moduli (x≡0(mod 4), x≡2(mod 6))
+crt --solve 0 4 2 6
+
+# List all solutions up to 300
+crt --solve 2 3 3 5 2 7 --all 300
+
+# JSON output
+crt --solve 2 3 3 5 2 7 --format json
+```
+
+</details>
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Time Series Forecasting** | Forecast future values with prediction intervals using simple, double (Holt's), or Holt-Winters exponential smoothing; supports backtesting and multiple output formats |
 | **Collatz Conjecture** | Evaluate the Collatz conjecture (3n+1 problem) for positive integers up to n; track which numbers reach 1 and report the largest consecutive verified sequence |
 | **Jevons' Paradox** | Quantify the rebound effect and backfire condition for resource efficiency improvements; compute expected savings, rebound consumption, actual savings, and net consumption change given an efficiency gain and price elasticity of demand; support sweeps over efficiency or elasticity ranges |
-| **Monte Carlo Simulator** | Empirically estimate probabilities for `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, `linboot` experiments with confidence intervals and analytical comparison |
 | **Sigmoid Function** | Evaluate σ(x) = 1/(1+e^(−x)), its derivative, and the inverse logit; range tables and Unicode sparkline |
 | **Euler's Number** | Explore e via limit convergence, Taylor series for e^x and ln(x), Euler's identity, and the Euler-Mascheroni constant |
+| **Monte Carlo Simulator** | Empirically estimate probabilities for `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, `linboot` experiments with confidence intervals and analytical comparison |
 | **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, and `euler` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
@@ -85,9 +85,9 @@ pip install -e .
 | `forecast` | Exponential smoothing: simple, Holt's method, and Holt-Winters |
 | `collatz` | Collatz conjecture (3n+1) verification for integers 1 through n |
 | `jevons` | Rebound effect and backfire analysis for resource efficiency improvements |
-| `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
 | `sigmoid` | Sigmoid σ(x), derivative σ'(x), inverse logit, range tables, and Unicode sparkline |
 | `euler` | Euler's number via limit/series, e^x Taylor series, ln(x) series, Euler's identity, and γ constant |
+| `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
 
 ---
 
@@ -2082,30 +2082,8 @@ result = analyze(baseline, eta, epsilon)
 print(f"Rebound rate: {result['rebound_pct']:.1f}%")
 print(f"Net consumption: {result['net_consumption']:.1f} units")
 ```
-
 </details>
 
-<details>
-<summary><strong>Monte Carlo Simulator</strong></summary>
-
-```python
-from src.utils.monte_carlo import (
-    simulate_binomial,
-    simulate_birthday,
-    simulate_streak,
-    simulate_poisson,
-    wilson_ci,
-    standard_error,
-)
-
-# Simulate P(X >= 5) for Binomial(10, 0.4) over 100,000 trials
-results = simulate_binomial(n=10, k=5, p=0.4, trials=100_000, seed=42)
-p_hat = sum(results) / len(results)
-se = standard_error(p_hat, len(results))
-ci = wilson_ci(p_hat, len(results))
-```
-
-</details>
 
 <details>
 <summary><strong><code>sigmoid</code></strong> — Sigmoid Function and Logistic Curve</summary>
@@ -2150,7 +2128,6 @@ sigma = sigmoid(2.0)          # 0.8807970779778823
 dsigma = sigmoid_derivative(0.0)  # 0.25
 x = inverse_logit(0.75)       # 1.0986122886681098
 ```
-
 </details>
 
 <details>
@@ -2204,6 +2181,30 @@ real, imag, total = euler_identity() # (-1.0, ~0.0, ~0.0)
 ```
 
 </details>
+
+
+<details>
+<summary><strong>Monte Carlo Simulator</strong></summary>
+
+```python
+from src.utils.monte_carlo import (
+    simulate_binomial,
+    simulate_birthday,
+    simulate_streak,
+    simulate_poisson,
+    wilson_ci,
+    standard_error,
+)
+
+# Simulate P(X >= 5) for Binomial(10, 0.4) over 100,000 trials
+results = simulate_binomial(n=10, k=5, p=0.4, trials=100_000, seed=42)
+p_hat = sum(results) / len(results)
+se = standard_error(p_hat, len(results))
+ci = wilson_ci(p_hat, len(results))
+```
+
+</details>
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Collatz Conjecture** | Evaluate the Collatz conjecture (3n+1 problem) for positive integers up to n; track which numbers reach 1 and report the largest consecutive verified sequence |
 | **Jevons' Paradox** | Quantify the rebound effect and backfire condition for resource efficiency improvements; compute expected savings, rebound consumption, actual savings, and net consumption change given an efficiency gain and price elasticity of demand; support sweeps over efficiency or elasticity ranges |
 | **Monte Carlo Simulator** | Empirically estimate probabilities for `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, `linboot` experiments with confidence intervals and analytical comparison |
-| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, and `simulate` commands |
+| **Sigmoid Function** | Evaluate σ(x) = 1/(1+e^(−x)), its derivative, and the inverse logit; range tables and Unicode sparkline |
+| **Euler's Number** | Explore e via limit convergence, Taylor series for e^x and ln(x), Euler's identity, and the Euler-Mascheroni constant |
+| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, and `euler` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
 
@@ -84,6 +86,8 @@ pip install -e .
 | `collatz` | Collatz conjecture (3n+1) verification for integers 1 through n |
 | `jevons` | Rebound effect and backfire analysis for resource efficiency improvements |
 | `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
+| `sigmoid` | Sigmoid σ(x), derivative σ'(x), inverse logit, range tables, and Unicode sparkline |
+| `euler` | Euler's number via limit/series, e^x Taylor series, ln(x) series, Euler's identity, and γ constant |
 
 ---
 
@@ -2099,6 +2103,104 @@ results = simulate_binomial(n=10, k=5, p=0.4, trials=100_000, seed=42)
 p_hat = sum(results) / len(results)
 se = standard_error(p_hat, len(results))
 ci = wilson_ci(p_hat, len(results))
+```
+
+</details>
+
+<details>
+<summary><strong><code>sigmoid</code></strong> — Sigmoid Function and Logistic Curve</summary>
+
+Computes the sigmoid (logistic) function σ(x) = 1 / (1 + e^(−x)), its derivative σ'(x) = σ(x)(1 − σ(x)), and the inverse logit. Supports single-value evaluation, range tables with optional derivative column, and a Unicode sparkline visualisation of the S-curve.
+
+```bash
+# Sigmoid value at x = 2.0
+sigmoid -x 2.0
+
+# Sigmoid and its derivative at x = 0
+sigmoid -x 0 --derivative
+
+# Range table from -5 to 5 in steps of 1
+sigmoid --range -5 5 1
+
+# Range table with derivative column and sparkline
+sigmoid --range -4 4 0.5 --derivative --plot
+
+# Inverse logit: find x such that σ(x) = 0.75
+sigmoid --inverse --prob 0.75
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| `-x` | `--value` | Evaluate sigmoid at a single value |
+| | `--range MIN MAX STEP` | Print a table over [MIN, MAX] in steps of STEP |
+| | `--inverse` | Compute the inverse logit (logit function) |
+| `-p` | `--prob` | Probability in (0, 1) for `--inverse` mode |
+| `-d` | `--derivative` | Also show σ'(x) |
+| | `--plot` | Append a Unicode sparkline of the sigmoid curve |
+| `-P` | `--precision` | Decimal places (default: `6`) |
+
+### 🐍 Python Library
+
+```python
+from src.utils.sigmoid import sigmoid, sigmoid_derivative, inverse_logit
+
+sigma = sigmoid(2.0)          # 0.8807970779778823
+dsigma = sigmoid_derivative(0.0)  # 0.25
+x = inverse_logit(0.75)       # 1.0986122886681098
+```
+
+</details>
+
+<details>
+<summary><strong><code>euler</code></strong> — Euler's Number and Related Functions</summary>
+
+Explores Euler's number e ≈ 2.71828 through multiple lenses: the classic limit definition (1 + 1/n)^n, Taylor series for e^x and ln(x), Euler's identity e^(iπ) + 1 = 0, and the Euler-Mascheroni constant γ ≈ 0.5772. Supports table and JSON output.
+
+```bash
+# Convergence table for (1+1/n)^n up to n = 1,000,000
+euler --approx 1000000
+
+# e^2 via 10th-order Taylor series, compared to math.exp
+euler --exp 2 --order 10 --compare
+
+# Display Euler's identity at 15 decimal places
+euler --identity --precision 15
+
+# ln(10) via arctanh series with comparison
+euler --ln 10 --compare
+
+# Euler-Mascheroni constant γ
+euler --mascheroni
+
+# JSON output for downstream processing
+euler --exp 1 --compare --format json
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| | `--approx N` | Show convergence of (1+1/N)^N to e at logarithmic steps |
+| | `--exp X` | Compute e^X via Taylor series |
+| | `--identity` | Display Euler's identity: e^(iπ) + 1 = 0 |
+| | `--ln X` | Approximate ln(X) via arctanh series |
+| | `--mascheroni` | Display the Euler-Mascheroni constant γ |
+| | `--order N` | Number of series terms for `--exp` / `--ln` (default: `20`) |
+| | `--compare` | Compare series result to `math.exp` / `math.log` reference |
+| `-P` | `--precision` | Decimal places (default: `10`) |
+| `-f` | `--format` | Output format: `table` (default) or `json` |
+
+### 🐍 Python Library
+
+```python
+from src.utils.euler import e_approx, exp_series, natural_log, euler_identity
+
+approx = e_approx(1_000_000)        # 2.718280469...
+ex = exp_series(1.0, 50)            # ≈ math.e to 15+ decimal places
+ln2 = natural_log(2.0, 100)         # ≈ 0.693147...
+real, imag, total = euler_identity() # (-1.0, ~0.0, ~0.0)
 ```
 
 </details>

--- a/docs/tool_ideas.md
+++ b/docs/tool_ideas.md
@@ -16,8 +16,10 @@ For the full list of implemented tools and their CLI entry points, see `README.m
 | `bootci` | Bootstrap confidence intervals |
 | `collatz` | Collatz conjecture / hailstone sequences |
 | `confint` | Confidence interval calculator |
+| `crt` | Sunzi's Theorem (CRT) solver |
 | `expected` | Expected value and variance for discrete distributions |
 | `forecast` | Time series forecasting with prediction intervals |
+| `gini` | Gini coefficient and Lorenz curve |
 | `jevons` | Jevons paradox / rebound effect modeling |
 | `linreg` | Simple linear regression |
 | `normal` | Gaussian PDF, CDF, and quantile |

--- a/docs/tool_ideas.md
+++ b/docs/tool_ideas.md
@@ -28,9 +28,11 @@ For the full list of implemented tools and their CLI entry points, see `README.m
 | `pythag` | Pythagorean win expectation |
 | `sample` | Sample size calculator |
 | `simulate` | Monte Carlo probability simulator |
+| `sigmoid` | Sigmoid function σ(x), derivative, inverse logit, and Unicode sparkline |
 | `spearman` | Spearman rank correlation |
 | `streak` | Consecutive success/failure streak probability |
 | `ttest` | One- and two-sample t-tests |
+| `euler` | Euler's number via limit/series, e^x, ln(x), identity, and γ constant |
 | `zscore` | Z-score calculator |
 
 ---
@@ -450,73 +452,7 @@ fibonacci --approx 40
 
 ---
 
-## 14. `sigmoid` — Sigmoid Function and Curve
-
-### Architecture
-- **Core functions:** `sigmoid(x)`, `sigmoid_derivative(x)`, `inverse_logit(p)`
-- Pure Python via `math.exp` — no external dependencies; shares internals with `logreg`
-- CLI flags: `-x`/`--value`, `--derivative` (return slope at x), `--range MIN MAX STEP` (table of values), `--plot` (Unicode sparkline; matplotlib curve if installed), `--precision`
-- Output: sigmoid value at x, optional derivative, optional range table
-
-### Application
-The sigmoid function maps any real number to (0, 1), making it the foundational activation function in neural networks and the link function in logistic regression. Used for probability squashing, S-curve growth modeling, dose-response curves, and anywhere a smooth transition between 0 and 1 is needed.
-
-```bash
-# Sigmoid value at x = 2.0
-sigmoid -x 2.0
-
-# Derivative (slope) at x = 0
-sigmoid -x 0 --derivative
-
-# Table of sigmoid values from -5 to 5 in steps of 1
-sigmoid --range -5 5 1
-
-# Inverse logit: what x gives P = 0.75?
-sigmoid --inverse --prob 0.75
-```
-
-### Target User Base
-- ML students and data scientists: _understanding neural network activations from first principles_
-- Statisticians: _exploring the logistic link function before fitting a `logreg` model_
-- Engineers and researchers: _modeling S-curve adoption, saturation, or dose-response phenomena_
-- Direct companion to `logreg` — where `sigmoid` evaluates the function itself, `logreg` fits it to data
-
----
-
-## 15. `euler` — Euler's Constant and Related Functions
-
-### Architecture
-- **Core functions:** `e_approx(n)` (limit definition `(1 + 1/n)^n`), `exp_series(x, n)` (Taylor expansion of e^x), `euler_identity()`, `natural_log(x, n)`, `euler_mascheroni()`
-- Pure Python via `math` — no external dependencies
-- CLI flags: `--approx N` (convergence to e via limit), `--exp X` (e^x via series), `--identity` (display Euler's identity), `--ln X` (natural log), `--mascheroni` (γ constant), `--precision INT`, `--format {table,json}`
-- Output: value, convergence table (for `--approx`), comparison to `math.e` / `math.log`
-
-### Application
-Euler's number e ≈ 2.71828 is the base of natural logarithms and the foundation of continuous compounding, exponential growth/decay, complex analysis, and information theory. Appearing in probability (normal distribution, Poisson), finance (continuous interest), and physics (radioactive decay), it is one of the five most important mathematical constants.
-
-```bash
-# Approximate e using the limit definition with n = 1,000,000
-euler --approx 1000000
-
-# e^2 via Taylor series to 10th order
-euler --exp 2 --order 10 --compare
-
-# Display Euler's identity: e^(iπ) + 1 = 0
-euler --identity --precision 15
-
-# Natural log of 10
-euler --ln 10
-```
-
-### Target User Base
-- Students and educators: _verifying convergence of the limit definition, exploring Taylor series for e^x_
-- Financial analysts: _computing continuous compounding values (complement to `compound`'s `--continuous` mode)_
-- Scientists and engineers: _evaluating e^x and ln(x) with explicit series-order control for numerical methods_
-- A foundational "pure math" companion to `fibonacci` and `taylor` — serving users who want to explore mathematical constants interactively
-
----
-
-## 16. `logreg` — Logistic Regression
+## 14. `logreg` — Logistic Regression
 
 ### Architecture
 - **Core functions:** `fit(X, y)` → coefficients, SE, z-stats, p-values, log-likelihood; `predict_proba(X, coeffs)` → probability; `predict_class(X, coeffs, threshold)` → binary label; `log_odds(p)` → logit
@@ -546,7 +482,7 @@ logreg --file train.csv --target clicked --predict-file new_users.csv --format j
 
 ---
 
-## 17. `breakeven` — Break-Even Analysis
+## 15. `breakeven` — Break-Even Analysis
 
 ### Architecture
 - **Core functions:** `breakeven_units(fixed, price, variable)`, `breakeven_revenue(fixed, margin)`, `margin_of_safety(actual_units, breakeven_units)`, `target_profit_units(fixed, price, variable, profit)`
@@ -576,7 +512,7 @@ breakeven --fixed 50000 --price 25 --variable 10 --sweep 0 8000 500
 
 ---
 
-## 18. `grover` — Grover's Quantum Search Algorithm Simulator
+## 16. `grover` — Grover's Quantum Search Algorithm Simulator
 
 ### Architecture
 - **Core functions:** `optimal_iterations(n)` → `floor(π/4 · √n)`; `success_probability(n, k, iterations)` → analytical amplitude calculation; `amplitude_evolution(n, k, t)` → probability at each step; `speedup_ratio(n)` → classical vs quantum step ratio
@@ -606,7 +542,7 @@ grover --compare --sweep 16 1048576
 
 ---
 
-## 19. `anova` — One-Way Analysis of Variance
+## 17. `anova` — One-Way Analysis of Variance
 
 ### Architecture
 - **Core functions:** `anova_one_way(groups)` → F-stat, p-value, df_between, df_within, SS_between, SS_within, MS values; `tukey_hsd(groups)` → pairwise mean differences with adjusted p-values; `bonferroni(groups, alpha)` → corrected per-comparison α
@@ -636,7 +572,7 @@ Tests whether the means of three or more independent groups are equal — the na
 
 ---
 
-## 20. `geometric` — Geometric Distribution Calculator
+## 18. `geometric` — Geometric Distribution Calculator
 
 ### Architecture
 - **Core functions:** `geo_pmf(k, p)`, `geo_cdf(k, p)`, `geo_survival(k, p)`, `geo_mean(p)`, `geo_variance(p)`
@@ -666,7 +602,7 @@ Models "how many independent trials until the first success?" — the discrete-t
 
 ---
 
-## 21. `exponential` — Exponential Distribution Calculator
+## 19. `exponential` — Exponential Distribution Calculator
 
 ### Architecture
 - **Core functions:** `exp_pdf(x, lam)`, `exp_cdf(x, lam)`, `exp_survival(x, lam)`, `exp_hazard(x, lam)`, `exp_quantile(p, lam)`
@@ -696,7 +632,7 @@ The continuous analog of the geometric distribution; models waiting times betwee
 
 ---
 
-## 22. `describe` — Descriptive Statistics
+## 20. `describe` — Descriptive Statistics
 
 ### Architecture
 - **Core functions:** `describe(data)` → n, mean, median, mode, std, variance, min, max, q1, q3, iqr, skewness, kurtosis, range, cv (coefficient of variation)
@@ -726,7 +662,7 @@ Produces a one-shot summary of a dataset's location, spread, shape, and outlier 
 
 ---
 
-## 23. `entropy` — Information Entropy
+## 21. `entropy` — Information Entropy
 
 ### Architecture
 - **Core functions:** `shannon_entropy(probs, base)` → bits (base 2) or nats (base e); `kl_divergence(p, q)` → KL(P‖Q); `cross_entropy(p, q)`; `mutual_information(joint)`; `conditional_entropy(joint)`
@@ -756,7 +692,7 @@ Shannon entropy quantifies the uncertainty or information content of a probabili
 
 ---
 
-## 24. `effect` — Effect Size Calculator
+## 22. `effect` — Effect Size Calculator
 
 ### Architecture
 - **Core functions:** `cohens_d(mean1, mean2, std1, std2, n1, n2)` → d and pooled SE; `eta_squared(ss_between, ss_total)` → η²; `omega_squared(ss_between, ms_within, k, n)` → ω²; `odds_ratio(a, b, c, d)` → OR and 95% CI; `risk_ratio(a, b, c, d)` → RR; `r_from_t(t, df)` → Pearson r
@@ -786,7 +722,7 @@ p-values tell you whether an effect exists; effect sizes tell you how large it i
 
 ---
 
-## 25. `combinatorics` — Permutations, Combinations & Counting
+## 23. `combinatorics` — Permutations, Combinations & Counting
 
 ### Architecture
 - **Core functions:** `permutations(n, r)`, `combinations(n, r)` (via `math.comb`), `multinomial(n, *ks)`, `derangements(n)`, `catalan(n)`, `stirling2(n, k)` (Stirling numbers, second kind), `bell(n)` (Bell numbers)
@@ -822,7 +758,7 @@ Counting functions underpin probability calculations everywhere — the denomina
 
 ---
 
-## 26. `weibull` — Weibull Distribution Calculator
+## 24. `weibull` — Weibull Distribution Calculator
 
 ### Architecture
 - **Core functions:** `weibull_pdf(x, k, lam)`, `weibull_cdf(x, k, lam)`, `weibull_survival(x, k, lam)`, `weibull_hazard(x, k, lam)`, `weibull_quantile(p, k, lam)`, `weibull_mean(k, lam)` (via `math.lgamma`)
@@ -869,8 +805,6 @@ weibull -k 2.5 --lambda 1200 --table 0 2000 200
 | `compound`     | Compound interest & time value of money      | None                               | N/A                | `expected`                | #25 |
 | `matrix`       | Matrix operations & linear algebra           | `numpy`*                           | ✅ nested lists    | `mlreg`                   | #26 |
 | `fibonacci`    | Fibonacci sequence & golden ratio            | None                               | N/A                | N/A                       | #27 |
-| `sigmoid`      | Sigmoid function and S-curve                 | None                               | N/A                | `normal`                  | #8  |
-| `euler`        | Euler's constant and related functions       | None                               | N/A                | `fibonacci` / `taylor`    | #9  |
 | `logreg`       | Logistic regression (binary classifier)      | `numpy`*                           | ✅ gradient descent| `linreg`                  | #10 |
 | `breakeven`    | Break-even analysis and cost-volume-profit   | `matplotlib`*                      | ✅ text table      | `compound` / `expected`   | #14 |
 | `grover`       | Grover's quantum search algorithm simulator  | None                               | N/A                | `prime` / `fibonacci`     | #16 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythodds"
-version = "0.19.0"
+version = "0.20.0"
 description = "Command line utilities for statistics, odds, and probabilities"
 readme = "README.md"
 authors = [
@@ -52,6 +52,8 @@ ttest = "src.utils.t_test:main"
 jevons = "src.utils.jevons_paradox:main"
 sigmoid = "src.utils.sigmoid:main"
 euler = "src.utils.euler:main"
+gini = "src.utils.gini:main"
+crt = "src.utils.crt:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythodds"
-version = "0.18.0"
+version = "0.19.0"
 description = "Command line utilities for statistics, odds, and probabilities"
 readme = "README.md"
 authors = [
@@ -50,6 +50,8 @@ pvalue = "src.utils.probability_values:main"
 zscore = "src.utils.z_score:main"
 ttest = "src.utils.t_test:main"
 jevons = "src.utils.jevons_paradox:main"
+sigmoid = "src.utils.sigmoid:main"
+euler = "src.utils.euler:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/utils/crt.py
+++ b/src/utils/crt.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Command-line utility for Sunzi's Theorem (CRT).
+
+Solves systems of simultaneous congruences:
+  x ≡ a₁ (mod n₁)
+  x ≡ a₂ (mod n₂)
+  ...
+
+Works for both coprime and non-coprime moduli (general CRT).  Remainders
+are normalized to [0, n) automatically.  Pure Python — no external
+dependencies.
+
+Usage examples:
+  crt --solve 2 3 3 5 2 7
+  crt --solve 0 4 3 6 --format json
+  crt --solve 2 3 3 5 2 7 --all 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def extended_gcd(a: int, b: int) -> tuple[int, int, int]:
+    """Compute the extended greatest common divisor.
+
+    Returns (g, s, t) such that a·s + b·t = g = gcd(a, b).
+
+    Args:
+        a: First integer.
+        b: Second integer.
+
+    Returns:
+        Tuple (g, s, t) with a·s + b·t = g.
+    """
+    if b == 0:
+        return a, 1, 0
+    g, x, y = extended_gcd(b, a % b)
+    return g, y, x - (a // b) * y
+
+
+def mod_inverse(a: int, m: int) -> int:
+    """Compute the modular inverse of a modulo m.
+
+    Args:
+        a: Integer to invert.
+        m: Modulus; must be >= 2.
+
+    Returns:
+        x in [0, m) such that a·x ≡ 1 (mod m).
+
+    Raises:
+        ValueError: If gcd(a, m) ≠ 1 (inverse does not exist) or m < 2.
+    """
+    if m < 2:
+        raise ValueError(f"modulus must be at least 2, got {m}")
+    g, s, _ = extended_gcd(a % m, m)
+    if g != 1:
+        raise ValueError(f"{a} has no inverse modulo {m} (gcd={g})")
+    return s % m
+
+
+def crt(remainders: list[int], moduli: list[int]) -> tuple[int, int]:
+    """Solve a system of congruences using Sunzi's Theorem (general CRT).
+
+    Handles both coprime and non-coprime moduli via pairwise merge.
+    Remainders are normalized to [0, nᵢ) internally.
+
+    Args:
+        remainders: Residues a₁, a₂, ..., aₖ (any integers).
+        moduli: Moduli n₁, n₂, ..., nₖ; each must be >= 1.
+
+    Returns:
+        Tuple (x, N) where x is the unique solution in [0, N) and
+        N = lcm(n₁, ..., nₖ).
+
+    Raises:
+        ValueError: If lengths differ, any modulus < 1, or the system is
+            inconsistent (no solution).
+    """
+    if len(remainders) != len(moduli):
+        raise ValueError("remainders and moduli must have the same length")
+    if not remainders:
+        raise ValueError("at least one congruence is required")
+    for n in moduli:
+        if n < 1:
+            raise ValueError(f"moduli must be >= 1, got {n}")
+
+    x = remainders[0] % moduli[0]
+    m = moduli[0]
+    for a, n in zip(remainders[1:], moduli[1:]):
+        a = a % n
+        g, p, _ = extended_gcd(m, n)
+        if (a - x) % g != 0:
+            raise ValueError(
+                f"No solution: x≡{x} (mod {m}) and x≡{a} (mod {n}) are inconsistent"
+            )
+        lcm = m * (n // g)
+        # Step k along m until congruent with a (mod n)
+        x = (x + m * ((a - x) // g * p % (n // g))) % lcm
+        m = lcm
+    return x, m
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Argument list; uses sys.argv[1:] when None.
+
+    Returns:
+        Parsed namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description="Sunzi's Theorem solver.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  crt --solve 2 3 3 5 2 7          # x≡2(3), x≡3(5), x≡2(7) → 23 (mod 105)
+  crt --solve 0 4 3 6              # non-coprime moduli (gcd=2, compatible)
+  crt --solve 2 3 3 5 2 7 --all 300
+  crt --solve 2 3 3 5 2 7 --format json
+""",
+    )
+    parser.add_argument(
+        "--solve",
+        type=int,
+        nargs="+",
+        metavar="VALUE",
+        help="flat list of remainder/modulus pairs: A1 N1 A2 N2 ...",
+    )
+    parser.add_argument(
+        "--all",
+        type=int,
+        metavar="MAX",
+        help="list all solutions in [0, MAX]",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        choices=["table", "json"],
+        default="table",
+        help="output format: table (default) or json",
+    )
+
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Validate parsed arguments.
+
+    Args:
+        args: Parsed namespace from parse_args.
+
+    Returns:
+        Error message if invalid; None if all arguments are valid.
+    """
+    if args.solve is None:
+        return "--solve is required"
+    if len(args.solve) < 2:
+        return "--solve requires at least one remainder/modulus pair (A N)"
+    if len(args.solve) % 2 != 0:
+        return "--solve requires an even number of values (A N pairs)"
+    vals = args.solve
+    for i in range(1, len(vals), 2):
+        if vals[i] < 1:
+            return f"moduli must be >= 1 (got {vals[i]} at position {i + 1})"
+    if args.all is not None and args.all < 0:
+        return "--all MAX must be non-negative"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def format_solution(
+    remainders: list[int],
+    moduli: list[int],
+    x: int,
+    N: int,
+    all_max: int | None,
+) -> str:
+    """Format CRT solution as a human-readable table.
+
+    Args:
+        remainders: Input residues (raw, before normalization).
+        moduli: Input moduli.
+        x: Unique solution in [0, N).
+        N: Period (lcm of moduli).
+        all_max: If not None, list all solutions up to this bound.
+
+    Returns:
+        Formatted string.
+    """
+    lines = [
+        "Sunzi's Theorem",
+        "=" * 40,
+        "Congruences:",
+    ]
+    for a, n in zip(remainders, moduli):
+        lines.append(f"  x ≡ {a} (mod {n})")
+
+    lines += [
+        "",
+        f"Solution:  x ≡ {x} (mod {N})",
+        "",
+        "Verification:",
+    ]
+    for a, n in zip(remainders, moduli):
+        check = x % n
+        tick = "✓" if check == (a % n) else "✗"
+        lines.append(f"  {x} mod {n} = {check} {tick}")
+
+    if all_max is not None:
+        solutions = list(range(x, all_max + 1, N))
+        lines += [
+            "",
+            f"All solutions in [0, {all_max}]:",
+            "  " + ", ".join(str(s) for s in solutions),
+        ]
+
+    return "\n".join(lines)
+
+
+def format_json(
+    remainders: list[int],
+    moduli: list[int],
+    x: int,
+    N: int,
+    all_max: int | None,
+) -> str:
+    """Format CRT solution as JSON.
+
+    Args:
+        remainders: Input residues.
+        moduli: Input moduli.
+        x: Unique solution in [0, N).
+        N: Period.
+        all_max: If not None, include all solutions up to this bound.
+
+    Returns:
+        JSON string.
+    """
+    payload: dict = {
+        "solution": x,
+        "modulus": N,
+        "congruences": [
+            {
+                "remainder": a,
+                "modulus": n,
+                "check": x % n,
+                "valid": (x % n) == (a % n),
+            }
+            for a, n in zip(remainders, moduli)
+        ],
+    }
+    if all_max is not None:
+        payload["all_solutions"] = list(range(x, all_max + 1, N))
+    return json.dumps(payload, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the crt CLI.
+
+    Args:
+        argv: Argument list; uses sys.argv[1:] when None.
+
+    Returns:
+        Exit code: 0 on success, 2 on input error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    vals = args.solve
+    remainders = [vals[i] for i in range(0, len(vals), 2)]
+    moduli = [vals[i] for i in range(1, len(vals), 2)]
+
+    try:
+        x, N = crt(remainders, moduli)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(format_json(remainders, moduli, x, N, args.all))
+    else:
+        print(format_solution(remainders, moduli, x, N, args.all))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/euler.py
+++ b/src/utils/euler.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""Command-line utility for Euler's number and related functions.
+
+Demonstrates the mathematical constant e ≈ 2.71828 via the limit definition,
+Taylor series for e^x, natural logarithm series, Euler's identity, and the
+Euler-Mascheroni constant.
+
+Usage examples:
+  euler --approx 1000000
+  euler --exp 2 --order 10 --compare
+  euler --identity --precision 15
+  euler --ln 10 --compare
+  euler --mascheroni
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+_EULER_MASCHERONI_KNOWN = 0.5772156649015328606065120900824024310421593359399235988
+
+
+def e_approx(n: int) -> float:
+    """Approximate e using the limit definition (1 + 1/n)^n.
+
+    Args:
+        n: Number of terms; larger n gives a closer approximation.
+
+    Returns:
+        Approximation of e.
+
+    Raises:
+        ValueError: If n < 1.
+    """
+    if n < 1:
+        raise ValueError("n must be at least 1")
+    return (1.0 + 1.0 / n) ** n
+
+
+def exp_series(x: float, n: int) -> float:
+    """Compute e^x via the Taylor series sum_{k=0}^{n} x^k / k!.
+
+    Args:
+        x: Exponent value.
+        n: Number of terms (order); larger n improves accuracy for large |x|.
+
+    Returns:
+        Approximation of e^x.
+
+    Raises:
+        ValueError: If n < 1.
+    """
+    if n < 1:
+        raise ValueError("n must be at least 1")
+    total = 0.0
+    term = 1.0
+    for k in range(n + 1):
+        total += term
+        term *= x / (k + 1)
+    return total
+
+
+def natural_log(x: float, n: int) -> float:
+    """Approximate ln(x) via the arctanh series 2·sum[(t^(2k+1))/(2k+1)] where t=(x-1)/(x+1).
+
+    This series converges for all x > 0. Accuracy improves with larger n,
+    but more terms are needed for x far from 1.
+
+    Args:
+        x: Argument; must be positive.
+        n: Number of terms; larger n improves accuracy.
+
+    Returns:
+        Approximation of ln(x).
+
+    Raises:
+        ValueError: If x <= 0 or n < 1.
+    """
+    if x <= 0:
+        raise ValueError("x must be positive for natural log")
+    if n < 1:
+        raise ValueError("n must be at least 1")
+    t = (x - 1.0) / (x + 1.0)
+    total = 0.0
+    t_power = t
+    t_sq = t * t
+    for k in range(n + 1):
+        total += t_power / (2 * k + 1)
+        t_power *= t_sq
+    return 2.0 * total
+
+
+def euler_identity() -> tuple[float, float, float]:
+    """Compute e^(iπ) using Euler's formula: e^(iθ) = cos(θ) + i·sin(θ).
+
+    Returns:
+        Tuple of (real_part, imaginary_part, sum) where sum = real_part + 1.
+        Euler's identity states e^(iπ) + 1 = 0, so sum ≈ 0.
+    """
+    real = math.cos(math.pi)
+    imag = math.sin(math.pi)
+    return real, imag, real + 1.0
+
+
+def euler_mascheroni(n: int = 1_000_000) -> float:
+    """Approximate the Euler-Mascheroni constant γ = lim(H_n - ln(n)).
+
+    Args:
+        n: Number of harmonic series terms; larger n gives higher accuracy.
+
+    Returns:
+        Approximation of γ ≈ 0.5772156649.
+    """
+    harmonic = sum(1.0 / k for k in range(1, n + 1))
+    return harmonic - math.log(n)
+
+
+# ---------------------------------------------------------------------------
+# Convergence table helper
+# ---------------------------------------------------------------------------
+
+
+def _approx_table(n: int) -> list[tuple[int, float, float]]:
+    """Build a convergence table for (1+1/k)^k at logarithmic steps up to n.
+
+    Args:
+        n: Maximum value; always included as the final row.
+
+    Returns:
+        List of (k, approximation, error_vs_e) tuples.
+    """
+    e = math.e
+    rows: list[tuple[int, float, float]] = []
+    seen: set[int] = set()
+    k = 1
+    while k <= n:
+        approx = (1.0 + 1.0 / k) ** k
+        rows.append((k, approx, abs(e - approx)))
+        seen.add(k)
+        k *= 10
+    if n not in seen:
+        approx = (1.0 + 1.0 / n) ** n
+        rows.append((n, approx, abs(e - approx)))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the euler utility.
+
+    Args:
+        argv: Argument list; uses sys.argv if None.
+
+    Returns:
+        Parsed namespace with validated attribute types.
+    """
+    parser = argparse.ArgumentParser(
+        description="Euler's number and related functions.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  euler --approx 1000000
+  euler --exp 2 --order 10 --compare
+  euler --identity --precision 15
+  euler --ln 10 --compare
+  euler --mascheroni
+""",
+    )
+
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--approx",
+        type=int,
+        metavar="N",
+        help="show convergence of (1+1/N)^N to e with a table at logarithmic steps",
+    )
+    mode.add_argument(
+        "--exp",
+        type=float,
+        metavar="X",
+        help="compute e^X via Taylor series",
+    )
+    mode.add_argument(
+        "--identity",
+        action="store_true",
+        help="display Euler's identity: e^(iπ) + 1 = 0",
+    )
+    mode.add_argument(
+        "--ln",
+        type=float,
+        metavar="X",
+        help="approximate ln(X) via the arctanh series",
+    )
+    mode.add_argument(
+        "--mascheroni",
+        action="store_true",
+        help="display the Euler-Mascheroni constant γ ≈ 0.5772",
+    )
+
+    parser.add_argument(
+        "--order",
+        type=int,
+        default=20,
+        metavar="N",
+        help="number of Taylor/series terms for --exp and --ln (default: 20)",
+    )
+    parser.add_argument(
+        "--compare",
+        action="store_true",
+        help="compare series result to math.exp / math.log reference value",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=10,
+        help="decimal places for printed values (default: 10)",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        choices=["table", "json"],
+        default="table",
+        help="output format: table (default) or json",
+    )
+
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Validate parsed arguments.
+
+    Args:
+        args: Parsed namespace from parse_args.
+
+    Returns:
+        Error message string if invalid, or None if all arguments are valid.
+    """
+    if args.precision < 0:
+        return "--precision must be non-negative"
+
+    if (
+        args.approx is None
+        and args.exp is None
+        and not args.identity
+        and args.ln is None
+        and not args.mascheroni
+    ):
+        return "one of --approx, --exp, --identity, --ln, or --mascheroni is required"
+
+    if args.approx is not None and args.approx < 1:
+        return "--approx N must be at least 1"
+
+    if args.exp is not None and args.order < 1:
+        return "--order must be at least 1"
+
+    if args.ln is not None:
+        if args.ln <= 0:
+            return "--ln x must be positive"
+        if args.order < 1:
+            return "--order must be at least 1"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def format_approx(table: list[tuple[int, float, float]], precision: int) -> str:
+    """Format the convergence table for --approx mode.
+
+    Args:
+        table: List of (n, approximation, error) rows from _approx_table.
+        precision: Decimal places.
+
+    Returns:
+        Formatted table string.
+    """
+    w = max(precision + 6, 14)
+    header = f"{'n':>12}  {'(1+1/n)^n':>{w}}  {'Error vs e':>{w}}"
+    sep = "-" * len(header)
+    lines = [header, sep]
+    for n_val, approx, err in table:
+        lines.append(f"{n_val:>12}  {approx:{w}.{precision}f}  {err:{w}.{precision}f}")
+    lines.append(f"\nmath.e = {math.e:.{precision}f}")
+    return "\n".join(lines)
+
+
+def format_exp(
+    x: float,
+    order: int,
+    result: float,
+    precision: int,
+    compare: bool,
+) -> str:
+    """Format output for --exp mode.
+
+    Args:
+        x: Exponent.
+        order: Number of Taylor terms used.
+        result: Series approximation.
+        precision: Decimal places.
+        compare: Whether to include comparison to math.exp.
+
+    Returns:
+        Formatted string.
+    """
+    lines = [
+        f"Value (x):          {x:.{precision}f}",
+        f"Taylor order:       {order}",
+        f"e^x (series):       {result:.{precision}f}",
+    ]
+    if compare:
+        true_val = math.exp(x)
+        lines.append(f"e^x (math.exp):     {true_val:.{precision}f}")
+        lines.append(f"Absolute error:     {abs(true_val - result):.{precision}f}")
+    return "\n".join(lines)
+
+
+def format_identity(real: float, imag: float, total: float, precision: int) -> str:
+    """Format output for --identity mode.
+
+    Args:
+        real: Real part of e^(iπ) (should be -1).
+        imag: Imaginary part of e^(iπ) (should be ≈ 0).
+        total: e^(iπ) + 1 (should be ≈ 0).
+        precision: Decimal places.
+
+    Returns:
+        Formatted string showing Euler's identity.
+    """
+    p = precision
+    lines = [
+        "Euler's Identity: e^(iπ) + 1 = 0",
+        "",
+        "  e^(iπ) = cos(π) + i·sin(π)",
+        f"  Real part:      {real:.{p}f}  (exact: -1)",
+        f"  Imaginary part: {imag:.{p}f}  (exact: 0)",
+        f"  e^(iπ) + 1:     {total:.{p}f}  (exact: 0)",
+    ]
+    return "\n".join(lines)
+
+
+def format_ln(
+    x: float,
+    order: int,
+    result: float,
+    precision: int,
+    compare: bool,
+) -> str:
+    """Format output for --ln mode.
+
+    Args:
+        x: Argument to ln.
+        order: Number of series terms used.
+        result: Series approximation.
+        precision: Decimal places.
+        compare: Whether to include comparison to math.log.
+
+    Returns:
+        Formatted string.
+    """
+    lines = [
+        f"Value (x):          {x:.{precision}f}",
+        f"Series order:       {order}",
+        f"ln(x) (series):     {result:.{precision}f}",
+    ]
+    if compare:
+        true_val = math.log(x)
+        lines.append(f"ln(x) (math.log):   {true_val:.{precision}f}")
+        lines.append(f"Absolute error:     {abs(true_val - result):.{precision}f}")
+    return "\n".join(lines)
+
+
+def format_mascheroni(gamma: float, precision: int) -> str:
+    """Format output for --mascheroni mode.
+
+    Args:
+        gamma: Approximation of the Euler-Mascheroni constant.
+        precision: Decimal places.
+
+    Returns:
+        Formatted string showing γ and the series definition.
+    """
+    p = precision
+    lines = [
+        "Euler-Mascheroni Constant (γ)",
+        "",
+        f"  Series approx (n=1,000,000): {gamma:.{p}f}",
+        f"  Known value:                 {_EULER_MASCHERONI_KNOWN:.{p}f}",
+        "  γ = lim(H_n − ln(n))  as n → ∞",
+        "  where H_n = 1 + 1/2 + 1/3 + ··· + 1/n",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the euler CLI.
+
+    Args:
+        argv: Argument list; uses sys.argv if None.
+
+    Returns:
+        Exit code: 0 on success, 2 on input error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    precision = args.precision
+    fmt = args.format
+
+    if args.approx is not None:
+        table = _approx_table(args.approx)
+        if fmt == "json":
+            rows = [
+                {"n": n_val, "approximation": approx, "error": err}
+                for n_val, approx, err in table
+            ]
+            print(
+                json.dumps(
+                    {"mode": "approx", "math_e": math.e, "table": rows}, indent=2
+                )
+            )
+        else:
+            print(format_approx(table, precision))
+        return 0
+
+    if args.exp is not None:
+        result = exp_series(args.exp, args.order)
+        if fmt == "json":
+            data: dict[str, object] = {
+                "mode": "exp",
+                "x": args.exp,
+                "order": args.order,
+                "series": result,
+            }
+            if args.compare:
+                true_val = math.exp(args.exp)
+                data["math_exp"] = true_val
+                data["error"] = abs(true_val - result)
+            print(json.dumps(data, indent=2))
+        else:
+            print(format_exp(args.exp, args.order, result, precision, args.compare))
+        return 0
+
+    if args.identity:
+        real, imag, total = euler_identity()
+        if fmt == "json":
+            print(
+                json.dumps(
+                    {
+                        "mode": "identity",
+                        "real": real,
+                        "imaginary": imag,
+                        "sum": total,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(format_identity(real, imag, total, precision))
+        return 0
+
+    if args.ln is not None:
+        result_ln = natural_log(args.ln, args.order)
+        if fmt == "json":
+            data_ln: dict[str, object] = {
+                "mode": "ln",
+                "x": args.ln,
+                "order": args.order,
+                "series": result_ln,
+            }
+            if args.compare:
+                true_val_ln = math.log(args.ln)
+                data_ln["math_log"] = true_val_ln
+                data_ln["error"] = abs(true_val_ln - result_ln)
+            print(json.dumps(data_ln, indent=2))
+        else:
+            print(format_ln(args.ln, args.order, result_ln, precision, args.compare))
+        return 0
+
+    # mascheroni mode
+    gamma = euler_mascheroni()
+    if fmt == "json":
+        print(
+            json.dumps(
+                {
+                    "mode": "mascheroni",
+                    "gamma": gamma,
+                    "known_value": _EULER_MASCHERONI_KNOWN,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(format_mascheroni(gamma, precision))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/gini.py
+++ b/src/utils/gini.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Command-line utility for the Gini coefficient and Lorenz curve.
+
+Computes inequality metrics from raw observations, weighted samples, or
+pre-aggregated population/income share pairs.  Pure Python — no external
+dependencies.
+
+Usage examples:
+  gini --data 1 2 3 4 5
+  gini --data 1 2 3 4 5 --lorenz --precision 4
+  gini --data 1 2 3 --weights 1 2 1 --correct
+  gini --groups 0.2 0.05 0.3 0.15 0.5 0.80
+  gini --data 1 2 3 --data 4 5 6 7 --data 2 2 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def _gini_trapezoid(values: list[float], weights: list[float]) -> float:
+    """Compute Gini via sorted Lorenz-trapezoid formula.
+
+    Args:
+        values: Non-negative observation values.
+        weights: Positive weights parallel to values; must sum to a positive number.
+
+    Returns:
+        Gini coefficient in [0, 1).
+    """
+    pairs = sorted(zip(values, weights), key=lambda t: t[0])
+    W = sum(w for _, w in pairs)
+    total = sum(x * w for x, w in pairs)
+    if total == 0.0:
+        return 0.0
+    prev_F = 0.0
+    prev_L = 0.0
+    area = 0.0
+    cum_w = 0.0
+    cum_xw = 0.0
+    for x, w in pairs:
+        cum_w += w
+        cum_xw += x * w
+        F = cum_w / W
+        L = cum_xw / total
+        area += (F - prev_F) * (L + prev_L) / 2.0
+        prev_F = F
+        prev_L = L
+    return 1.0 - 2.0 * area
+
+
+def gini_coefficient(
+    data: list[float],
+    weights: list[float] | None = None,
+    corrected: bool = False,
+) -> float:
+    """Compute the Gini coefficient for a dataset.
+
+    Args:
+        data: Non-negative observations.  Must not be empty; sum must be > 0.
+        weights: Optional positive weights parallel to data.  When None, each
+            observation receives equal weight.
+        corrected: If True, apply the n/(n−1) small-sample bias correction.
+
+    Returns:
+        Gini coefficient; 0 = perfect equality, approaching 1 = maximum inequality.
+
+    Raises:
+        ValueError: If data is empty, contains negative values, sums to zero,
+            or weights are invalid.
+    """
+    if not data:
+        raise ValueError("data must not be empty")
+    if any(x < 0 for x in data):
+        raise ValueError("data values must be non-negative")
+    n = len(data)
+    if weights is None:
+        w = [1.0] * n
+    else:
+        if len(weights) != n:
+            raise ValueError("weights length must match data length")
+        if any(ww <= 0 for ww in weights):
+            raise ValueError("weights must be positive")
+        w = list(weights)
+    if sum(x * ww for x, ww in zip(data, w)) == 0.0:
+        raise ValueError("sum of values must be positive")
+    g = _gini_trapezoid(data, w)
+    if corrected and n > 1:
+        g = g * n / (n - 1)
+    return g
+
+
+def lorenz_curve(
+    data: list[float],
+    weights: list[float] | None = None,
+) -> list[tuple[float, float]]:
+    """Compute Lorenz curve coordinates.
+
+    Args:
+        data: Non-negative observations.
+        weights: Optional positive weights parallel to data.
+
+    Returns:
+        List of (cumulative_population_share, cumulative_income_share) tuples,
+        starting at (0.0, 0.0) and ending at (1.0, 1.0).
+
+    Raises:
+        ValueError: If data is invalid or sum is zero.
+    """
+    if not data:
+        raise ValueError("data must not be empty")
+    if any(x < 0 for x in data):
+        raise ValueError("data values must be non-negative")
+    n = len(data)
+    if weights is None:
+        w = [1.0] * n
+    else:
+        if len(weights) != n:
+            raise ValueError("weights length must match data length")
+        if any(ww <= 0 for ww in weights):
+            raise ValueError("weights must be positive")
+        w = list(weights)
+    W = sum(w)
+    total = sum(x * ww for x, ww in zip(data, w))
+    if total == 0.0:
+        raise ValueError("sum of values must be positive for Lorenz curve")
+    pairs = sorted(zip(data, w), key=lambda t: t[0])
+    points: list[tuple[float, float]] = [(0.0, 0.0)]
+    cum_w = 0.0
+    cum_xw = 0.0
+    for x, ww in pairs:
+        cum_w += ww
+        cum_xw += x * ww
+        points.append((cum_w / W, cum_xw / total))
+    return points
+
+
+def relative_mad(
+    data: list[float],
+    weights: list[float] | None = None,
+) -> float:
+    """Compute the relative mean absolute difference (= 2 × Gini coefficient).
+
+    Args:
+        data: Non-negative observations.
+        weights: Optional positive weights.
+
+    Returns:
+        Relative mean absolute difference.
+
+    Raises:
+        ValueError: See gini_coefficient.
+    """
+    return 2.0 * gini_coefficient(data, weights=weights, corrected=False)
+
+
+def gini_grouped(groups: list[tuple[float, float]]) -> float:
+    """Compute the Gini coefficient from pre-aggregated (pop_share, inc_share) pairs.
+
+    Groups are sorted internally by per-capita income (inc_share / pop_share).
+
+    Args:
+        groups: List of (population_share, income_share) tuples.  Population
+            shares must be positive and sum to 1; income shares must be
+            non-negative and sum to 1.
+
+    Returns:
+        Gini coefficient computed via Lorenz trapezoid area.
+
+    Raises:
+        ValueError: If groups are empty, shares are invalid, or sums deviate from 1.
+    """
+    if not groups:
+        raise ValueError("groups must not be empty")
+    if any(p <= 0 for p, _ in groups):
+        raise ValueError("population shares must be positive")
+    if any(s < 0 for _, s in groups):
+        raise ValueError("income shares must be non-negative")
+    total_pop = sum(p for p, _ in groups)
+    total_inc = sum(s for _, s in groups)
+    if not math.isclose(total_pop, 1.0, rel_tol=1e-5, abs_tol=1e-5):
+        raise ValueError(f"population shares must sum to 1.0 (got {total_pop:.6f})")
+    if not math.isclose(total_inc, 1.0, rel_tol=1e-5, abs_tol=1e-5):
+        raise ValueError(f"income shares must sum to 1.0 (got {total_inc:.6f})")
+    # Sort groups by ascending per-capita income
+    sorted_groups = sorted(groups, key=lambda g: g[1] / g[0])
+    area = 0.0
+    prev_x = 0.0
+    prev_y = 0.0
+    cum_pop = 0.0
+    cum_inc = 0.0
+    for pop, inc in sorted_groups:
+        cum_pop += pop
+        cum_inc += inc
+        area += (cum_pop - prev_x) * (cum_inc + prev_y) / 2.0
+        prev_x = cum_pop
+        prev_y = cum_inc
+    return 1.0 - 2.0 * area
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Argument list; uses sys.argv[1:] when None.
+
+    Returns:
+        Parsed namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description="Gini coefficient and Lorenz curve calculator.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  gini --data 1 2 3 4 5
+  gini --data 1 2 3 4 5 --lorenz
+  gini --data 1 2 3 --weights 2 1 1 --correct
+  gini --groups 0.2 0.05 0.3 0.15 0.5 0.80
+  gini --data 10 30 50 --data 5 5 90 --data 30 35 35
+""",
+    )
+
+    parser.add_argument(
+        "--data",
+        type=float,
+        nargs="+",
+        action="append",
+        metavar="VALUE",
+        help="observed values (repeat flag for multiple datasets)",
+    )
+    parser.add_argument(
+        "--groups",
+        type=float,
+        nargs="+",
+        metavar="VALUE",
+        help="alternating population and income shares: POP INC POP INC ...",
+    )
+    parser.add_argument(
+        "--weights",
+        type=float,
+        nargs="+",
+        metavar="W",
+        help="positive weights parallel to --data (single dataset only)",
+    )
+    parser.add_argument(
+        "--lorenz",
+        action="store_true",
+        help="display Lorenz curve coordinates (single dataset only)",
+    )
+    parser.add_argument(
+        "--correct",
+        action="store_true",
+        help="apply n/(n−1) small-sample bias correction",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        choices=["table", "json"],
+        default="table",
+        help="output format: table (default) or json",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=6,
+        metavar="DIGITS",
+        help="decimal places for printed values (default: 6)",
+    )
+
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Validate parsed arguments.
+
+    Args:
+        args: Parsed namespace from parse_args.
+
+    Returns:
+        Error message if invalid; None if all arguments are valid.
+    """
+    if args.precision < 0:
+        return "--precision must be non-negative"
+
+    has_data = bool(args.data)
+    has_groups = args.groups is not None
+
+    if not has_data and not has_groups:
+        return "one of --data or --groups is required"
+    if has_data and has_groups:
+        return "--data and --groups are mutually exclusive"
+
+    if has_groups:
+        if len(args.groups) < 2 or len(args.groups) % 2 != 0:
+            return "--groups requires an even number of values (POP INC pairs)"
+
+    if has_data:
+        n_datasets = len(args.data)
+        if args.weights is not None:
+            if n_datasets > 1:
+                return "--weights is only supported with a single --data group"
+            if len(args.weights) != len(args.data[0]):
+                return "--weights length must match --data length"
+            if any(w <= 0 for w in args.weights):
+                return "--weights values must be positive"
+        if n_datasets > 1 and args.lorenz:
+            return "--lorenz is only supported with a single dataset"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(x: float, p: int) -> str:
+    return f"{x:.{p}f}"
+
+
+def format_single(
+    n: int,
+    mean: float,
+    gini: float,
+    rmad: float,
+    corrected: float | None,
+    precision: int,
+) -> str:
+    """Format point-estimate output for a single dataset.
+
+    Args:
+        n: Number of observations.
+        mean: Arithmetic mean (or weighted mean).
+        gini: Gini coefficient.
+        rmad: Relative mean absolute difference.
+        corrected: Bias-corrected Gini, or None if not requested.
+        precision: Decimal places.
+
+    Returns:
+        Formatted string.
+    """
+    p = precision
+    lines = [
+        "Gini Coefficient Analysis",
+        "=" * 40,
+        f"Observations:           {n}",
+        f"Mean:                   {_fmt(mean, p)}",
+        f"Gini coefficient:       {_fmt(gini, p)}",
+    ]
+    if corrected is not None:
+        lines.append(f"Corrected Gini (n/n-1): {_fmt(corrected, p)}")
+    lines.append(f"Rel. mean abs. diff.:   {_fmt(rmad, p)}")
+    return "\n".join(lines)
+
+
+def format_lorenz(
+    points: list[tuple[float, float]],
+    gini: float,
+    precision: int,
+) -> str:
+    """Format Lorenz curve coordinates as a table.
+
+    Args:
+        points: List of (pop_share, inc_share) from lorenz_curve().
+        gini: Gini coefficient for the header.
+        precision: Decimal places.
+
+    Returns:
+        Formatted string with header and coordinate table.
+    """
+    p = precision
+    w = max(14, p + 8)
+    header = f"{'Population %':>{w}}  {'Income %':>{w}}"
+    sep = "-" * len(header)
+    rows = [f"{pop:{w}.{p}f}  {inc:{w}.{p}f}" for pop, inc in points]
+    lines = [
+        f"Lorenz Curve  (Gini = {_fmt(gini, p)})",
+        "=" * 40,
+        header,
+        sep,
+    ] + rows
+    return "\n".join(lines)
+
+
+def format_grouped(gini: float, n_groups: int, precision: int) -> str:
+    """Format output for grouped-data mode.
+
+    Args:
+        gini: Computed Gini coefficient.
+        n_groups: Number of input groups.
+        precision: Decimal places.
+
+    Returns:
+        Formatted string.
+    """
+    lines = [
+        "Gini Coefficient (Grouped Data)",
+        "=" * 40,
+        f"Groups:                 {n_groups}",
+        f"Gini coefficient:       {_fmt(gini, precision)}",
+        f"Rel. mean abs. diff.:   {_fmt(2.0 * gini, precision)}",
+    ]
+    return "\n".join(lines)
+
+
+def format_comparison(
+    results: list[dict[str, float | int]],
+    corrected: bool,
+    precision: int,
+) -> str:
+    """Format a multi-dataset comparison table ranked by Gini.
+
+    Args:
+        results: List of dicts with keys 'index', 'n', 'mean', 'gini',
+            'corrected', 'rank'.
+        corrected: Whether to include the corrected Gini column.
+        precision: Decimal places.
+
+    Returns:
+        Formatted comparison table string.
+    """
+    p = precision
+    w = max(12, p + 6)
+    if corrected:
+        header = (
+            f"{'Dataset':>10}  {'N':>6}  {'Mean':>{w}}  "
+            f"{'Gini':>{w}}  {'Corrected':>{w}}  {'Rank':>6}"
+        )
+    else:
+        header = f"{'Dataset':>10}  {'N':>6}  {'Mean':>{w}}  {'Gini':>{w}}  {'Rank':>6}"
+    sep = "-" * len(header)
+    rows = []
+    for r in results:
+        if corrected:
+            rows.append(
+                f"{r['index']:>10}  {r['n']:>6}  {r['mean']:{w}.{p}f}  "
+                f"{r['gini']:{w}.{p}f}  {r['corrected']:{w}.{p}f}  {r['rank']:>6}"
+            )
+        else:
+            rows.append(
+                f"{r['index']:>10}  {r['n']:>6}  {r['mean']:{w}.{p}f}  "
+                f"{r['gini']:{w}.{p}f}  {r['rank']:>6}"
+            )
+    lines = ["Dataset Comparison", "=" * 40, header, sep] + rows
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _weighted_mean(data: list[float], weights: list[float]) -> float:
+    W = sum(weights)
+    return sum(x * w for x, w in zip(data, weights)) / W
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the gini CLI.
+
+    Args:
+        argv: Argument list; uses sys.argv[1:] when None.
+
+    Returns:
+        Exit code: 0 on success, 2 on input error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    p = args.precision
+    fmt = args.format
+
+    # ---- grouped-data mode ----
+    if args.groups is not None:
+        vals = args.groups
+        groups = [(vals[i], vals[i + 1]) for i in range(0, len(vals), 2)]
+        try:
+            g = gini_grouped(groups)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+        if fmt == "json":
+            print(
+                json.dumps(
+                    {
+                        "mode": "grouped",
+                        "n_groups": len(groups),
+                        "gini": round(g, p + 4),
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(format_grouped(g, len(groups), p))
+        return 0
+
+    # ---- raw data mode ----
+    datasets: list[list[float]] = args.data
+    weights = args.weights
+
+    # Single dataset
+    if len(datasets) == 1:
+        data = datasets[0]
+        w = weights
+        try:
+            g = gini_coefficient(data, weights=w, corrected=False)
+            rmad = relative_mad(data, weights=w)
+            g_corr: float | None = None
+            if args.correct:
+                g_corr = gini_coefficient(data, weights=w, corrected=True)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+
+        if args.lorenz:
+            try:
+                points = lorenz_curve(data, weights=w)
+            except ValueError as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                return 2
+            if fmt == "json":
+                payload: dict = {
+                    "mode": "lorenz",
+                    "n": len(data),
+                    "gini": round(g, p + 4),
+                    "lorenz_curve": [
+                        [round(x, p + 4), round(y, p + 4)] for x, y in points
+                    ],
+                }
+                if g_corr is not None:
+                    payload["corrected_gini"] = round(g_corr, p + 4)
+                print(json.dumps(payload, indent=2))
+            else:
+                print(format_lorenz(points, g, p))
+            return 0
+
+        ew = w if w is not None else [1.0] * len(data)
+        mean = _weighted_mean(data, ew)
+        if fmt == "json":
+            payload = {
+                "mode": "single",
+                "n": len(data),
+                "mean": round(mean, p + 4),
+                "gini": round(g, p + 4),
+                "relative_mad": round(rmad, p + 4),
+            }
+            if g_corr is not None:
+                payload["corrected_gini"] = round(g_corr, p + 4)
+            print(json.dumps(payload, indent=2))
+        else:
+            print(format_single(len(data), mean, g, rmad, g_corr, p))
+        return 0
+
+    # Multiple datasets — comparison mode
+    try:
+        results = []
+        for i, data in enumerate(datasets, start=1):
+            g = gini_coefficient(data, corrected=False)
+            g_corr = gini_coefficient(data, corrected=True)
+            ew = [1.0] * len(data)
+            mean = _weighted_mean(data, ew)
+            results.append(
+                {
+                    "index": i,
+                    "n": len(data),
+                    "mean": mean,
+                    "gini": g,
+                    "corrected": g_corr,
+                }
+            )
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    # Assign ranks (1 = most equal)
+    ranked = sorted(results, key=lambda r: r["gini"])
+    for rank, r in enumerate(ranked, start=1):
+        r["rank"] = rank
+
+    if fmt == "json":
+        payload = {
+            "mode": "compare",
+            "datasets": [
+                {
+                    "index": r["index"],
+                    "n": r["n"],
+                    "mean": round(r["mean"], p + 4),
+                    "gini": round(r["gini"], p + 4),
+                    "corrected_gini": round(r["corrected"], p + 4),
+                    "rank": r["rank"],
+                }
+                for r in results
+            ],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(format_comparison(results, args.correct, p))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/sigmoid.py
+++ b/src/utils/sigmoid.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Command-line utility for the sigmoid (logistic) function.
+
+Computes σ(x) = 1 / (1 + e^(−x)), its derivative σ'(x) = σ(x)(1 − σ(x)),
+and the inverse logit (logit function). Supports single-value evaluation,
+range tables, and an optional Unicode sparkline.
+
+Usage examples:
+  sigmoid -x 2.0
+  sigmoid -x 0 --derivative
+  sigmoid --range -5 5 1
+  sigmoid --inverse --prob 0.75
+  sigmoid --range -4 4 0.5 --plot
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from typing import Sequence
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def sigmoid(x: float) -> float:
+    """Compute the sigmoid function σ(x) = 1 / (1 + e^(−x)).
+
+    Uses a numerically stable formulation to avoid overflow for large |x|.
+
+    Args:
+        x: Input value.
+
+    Returns:
+        Sigmoid output in the open interval (0, 1).
+    """
+    if x >= 0:
+        exp_neg = math.exp(-x)
+        return 1.0 / (1.0 + exp_neg)
+    exp_pos = math.exp(x)
+    return exp_pos / (1.0 + exp_pos)
+
+
+def sigmoid_derivative(x: float) -> float:
+    """Compute the derivative σ'(x) = σ(x) · (1 − σ(x)).
+
+    Args:
+        x: Input value.
+
+    Returns:
+        Derivative of the sigmoid at x; maximum value 0.25 at x = 0.
+    """
+    s = sigmoid(x)
+    return s * (1.0 - s)
+
+
+def inverse_logit(p: float) -> float:
+    """Compute the inverse sigmoid (logit function): log(p / (1 − p)).
+
+    Args:
+        p: Probability strictly between 0 and 1.
+
+    Returns:
+        Log-odds value x such that σ(x) = p.
+
+    Raises:
+        ValueError: If p is not strictly between 0 and 1.
+    """
+    if not (0.0 < p < 1.0):
+        raise ValueError("p must be strictly between 0 and 1")
+    return math.log(p / (1.0 - p))
+
+
+# ---------------------------------------------------------------------------
+# Range generation
+# ---------------------------------------------------------------------------
+
+
+def _frange(start: float, stop: float, step: float) -> list[float]:
+    """Generate evenly-spaced float values from start to stop inclusive.
+
+    Args:
+        start: First value in the range.
+        stop: Last value (included if reachable within floating-point tolerance).
+        step: Step size; must be positive.
+
+    Returns:
+        List of values from start to stop in increments of step.
+    """
+    n = math.floor((stop - start) / step + 1e-9) + 1
+    return [start + i * step for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Sparkline
+# ---------------------------------------------------------------------------
+
+_SPARK_CHARS = "▁▂▃▄▅▆▇█"
+
+
+def sparkline(values: Sequence[float]) -> str:
+    """Create a Unicode block-character sparkline for values in [0, 1].
+
+    Args:
+        values: Sequence of values; each should be in [0, 1].
+
+    Returns:
+        A string of Unicode block characters visualising the values.
+    """
+    if not values:
+        return ""
+    n = len(_SPARK_CHARS)
+    result = []
+    for v in values:
+        idx = min(n - 1, int(v * n))
+        result.append(_SPARK_CHARS[idx])
+    return "".join(result)
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the sigmoid utility.
+
+    Args:
+        argv: Argument list; uses sys.argv if None.
+
+    Returns:
+        Parsed namespace with validated attribute types.
+    """
+    parser = argparse.ArgumentParser(
+        description="Sigmoid function calculator.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  sigmoid -x 2.0
+  sigmoid -x 0 --derivative
+  sigmoid --range -5 5 1
+  sigmoid --inverse --prob 0.75
+  sigmoid --range -4 4 0.5 --plot
+""",
+    )
+
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--value",
+        "-x",
+        type=float,
+        metavar="X",
+        help="evaluate sigmoid at a single value",
+    )
+    mode.add_argument(
+        "--range",
+        nargs=3,
+        type=float,
+        metavar=("MIN", "MAX", "STEP"),
+        help="print a table of sigmoid values over [MIN, MAX] in steps of STEP",
+    )
+    mode.add_argument(
+        "--inverse",
+        action="store_true",
+        help="compute the inverse logit: find x such that σ(x) = P",
+    )
+
+    parser.add_argument(
+        "--prob",
+        "-p",
+        type=float,
+        metavar="P",
+        help="probability in (0, 1) for --inverse mode",
+    )
+    parser.add_argument(
+        "--derivative",
+        "-d",
+        action="store_true",
+        help="also show the derivative σ'(x)",
+    )
+    parser.add_argument(
+        "--plot",
+        action="store_true",
+        help="append a Unicode sparkline visualising the sigmoid curve",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=6,
+        help="decimal places for printed values (default: 6)",
+    )
+
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Validate parsed arguments.
+
+    Args:
+        args: Parsed namespace from parse_args.
+
+    Returns:
+        Error message string if invalid, or None if all arguments are valid.
+    """
+    if args.precision < 0:
+        return "--precision must be non-negative"
+
+    if args.inverse:
+        if args.prob is None:
+            return "--prob is required with --inverse"
+        if not (0.0 < args.prob < 1.0):
+            return "--prob must be strictly between 0 and 1"
+        return None
+
+    if args.value is None and args.range is None:
+        return "one of --value, --range, or --inverse is required"
+
+    if args.range is not None:
+        lo, hi, step = args.range
+        if step <= 0:
+            return "STEP must be greater than 0"
+        if lo >= hi:
+            return "MIN must be less than MAX"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(x: float, precision: int) -> str:
+    return f"{x:.{precision}f}"
+
+
+def format_single(
+    x: float,
+    sig: float,
+    dsig: float,
+    precision: int,
+    show_deriv: bool,
+) -> str:
+    """Format output for single-value mode.
+
+    Args:
+        x: Input value.
+        sig: Sigmoid value σ(x).
+        dsig: Derivative value σ'(x).
+        precision: Decimal places.
+        show_deriv: Whether to include the derivative line.
+
+    Returns:
+        Formatted string.
+    """
+    lines = [
+        f"Value (x):         {_fmt(x, precision)}",
+        f"Sigmoid σ(x):      {_fmt(sig, precision)}",
+    ]
+    if show_deriv:
+        lines.append(f"Derivative σ'(x):  {_fmt(dsig, precision)}")
+    return "\n".join(lines)
+
+
+def format_table(
+    xs: list[float],
+    sigs: list[float],
+    dsigs: list[float],
+    precision: int,
+    show_deriv: bool,
+    show_plot: bool,
+) -> str:
+    """Format output for range-table mode.
+
+    Args:
+        xs: Input x values.
+        sigs: Corresponding σ(x) values.
+        dsigs: Corresponding σ'(x) values.
+        precision: Decimal places.
+        show_deriv: Whether to include the derivative column.
+        show_plot: Whether to append a Unicode sparkline.
+
+    Returns:
+        Formatted string with header, separator, data rows, and optional sparkline.
+    """
+    w = max(12, precision + 6)
+    p = precision
+    deriv_label = "σ'(x)"
+
+    if show_deriv:
+        header = f"{'x':>{w}}  {'σ(x)':>{w}}  {deriv_label:>{w}}"
+        sep = "-" * len(header)
+        rows = [
+            f"{x:{w}.{p}f}  {s:{w}.{p}f}  {d:{w}.{p}f}"
+            for x, s, d in zip(xs, sigs, dsigs)
+        ]
+    else:
+        header = f"{'x':>{w}}  {'σ(x)':>{w}}"
+        sep = "-" * len(header)
+        rows = [f"{x:{w}.{p}f}  {s:{w}.{p}f}" for x, s in zip(xs, sigs)]
+
+    lines = [header, sep] + rows
+
+    if show_plot:
+        lines.extend(["", sparkline(sigs)])
+
+    return "\n".join(lines)
+
+
+def format_inverse(p: float, x: float, precision: int) -> str:
+    """Format output for inverse-logit mode.
+
+    Args:
+        p: Input probability.
+        x: Computed logit value.
+        precision: Decimal places.
+
+    Returns:
+        Formatted string showing p, logit(p), and a round-trip check.
+    """
+    lines = [
+        f"Probability (p):      {_fmt(p, precision)}",
+        f"Logit log(p/(1-p)):   {_fmt(x, precision)}",
+        f"Check σ(logit):       {_fmt(sigmoid(x), precision)}",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the sigmoid CLI.
+
+    Args:
+        argv: Argument list; uses sys.argv if None.
+
+    Returns:
+        Exit code: 0 on success, 2 on input error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    precision = args.precision
+
+    if args.inverse:
+        try:
+            x = inverse_logit(args.prob)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+        print(format_inverse(args.prob, x, precision))
+        return 0
+
+    if args.range is not None:
+        lo, hi, step = args.range
+        xs = _frange(lo, hi, step)
+        sigs = [sigmoid(v) for v in xs]
+        dsigs = [sigmoid_derivative(v) for v in xs]
+        print(format_table(xs, sigs, dsigs, precision, args.derivative, args.plot))
+        return 0
+
+    # Single-value mode
+    x = args.value
+    sig = sigmoid(x)
+    dsig = sigmoid_derivative(x)
+    output = format_single(x, sig, dsig, precision, args.derivative)
+
+    if args.plot:
+        plot_xs = _frange(-6.0, 6.0, 0.25)
+        plot_sigs = [sigmoid(v) for v in plot_xs]
+        print(output)
+        print("")
+        print(sparkline(plot_sigs))
+    else:
+        print(output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_crt.py
+++ b/tests/test_crt.py
@@ -1,0 +1,340 @@
+"""Tests for Sunzi's Theorem (CRT) utility."""
+
+import argparse
+import json
+
+import pytest
+
+import src.utils.crt as crt_module
+from src.utils.crt import (
+    crt,
+    extended_gcd,
+    format_json,
+    format_solution,
+    main,
+    mod_inverse,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# extended_gcd
+# ---------------------------------------------------------------------------
+
+
+def test_extended_gcd_basic():
+    g, s, t = extended_gcd(3, 5)
+    assert g == 1
+    assert 3 * s + 5 * t == 1
+
+
+def test_extended_gcd_gcd_twelve_eight():
+    g, s, t = extended_gcd(12, 8)
+    assert g == 4
+    assert 12 * s + 8 * t == 4
+
+
+def test_extended_gcd_zero_b():
+    g, s, t = extended_gcd(7, 0)
+    assert g == 7
+    assert s == 1
+    assert t == 0
+
+
+def test_extended_gcd_both_equal():
+    g, s, t = extended_gcd(5, 5)
+    assert g == 5
+    assert 5 * s + 5 * t == 5
+
+
+def test_extended_gcd_identity():
+    for a, b in [(35, 15), (100, 37), (13, 5)]:
+        g, s, t = extended_gcd(a, b)
+        assert a * s + b * t == g
+
+
+# ---------------------------------------------------------------------------
+# mod_inverse
+# ---------------------------------------------------------------------------
+
+
+def test_mod_inverse_basic():
+    assert mod_inverse(3, 7) == 5  # 3*5 = 15 ≡ 1 (mod 7)
+
+
+def test_mod_inverse_result_in_range():
+    x = mod_inverse(4, 9)
+    assert 0 <= x < 9
+    assert (4 * x) % 9 == 1
+
+
+def test_mod_inverse_no_inverse_raises():
+    with pytest.raises(ValueError, match="no inverse"):
+        mod_inverse(4, 6)  # gcd(4,6) = 2 ≠ 1
+
+
+def test_mod_inverse_modulus_too_small_raises():
+    with pytest.raises(ValueError, match="at least 2"):
+        mod_inverse(3, 1)
+
+
+def test_mod_inverse_modulus_zero_raises():
+    with pytest.raises(ValueError, match="at least 2"):
+        mod_inverse(3, 0)
+
+
+# ---------------------------------------------------------------------------
+# crt
+# ---------------------------------------------------------------------------
+
+
+def test_crt_sunzi_classic():
+    # x≡2(3), x≡3(5), x≡2(7) → 23 (mod 105)
+    x, N = crt([2, 3, 2], [3, 5, 7])
+    assert x == 23
+    assert N == 105
+
+
+def test_crt_single_congruence():
+    x, N = crt([3], [7])
+    assert x == 3
+    assert N == 7
+
+
+def test_crt_solution_satisfies_all():
+    remainders = [2, 3, 2]
+    moduli = [3, 5, 7]
+    x, N = crt(remainders, moduli)
+    for a, n in zip(remainders, moduli):
+        assert x % n == a % n
+
+
+def test_crt_negative_remainder_normalized():
+    x, N = crt([-1, 0], [3, 5])
+    assert x % 3 == 2  # -1 mod 3 = 2
+    assert x % 5 == 0
+
+
+def test_crt_large_remainders_normalized():
+    x, N = crt([11, 13], [3, 5])
+    assert x % 3 == 11 % 3
+    assert x % 5 == 13 % 5
+
+
+def test_crt_non_coprime_compatible():
+    # x≡0(4), x≡3(6) → gcd(4,6)=2; (3-0)%2=1 ≠ 0 → inconsistent
+    # x≡0(4), x≡2(6) → gcd(4,6)=2; (2-0)%2=0 ✓ → solution exists
+    x, N = crt([0, 2], [4, 6])
+    assert x % 4 == 0
+    assert x % 6 == 2
+
+
+def test_crt_non_coprime_inconsistent_raises():
+    with pytest.raises(ValueError, match="inconsistent"):
+        crt([0, 3], [4, 6])
+
+
+def test_crt_length_mismatch_raises():
+    with pytest.raises(ValueError, match="same length"):
+        crt([1, 2], [3])
+
+
+def test_crt_empty_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        crt([], [])
+
+
+def test_crt_modulus_zero_raises():
+    with pytest.raises(ValueError, match=">= 1"):
+        crt([1, 2], [3, 0])
+
+
+def test_crt_modulus_negative_raises():
+    with pytest.raises(ValueError, match=">= 1"):
+        crt([1, 2], [3, -2])
+
+
+def test_crt_result_in_range():
+    x, N = crt([2, 3, 2], [3, 5, 7])
+    assert 0 <= x < N
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_no_solve():
+    args = argparse.Namespace(solve=None, all=None, format="table")
+    assert "--solve" in validate(args)
+
+
+def test_validate_single_value():
+    args = argparse.Namespace(solve=[3], all=None, format="table")
+    assert "pair" in validate(args)
+
+
+def test_validate_odd_values():
+    args = argparse.Namespace(solve=[2, 3, 4], all=None, format="table")
+    assert "even" in validate(args)
+
+
+def test_validate_modulus_zero():
+    # Moduli are at odd indices; index 1 is the first modulus
+    args = argparse.Namespace(solve=[2, 0, 3, 5], all=None, format="table")
+    assert ">= 1" in validate(args)
+
+
+def test_validate_modulus_negative():
+    args = argparse.Namespace(solve=[2, 3, 1, -5], all=None, format="table")
+    assert ">= 1" in validate(args)
+
+
+def test_validate_all_negative():
+    args = argparse.Namespace(solve=[2, 3, 3, 5], all=-1, format="table")
+    assert "--all" in validate(args)
+
+
+def test_validate_valid():
+    args = argparse.Namespace(solve=[2, 3, 3, 5, 2, 7], all=None, format="table")
+    assert validate(args) is None
+
+
+def test_validate_valid_with_all():
+    args = argparse.Namespace(solve=[2, 3, 3, 5], all=100, format="table")
+    assert validate(args) is None
+
+
+# ---------------------------------------------------------------------------
+# format_solution
+# ---------------------------------------------------------------------------
+
+
+def test_format_solution_contains_congruences():
+    out = format_solution([2, 3, 2], [3, 5, 7], 23, 105, None)
+    assert "x ≡ 2 (mod 3)" in out
+    assert "x ≡ 3 (mod 5)" in out
+    assert "x ≡ 2 (mod 7)" in out
+
+
+def test_format_solution_shows_result():
+    out = format_solution([2, 3, 2], [3, 5, 7], 23, 105, None)
+    assert "23" in out
+    assert "105" in out
+
+
+def test_format_solution_verification_marks():
+    out = format_solution([2, 3, 2], [3, 5, 7], 23, 105, None)
+    assert "✓" in out
+
+
+def test_format_solution_with_all():
+    out = format_solution([2, 3], [3, 5], 2, 15, 50)
+    assert "All solutions" in out
+    assert "2" in out
+    assert "17" in out
+    assert "32" in out
+    assert "47" in out
+
+
+def test_format_solution_no_all():
+    out = format_solution([2, 3], [3, 5], 2, 15, None)
+    assert "All solutions" not in out
+
+
+# ---------------------------------------------------------------------------
+# format_json
+# ---------------------------------------------------------------------------
+
+
+def test_format_json_basic():
+    out = format_json([2, 3, 2], [3, 5, 7], 23, 105, None)
+    data = json.loads(out)
+    assert data["solution"] == 23
+    assert data["modulus"] == 105
+    assert len(data["congruences"]) == 3
+    assert all(c["valid"] for c in data["congruences"])
+
+
+def test_format_json_with_all():
+    out = format_json([2, 3], [3, 5], 2, 15, 50)
+    data = json.loads(out)
+    assert "all_solutions" in data
+    assert 2 in data["all_solutions"]
+    assert 17 in data["all_solutions"]
+
+
+def test_format_json_no_all():
+    out = format_json([2, 3, 2], [3, 5, 7], 23, 105, None)
+    data = json.loads(out)
+    assert "all_solutions" not in data
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_no_args_returns_2(capsys):
+    assert main([]) == 2
+
+
+def test_main_odd_values_returns_2(capsys):
+    assert main(["--solve", "2", "3", "4"]) == 2
+
+
+def test_main_bad_modulus_returns_2(capsys):
+    assert main(["--solve", "2", "0"]) == 2
+
+
+def test_main_sunzi_table(capsys):
+    rc = main(["--solve", "2", "3", "3", "5", "2", "7"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "23" in out
+    assert "105" in out
+
+
+def test_main_sunzi_json(capsys):
+    rc = main(["--solve", "2", "3", "3", "5", "2", "7", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["solution"] == 23
+
+
+def test_main_with_all_table(capsys):
+    rc = main(["--solve", "2", "3", "3", "5", "--all", "100"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "All solutions" in out
+
+
+def test_main_with_all_json(capsys):
+    rc = main(["--solve", "2", "3", "3", "5", "--all", "50", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert "all_solutions" in data
+
+
+def test_main_all_negative_returns_2(capsys):
+    assert main(["--solve", "2", "3", "3", "5", "--all", "-1"]) == 2
+
+
+def test_main_inconsistent_system_returns_2(capsys):
+    # x≡0(4) and x≡3(6) are inconsistent
+    assert main(["--solve", "0", "4", "3", "6"]) == 2
+    err = capsys.readouterr().err
+    assert "Error" in err
+
+
+def test_main_crt_error_path(monkeypatch, capsys):
+    """Cover the ValueError branch in main when crt() raises."""
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("forced crt error")
+
+    monkeypatch.setattr(crt_module, "crt", raise_value_error)
+    assert main(["--solve", "2", "3", "3", "5"]) == 2
+    err = capsys.readouterr().err
+    assert "forced crt error" in err

--- a/tests/test_euler.py
+++ b/tests/test_euler.py
@@ -1,0 +1,597 @@
+"""Tests for Euler's number and related functions."""
+
+import argparse
+import json
+import math
+
+import pytest
+
+import src.utils.euler as euler_module
+from src.utils.euler import (
+    _EULER_MASCHERONI_KNOWN,
+    _approx_table,
+    e_approx,
+    euler_identity,
+    euler_mascheroni,
+    exp_series,
+    format_approx,
+    format_exp,
+    format_identity,
+    format_ln,
+    format_mascheroni,
+    main,
+    natural_log,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# e_approx
+# ---------------------------------------------------------------------------
+
+
+def test_e_approx_one():
+    assert e_approx(1) == 2.0
+
+
+def test_e_approx_large_n_close_to_e():
+    assert abs(e_approx(1_000_000) - math.e) < 1e-5
+
+
+def test_e_approx_monotone_increasing():
+    prev = e_approx(1)
+    for n in [10, 100, 1000, 10000]:
+        curr = e_approx(n)
+        assert curr > prev
+        prev = curr
+
+
+def test_e_approx_zero_raises():
+    with pytest.raises(ValueError, match="at least 1"):
+        e_approx(0)
+
+
+def test_e_approx_negative_raises():
+    with pytest.raises(ValueError):
+        e_approx(-5)
+
+
+# ---------------------------------------------------------------------------
+# exp_series
+# ---------------------------------------------------------------------------
+
+
+def test_exp_series_at_zero():
+    assert exp_series(0.0, 10) == pytest.approx(1.0, abs=1e-12)
+
+
+def test_exp_series_at_one():
+    assert exp_series(1.0, 50) == pytest.approx(math.e, abs=1e-10)
+
+
+def test_exp_series_negative():
+    assert exp_series(-1.0, 50) == pytest.approx(math.exp(-1.0), abs=1e-10)
+
+
+def test_exp_series_higher_order_more_accurate():
+    err_low = abs(exp_series(2.0, 5) - math.exp(2.0))
+    err_high = abs(exp_series(2.0, 20) - math.exp(2.0))
+    assert err_high < err_low
+
+
+def test_exp_series_zero_order_raises():
+    with pytest.raises(ValueError, match="at least 1"):
+        exp_series(1.0, 0)
+
+
+# ---------------------------------------------------------------------------
+# natural_log
+# ---------------------------------------------------------------------------
+
+
+def test_natural_log_at_one():
+    assert natural_log(1.0, 50) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_natural_log_at_e():
+    assert natural_log(math.e, 100) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_natural_log_at_two():
+    assert natural_log(2.0, 100) == pytest.approx(math.log(2.0), abs=1e-6)
+
+
+def test_natural_log_higher_order_more_accurate():
+    err_low = abs(natural_log(10.0, 5) - math.log(10.0))
+    err_high = abs(natural_log(10.0, 50) - math.log(10.0))
+    assert err_high < err_low
+
+
+def test_natural_log_zero_raises():
+    with pytest.raises(ValueError, match="positive"):
+        natural_log(0.0, 10)
+
+
+def test_natural_log_negative_raises():
+    with pytest.raises(ValueError):
+        natural_log(-1.0, 10)
+
+
+def test_natural_log_zero_order_raises():
+    with pytest.raises(ValueError, match="at least 1"):
+        natural_log(2.0, 0)
+
+
+# ---------------------------------------------------------------------------
+# euler_identity
+# ---------------------------------------------------------------------------
+
+
+def test_euler_identity_real_is_minus_one():
+    real, _, _ = euler_identity()
+    assert real == pytest.approx(-1.0, abs=1e-12)
+
+
+def test_euler_identity_imaginary_near_zero():
+    _, imag, _ = euler_identity()
+    assert abs(imag) < 1e-15
+
+
+def test_euler_identity_sum_near_zero():
+    _, _, total = euler_identity()
+    assert abs(total) < 1e-15
+
+
+# ---------------------------------------------------------------------------
+# euler_mascheroni
+# ---------------------------------------------------------------------------
+
+
+def test_euler_mascheroni_accuracy():
+    gamma = euler_mascheroni(100_000)
+    assert abs(gamma - _EULER_MASCHERONI_KNOWN) < 0.001
+
+
+def test_euler_mascheroni_default_close():
+    gamma = euler_mascheroni(1000)
+    assert abs(gamma - _EULER_MASCHERONI_KNOWN) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# _approx_table
+# ---------------------------------------------------------------------------
+
+
+def test_approx_table_last_row_is_n():
+    table = _approx_table(500)
+    assert table[-1][0] == 500
+
+
+def test_approx_table_includes_powers_of_ten():
+    table = _approx_table(1000)
+    ns = [row[0] for row in table]
+    assert 1 in ns
+    assert 10 in ns
+    assert 100 in ns
+    assert 1000 in ns
+
+
+def test_approx_table_no_duplicate_n():
+    table = _approx_table(1000)
+    ns = [row[0] for row in table]
+    assert len(ns) == len(set(ns))
+
+
+def test_approx_table_n_equals_one():
+    table = _approx_table(1)
+    assert len(table) == 1
+    assert table[0][0] == 1
+
+
+def test_approx_table_errors_decrease():
+    table = _approx_table(10_000)
+    errors = [row[2] for row in table]
+    for i in range(1, len(errors)):
+        assert errors[i] < errors[i - 1]
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_no_mode():
+    args = argparse.Namespace(
+        approx=None,
+        exp=None,
+        identity=False,
+        ln=None,
+        mascheroni=False,
+        order=20,
+        compare=False,
+        precision=10,
+        format="table",
+    )
+    assert "required" in validate(args)
+
+
+def test_validate_negative_precision():
+    args = argparse.Namespace(
+        approx=None,
+        exp=None,
+        identity=True,
+        ln=None,
+        mascheroni=False,
+        order=20,
+        compare=False,
+        precision=-1,
+        format="table",
+    )
+    assert "--precision" in validate(args)
+
+
+def test_validate_approx_zero():
+    args = argparse.Namespace(
+        approx=0,
+        exp=None,
+        identity=False,
+        ln=None,
+        mascheroni=False,
+        order=20,
+        compare=False,
+        precision=10,
+        format="table",
+    )
+    assert "--approx" in validate(args)
+
+
+def test_validate_exp_bad_order():
+    args = argparse.Namespace(
+        approx=None,
+        exp=2.0,
+        identity=False,
+        ln=None,
+        mascheroni=False,
+        order=0,
+        compare=False,
+        precision=10,
+        format="table",
+    )
+    assert "--order" in validate(args)
+
+
+def test_validate_ln_nonpositive():
+    args = argparse.Namespace(
+        approx=None,
+        exp=None,
+        identity=False,
+        ln=0.0,
+        mascheroni=False,
+        order=20,
+        compare=False,
+        precision=10,
+        format="table",
+    )
+    assert "--ln" in validate(args)
+
+
+def test_validate_ln_negative():
+    args = argparse.Namespace(
+        approx=None,
+        exp=None,
+        identity=False,
+        ln=-1.0,
+        mascheroni=False,
+        order=20,
+        compare=False,
+        precision=10,
+        format="table",
+    )
+    assert "--ln" in validate(args)
+
+
+def test_validate_ln_bad_order():
+    args = argparse.Namespace(
+        approx=None,
+        exp=None,
+        identity=False,
+        ln=2.0,
+        mascheroni=False,
+        order=0,
+        compare=False,
+        precision=10,
+        format="table",
+    )
+    assert "--order" in validate(args)
+
+
+def test_validate_identity_valid():
+    args = argparse.Namespace(
+        approx=None,
+        exp=None,
+        identity=True,
+        ln=None,
+        mascheroni=False,
+        order=20,
+        compare=False,
+        precision=10,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+def test_validate_mascheroni_valid():
+    args = argparse.Namespace(
+        approx=None,
+        exp=None,
+        identity=False,
+        ln=None,
+        mascheroni=True,
+        order=20,
+        compare=False,
+        precision=10,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+def test_validate_approx_valid():
+    args = argparse.Namespace(
+        approx=1000,
+        exp=None,
+        identity=False,
+        ln=None,
+        mascheroni=False,
+        order=20,
+        compare=False,
+        precision=10,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+def test_validate_exp_valid():
+    args = argparse.Namespace(
+        approx=None,
+        exp=2.0,
+        identity=False,
+        ln=None,
+        mascheroni=False,
+        order=20,
+        compare=False,
+        precision=10,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+def test_validate_ln_valid():
+    args = argparse.Namespace(
+        approx=None,
+        exp=None,
+        identity=False,
+        ln=2.0,
+        mascheroni=False,
+        order=20,
+        compare=False,
+        precision=10,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+# ---------------------------------------------------------------------------
+# format_approx
+# ---------------------------------------------------------------------------
+
+
+def test_format_approx_contains_header():
+    table = _approx_table(100)
+    out = format_approx(table, precision=6)
+    assert "(1+1/n)^n" in out
+    assert "Error vs e" in out
+
+
+def test_format_approx_contains_math_e():
+    table = _approx_table(100)
+    out = format_approx(table, precision=6)
+    assert "math.e" in out
+
+
+# ---------------------------------------------------------------------------
+# format_exp
+# ---------------------------------------------------------------------------
+
+
+def test_format_exp_no_compare():
+    out = format_exp(1.0, 20, math.e, precision=6, compare=False)
+    assert "e^x (series)" in out
+    assert "math.exp" not in out
+
+
+def test_format_exp_with_compare():
+    result = exp_series(1.0, 50)
+    out = format_exp(1.0, 50, result, precision=6, compare=True)
+    assert "math.exp" in out
+    assert "Absolute error" in out
+
+
+# ---------------------------------------------------------------------------
+# format_identity
+# ---------------------------------------------------------------------------
+
+
+def test_format_identity_contains_identity_label():
+    real, imag, total = euler_identity()
+    out = format_identity(real, imag, total, precision=6)
+    assert "Euler" in out
+    assert "e^(iπ)" in out
+
+
+# ---------------------------------------------------------------------------
+# format_ln
+# ---------------------------------------------------------------------------
+
+
+def test_format_ln_no_compare():
+    out = format_ln(2.0, 20, math.log(2.0), precision=6, compare=False)
+    assert "ln(x) (series)" in out
+    assert "math.log" not in out
+
+
+def test_format_ln_with_compare():
+    out = format_ln(2.0, 50, natural_log(2.0, 50), precision=6, compare=True)
+    assert "math.log" in out
+    assert "Absolute error" in out
+
+
+# ---------------------------------------------------------------------------
+# format_mascheroni
+# ---------------------------------------------------------------------------
+
+
+def test_format_mascheroni_contains_gamma():
+    out = format_mascheroni(0.5772, precision=6)
+    assert "γ" in out or "Euler" in out
+
+
+def test_format_mascheroni_contains_known_value():
+    out = format_mascheroni(0.5772156649, precision=10)
+    assert "0.5772156649" in out
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_no_args_returns_2(capsys):
+    assert main([]) == 2
+
+
+def test_main_invalid_precision_returns_2(capsys):
+    assert main(["--identity", "--precision", "-1"]) == 2
+
+
+def test_main_approx_table(capsys):
+    rc = main(["--approx", "1000", "--precision", "6"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "(1+1/n)^n" in out
+
+
+def test_main_approx_json(capsys):
+    rc = main(["--approx", "100", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "approx"
+    assert "table" in data
+
+
+def test_main_exp_table(capsys):
+    rc = main(["--exp", "1", "--order", "20", "--precision", "6"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "e^x (series)" in out
+
+
+def test_main_exp_table_compare(capsys):
+    rc = main(["--exp", "1", "--compare", "--precision", "6"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "math.exp" in out
+
+
+def test_main_exp_json(capsys):
+    rc = main(["--exp", "2", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "exp"
+
+
+def test_main_exp_json_compare(capsys):
+    rc = main(["--exp", "2", "--format", "json", "--compare"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert "math_exp" in data
+
+
+def test_main_identity_table(capsys):
+    rc = main(["--identity", "--precision", "6"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Euler" in out
+
+
+def test_main_identity_json(capsys):
+    rc = main(["--identity", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "identity"
+    assert abs(data["real"] - (-1.0)) < 1e-12
+
+
+def test_main_ln_table(capsys):
+    rc = main(["--ln", "2", "--precision", "6"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "ln(x)" in out
+
+
+def test_main_ln_table_compare(capsys):
+    rc = main(["--ln", "2", "--compare", "--precision", "6"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "math.log" in out
+
+
+def test_main_ln_json(capsys):
+    rc = main(["--ln", "2", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "ln"
+
+
+def test_main_ln_json_compare(capsys):
+    rc = main(["--ln", "2", "--format", "json", "--compare"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert "math_log" in data
+
+
+def test_main_ln_invalid_x_returns_2(capsys):
+    assert main(["--ln", "0"]) == 2
+
+
+def test_main_mascheroni_table(monkeypatch, capsys):
+    monkeypatch.setattr(
+        euler_module, "euler_mascheroni", lambda: _EULER_MASCHERONI_KNOWN
+    )
+    rc = main(["--mascheroni", "--precision", "6"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Euler" in out
+
+
+def test_main_mascheroni_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        euler_module, "euler_mascheroni", lambda: _EULER_MASCHERONI_KNOWN
+    )
+    rc = main(["--mascheroni", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "mascheroni"
+
+
+def test_main_approx_bad_n_returns_2(capsys):
+    assert main(["--approx", "0"]) == 2
+
+
+def test_main_exp_bad_order_returns_2(capsys):
+    assert main(["--exp", "1", "--order", "0"]) == 2

--- a/tests/test_gini.py
+++ b/tests/test_gini.py
@@ -1,0 +1,672 @@
+"""Tests for Gini coefficient utility."""
+
+import argparse
+import json
+
+import pytest
+
+import src.utils.gini as gini_module
+from src.utils.gini import (
+    _gini_trapezoid,
+    _weighted_mean,
+    format_comparison,
+    format_grouped,
+    format_lorenz,
+    format_single,
+    gini_coefficient,
+    gini_grouped,
+    lorenz_curve,
+    main,
+    relative_mad,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# _gini_trapezoid
+# ---------------------------------------------------------------------------
+
+
+def test_gini_trapezoid_known():
+    vals = [1.0, 2.0, 3.0, 4.0, 5.0]
+    w = [1.0] * 5
+    assert _gini_trapezoid(vals, w) == pytest.approx(4 / 15, abs=1e-12)
+
+
+def test_gini_trapezoid_zero_total():
+    assert _gini_trapezoid([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# gini_coefficient
+# ---------------------------------------------------------------------------
+
+
+def test_gini_coefficient_known():
+    assert gini_coefficient([1, 2, 3, 4, 5]) == pytest.approx(4 / 15, abs=1e-12)
+
+
+def test_gini_coefficient_perfect_equality():
+    assert gini_coefficient([3.0, 3.0, 3.0]) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_gini_coefficient_max_inequality():
+    assert gini_coefficient([0.0, 0.0, 0.0, 1.0]) == pytest.approx(0.75, abs=1e-12)
+
+
+def test_gini_coefficient_corrected():
+    g = gini_coefficient([1, 2, 3, 4, 5], corrected=True)
+    assert g == pytest.approx(4 / 15 * 5 / 4, abs=1e-12)
+
+
+def test_gini_coefficient_corrected_n2():
+    g = gini_coefficient([1.0, 3.0], corrected=True)
+    g_raw = gini_coefficient([1.0, 3.0], corrected=False)
+    assert g == pytest.approx(g_raw * 2 / 1, abs=1e-12)
+
+
+def test_gini_coefficient_corrected_n1():
+    # n=1: correction skipped (n-1 = 0)
+    assert gini_coefficient([5.0], corrected=True) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_gini_coefficient_weighted():
+    # Equal data but unequal weights → non-zero Gini
+    g = gini_coefficient([1.0, 3.0], weights=[3.0, 1.0])
+    assert 0.0 < g < 1.0
+
+
+def test_gini_coefficient_empty_raises():
+    with pytest.raises(ValueError, match="empty"):
+        gini_coefficient([])
+
+
+def test_gini_coefficient_negative_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        gini_coefficient([-1.0, 2.0, 3.0])
+
+
+def test_gini_coefficient_all_zero_raises():
+    with pytest.raises(ValueError, match="positive"):
+        gini_coefficient([0.0, 0.0, 0.0])
+
+
+def test_gini_coefficient_weights_wrong_length():
+    with pytest.raises(ValueError, match="length"):
+        gini_coefficient([1.0, 2.0], weights=[1.0])
+
+
+def test_gini_coefficient_weights_nonpositive():
+    with pytest.raises(ValueError, match="positive"):
+        gini_coefficient([1.0, 2.0], weights=[0.0, 1.0])
+
+
+# ---------------------------------------------------------------------------
+# lorenz_curve
+# ---------------------------------------------------------------------------
+
+
+def test_lorenz_curve_starts_at_origin():
+    pts = lorenz_curve([1, 2, 3, 4, 5])
+    assert pts[0] == (0.0, 0.0)
+
+
+def test_lorenz_curve_ends_at_one():
+    pts = lorenz_curve([1, 2, 3, 4, 5])
+    assert pts[-1][0] == pytest.approx(1.0, abs=1e-12)
+    assert pts[-1][1] == pytest.approx(1.0, abs=1e-12)
+
+
+def test_lorenz_curve_length():
+    data = [1, 2, 3, 4, 5]
+    pts = lorenz_curve(data)
+    assert len(pts) == len(data) + 1
+
+
+def test_lorenz_curve_monotone():
+    pts = lorenz_curve([1, 2, 3, 4, 5])
+    pops = [p for p, _ in pts]
+    incs = [i for _, i in pts]
+    assert all(pops[j] <= pops[j + 1] for j in range(len(pops) - 1))
+    assert all(incs[j] <= incs[j + 1] for j in range(len(incs) - 1))
+
+
+def test_lorenz_curve_perfect_equality():
+    pts = lorenz_curve([3.0, 3.0, 3.0])
+    for pop, inc in pts[1:]:
+        assert pop == pytest.approx(inc, abs=1e-12)
+
+
+def test_lorenz_curve_weighted():
+    pts = lorenz_curve([1.0, 2.0], weights=[2.0, 1.0])
+    assert pts[0] == (0.0, 0.0)
+    assert len(pts) == 3
+
+
+def test_lorenz_curve_empty_raises():
+    with pytest.raises(ValueError, match="empty"):
+        lorenz_curve([])
+
+
+def test_lorenz_curve_negative_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        lorenz_curve([-1.0, 2.0])
+
+
+def test_lorenz_curve_all_zero_raises():
+    with pytest.raises(ValueError, match="positive"):
+        lorenz_curve([0.0, 0.0])
+
+
+def test_lorenz_curve_weights_wrong_length():
+    with pytest.raises(ValueError, match="length"):
+        lorenz_curve([1.0, 2.0], weights=[1.0])
+
+
+def test_lorenz_curve_weights_nonpositive():
+    with pytest.raises(ValueError, match="positive"):
+        lorenz_curve([1.0, 2.0], weights=[0.0, 1.0])
+
+
+# ---------------------------------------------------------------------------
+# relative_mad
+# ---------------------------------------------------------------------------
+
+
+def test_relative_mad_equals_two_times_gini():
+    data = [1.0, 2.0, 3.0, 4.0, 5.0]
+    assert relative_mad(data) == pytest.approx(2 * gini_coefficient(data), abs=1e-12)
+
+
+def test_relative_mad_weighted():
+    data = [1.0, 3.0]
+    w = [2.0, 1.0]
+    assert relative_mad(data, weights=w) == pytest.approx(
+        2 * gini_coefficient(data, weights=w), abs=1e-12
+    )
+
+
+# ---------------------------------------------------------------------------
+# gini_grouped
+# ---------------------------------------------------------------------------
+
+
+def test_gini_grouped_perfect_equality():
+    groups = [(1 / 3, 1 / 3), (1 / 3, 1 / 3), (1 / 3, 1 / 3)]
+    assert gini_grouped(groups) == pytest.approx(0.0, abs=1e-10)
+
+
+def test_gini_grouped_two_groups_known():
+    # Bottom 40% earns 10%, top 60% earns 90%
+    groups = [(0.4, 0.1), (0.6, 0.9)]
+    g = gini_grouped(groups)
+    assert 0.0 < g < 1.0
+
+
+def test_gini_grouped_sorted_by_per_capita():
+    # Same groups in different order should yield same result
+    groups_a = [(0.4, 0.1), (0.6, 0.9)]
+    groups_b = [(0.6, 0.9), (0.4, 0.1)]
+    assert gini_grouped(groups_a) == pytest.approx(gini_grouped(groups_b), abs=1e-12)
+
+
+def test_gini_grouped_empty_raises():
+    with pytest.raises(ValueError, match="empty"):
+        gini_grouped([])
+
+
+def test_gini_grouped_negative_pop_raises():
+    with pytest.raises(ValueError, match="positive"):
+        gini_grouped([(-0.1, 0.5), (1.1, 0.5)])
+
+
+def test_gini_grouped_negative_inc_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        gini_grouped([(0.5, -0.1), (0.5, 1.1)])
+
+
+def test_gini_grouped_pop_sum_not_one_raises():
+    with pytest.raises(ValueError, match="sum to 1"):
+        gini_grouped([(0.3, 0.5), (0.3, 0.5)])
+
+
+def test_gini_grouped_inc_sum_not_one_raises():
+    with pytest.raises(ValueError, match="sum to 1"):
+        gini_grouped([(0.5, 0.3), (0.5, 0.3)])
+
+
+# ---------------------------------------------------------------------------
+# _weighted_mean
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_mean_equal_weights():
+    assert _weighted_mean([1.0, 2.0, 3.0], [1.0, 1.0, 1.0]) == pytest.approx(2.0)
+
+
+def test_weighted_mean_unequal_weights():
+    # Mean of [1, 3] with weights [3, 1] = (3+3)/4 = 1.5
+    assert _weighted_mean([1.0, 3.0], [3.0, 1.0]) == pytest.approx(1.5)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_no_mode():
+    args = argparse.Namespace(
+        data=None,
+        groups=None,
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "required" in validate(args)
+
+
+def test_validate_negative_precision():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0]],
+        groups=None,
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=-1,
+        format="table",
+    )
+    assert "--precision" in validate(args)
+
+
+def test_validate_data_and_groups_exclusive():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0]],
+        groups=[0.5, 0.5, 0.5, 0.5],
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "mutually exclusive" in validate(args)
+
+
+def test_validate_groups_odd_count():
+    args = argparse.Namespace(
+        data=None,
+        groups=[0.5, 0.5, 0.5],
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "--groups" in validate(args)
+
+
+def test_validate_groups_single_value():
+    args = argparse.Namespace(
+        data=None,
+        groups=[0.5],
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "--groups" in validate(args)
+
+
+def test_validate_weights_multi_dataset():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0], [3.0, 4.0]],
+        groups=None,
+        weights=[1.0, 1.0],
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "--weights" in validate(args)
+
+
+def test_validate_weights_wrong_length():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0, 3.0]],
+        groups=None,
+        weights=[1.0, 1.0],
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "--weights" in validate(args)
+
+
+def test_validate_weights_nonpositive():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0]],
+        groups=None,
+        weights=[0.0, 1.0],
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "--weights" in validate(args)
+
+
+def test_validate_lorenz_multi_dataset():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0], [3.0, 4.0]],
+        groups=None,
+        weights=None,
+        lorenz=True,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "--lorenz" in validate(args)
+
+
+def test_validate_valid_single_data():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0, 3.0]],
+        groups=None,
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+def test_validate_valid_groups():
+    args = argparse.Namespace(
+        data=None,
+        groups=[0.5, 0.3, 0.5, 0.7],
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+def test_validate_valid_multi_data():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0], [3.0, 4.0]],
+        groups=None,
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+def test_validate_valid_data_with_weights():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0, 3.0]],
+        groups=None,
+        weights=[1.0, 2.0, 1.0],
+        lorenz=False,
+        correct=True,
+        precision=6,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+def test_validate_valid_lorenz_single():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0, 3.0]],
+        groups=None,
+        weights=None,
+        lorenz=True,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+# ---------------------------------------------------------------------------
+# format_single
+# ---------------------------------------------------------------------------
+
+
+def test_format_single_no_corrected():
+    out = format_single(5, 3.0, 0.2667, 0.5333, None, 4)
+    assert "0.2667" in out
+    assert "Corrected" not in out
+    assert "5" in out
+
+
+def test_format_single_with_corrected():
+    out = format_single(5, 3.0, 0.2667, 0.5333, 0.3333, 4)
+    assert "0.3333" in out
+    assert "Corrected" in out
+
+
+# ---------------------------------------------------------------------------
+# format_lorenz
+# ---------------------------------------------------------------------------
+
+
+def test_format_lorenz_contains_header():
+    points = [(0.0, 0.0), (0.5, 0.3), (1.0, 1.0)]
+    out = format_lorenz(points, 0.2667, 4)
+    assert "Population" in out
+    assert "Income" in out
+    assert "0.2667" in out
+
+
+def test_format_lorenz_contains_rows():
+    points = [(0.0, 0.0), (1.0, 1.0)]
+    out = format_lorenz(points, 0.0, 4)
+    assert "0.0000" in out
+    assert "1.0000" in out
+
+
+# ---------------------------------------------------------------------------
+# format_grouped
+# ---------------------------------------------------------------------------
+
+
+def test_format_grouped_contains_gini():
+    out = format_grouped(0.3333, 3, 4)
+    assert "0.3333" in out
+    assert "3" in out
+
+
+def test_format_grouped_contains_rmad():
+    out = format_grouped(0.25, 2, 4)
+    rmad = 2 * 0.25
+    assert f"{rmad:.4f}" in out
+
+
+# ---------------------------------------------------------------------------
+# format_comparison
+# ---------------------------------------------------------------------------
+
+
+def test_format_comparison_no_corrected():
+    results = [
+        {"index": 1, "n": 5, "mean": 3.0, "gini": 0.27, "corrected": 0.33, "rank": 1},
+        {"index": 2, "n": 4, "mean": 2.5, "gini": 0.35, "corrected": 0.47, "rank": 2},
+    ]
+    out = format_comparison(results, corrected=False, precision=4)
+    assert "Gini" in out
+    assert "Corrected" not in out
+    assert "0.2700" in out
+
+
+def test_format_comparison_with_corrected():
+    results = [
+        {"index": 1, "n": 5, "mean": 3.0, "gini": 0.27, "corrected": 0.33, "rank": 1},
+    ]
+    out = format_comparison(results, corrected=True, precision=4)
+    assert "Corrected" in out
+    assert "0.3300" in out
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_no_args_returns_2(capsys):
+    assert main([]) == 2
+
+
+def test_main_negative_precision_returns_2(capsys):
+    assert main(["--data", "1", "2", "3", "--precision", "-1"]) == 2
+
+
+def test_main_single_data_table(capsys):
+    rc = main(["--data", "1", "2", "3", "4", "5", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0.2667" in out
+
+
+def test_main_single_data_json(capsys):
+    rc = main(["--data", "1", "2", "3", "4", "5", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "single"
+    assert abs(data["gini"] - 4 / 15) < 1e-4
+
+
+def test_main_single_data_json_with_correct(capsys):
+    rc = main(["--data", "1", "2", "3", "4", "5", "--format", "json", "--correct"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert "corrected_gini" in data
+
+
+def test_main_single_data_lorenz_table(capsys):
+    rc = main(["--data", "1", "2", "3", "4", "5", "--lorenz", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Population" in out
+
+
+def test_main_single_data_lorenz_json(capsys):
+    rc = main(["--data", "1", "2", "3", "--lorenz", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "lorenz"
+    assert "lorenz_curve" in data
+
+
+def test_main_single_data_lorenz_json_with_correct(capsys):
+    rc = main(["--data", "1", "2", "3", "--lorenz", "--format", "json", "--correct"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert "corrected_gini" in data
+
+
+def test_main_single_data_with_weights(capsys):
+    rc = main(["--data", "1", "2", "3", "--weights", "2", "1", "1", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Gini" in out
+
+
+def test_main_single_data_with_correct(capsys):
+    rc = main(["--data", "1", "2", "3", "4", "5", "--correct", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Corrected" in out
+
+
+def test_main_groups_table(capsys):
+    rc = main(
+        ["--groups", "0.2", "0.05", "0.3", "0.15", "0.5", "0.80", "--precision", "4"]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Gini" in out
+
+
+def test_main_groups_json(capsys):
+    rc = main(["--groups", "0.4", "0.1", "0.6", "0.9", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "grouped"
+    assert "gini" in data
+
+
+def test_main_groups_invalid_returns_2(capsys):
+    # Two groups but pop sums to 0.5 (not 1.0) → gini_grouped raises
+    assert main(["--groups", "0.2", "0.05", "0.3", "0.15"]) == 2
+
+
+def test_main_multi_data_table(capsys):
+    rc = main(["--data", "1", "2", "3", "--data", "4", "5", "6", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Dataset" in out
+
+
+def test_main_multi_data_json(capsys):
+    rc = main(["--data", "1", "2", "3", "--data", "4", "5", "6", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "compare"
+    assert len(data["datasets"]) == 2
+
+
+def test_main_multi_data_with_correct(capsys):
+    rc = main(
+        [
+            "--data",
+            "1",
+            "2",
+            "3",
+            "--data",
+            "4",
+            "5",
+            "6",
+            "--correct",
+            "--precision",
+            "4",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Corrected" in out
+
+
+def test_main_single_data_invalid_returns_2(capsys):
+    # Negative value passes validate but fails gini_coefficient
+    assert main(["--data", "-1", "2", "3"]) == 2
+
+
+def test_main_multi_data_invalid_returns_2(capsys):
+    # Negative in first dataset → ValueError in multi-dataset loop
+    assert main(["--data", "-1", "2", "3", "--data", "4", "5", "6"]) == 2
+
+
+def test_main_lorenz_error_path(monkeypatch, capsys):
+    """Cover the lorenz_curve ValueError branch in main."""
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("forced lorenz error")
+
+    monkeypatch.setattr(gini_module, "lorenz_curve", raise_value_error)
+    assert main(["--data", "1", "2", "3", "--lorenz"]) == 2
+    err = capsys.readouterr().err
+    assert "forced lorenz error" in err

--- a/tests/test_sigmoid.py
+++ b/tests/test_sigmoid.py
@@ -1,0 +1,466 @@
+"""Tests for sigmoid function utility."""
+
+import argparse
+import math
+
+import pytest
+
+import src.utils.sigmoid as sigmoid_module
+from src.utils.sigmoid import (
+    _frange,
+    format_inverse,
+    format_single,
+    format_table,
+    inverse_logit,
+    main,
+    sigmoid,
+    sigmoid_derivative,
+    sparkline,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# sigmoid
+# ---------------------------------------------------------------------------
+
+
+def test_sigmoid_at_zero():
+    assert sigmoid(0.0) == 0.5
+
+
+def test_sigmoid_positive_x():
+    result = sigmoid(2.0)
+    assert abs(result - 1.0 / (1.0 + math.exp(-2.0))) < 1e-12
+
+
+def test_sigmoid_negative_x():
+    result = sigmoid(-3.0)
+    expected = math.exp(-3.0) / (1.0 + math.exp(-3.0))
+    assert abs(result - expected) < 1e-12
+
+
+def test_sigmoid_large_positive():
+    assert sigmoid(1000.0) == pytest.approx(1.0, abs=1e-10)
+
+
+def test_sigmoid_large_negative():
+    assert sigmoid(-1000.0) == pytest.approx(0.0, abs=1e-10)
+
+
+def test_sigmoid_output_in_zero_one():
+    for x in [-1.0, 0.0, 1.0]:
+        assert 0.0 < sigmoid(x) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# sigmoid_derivative
+# ---------------------------------------------------------------------------
+
+
+def test_derivative_at_zero():
+    assert sigmoid_derivative(0.0) == pytest.approx(0.25, abs=1e-12)
+
+
+def test_derivative_is_s_times_one_minus_s():
+    for x in [-2.0, 0.0, 1.5]:
+        s = sigmoid(x)
+        assert sigmoid_derivative(x) == pytest.approx(s * (1.0 - s), abs=1e-12)
+
+
+def test_derivative_symmetry():
+    assert sigmoid_derivative(3.0) == pytest.approx(sigmoid_derivative(-3.0), abs=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# inverse_logit
+# ---------------------------------------------------------------------------
+
+
+def test_inverse_logit_half():
+    assert inverse_logit(0.5) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_inverse_logit_roundtrip():
+    for p in [0.1, 0.3, 0.75, 0.9]:
+        assert sigmoid(inverse_logit(p)) == pytest.approx(p, abs=1e-12)
+
+
+def test_inverse_logit_zero_raises():
+    with pytest.raises(ValueError, match="strictly between 0 and 1"):
+        inverse_logit(0.0)
+
+
+def test_inverse_logit_one_raises():
+    with pytest.raises(ValueError, match="strictly between 0 and 1"):
+        inverse_logit(1.0)
+
+
+def test_inverse_logit_negative_raises():
+    with pytest.raises(ValueError):
+        inverse_logit(-0.1)
+
+
+# ---------------------------------------------------------------------------
+# _frange
+# ---------------------------------------------------------------------------
+
+
+def test_frange_integers():
+    assert _frange(0.0, 3.0, 1.0) == [0.0, 1.0, 2.0, 3.0]
+
+
+def test_frange_includes_stop():
+    result = _frange(-5.0, 5.0, 1.0)
+    assert result[0] == -5.0
+    assert result[-1] == pytest.approx(5.0, abs=1e-9)
+    assert len(result) == 11
+
+
+def test_frange_fractional_step():
+    result = _frange(0.0, 1.0, 0.5)
+    assert len(result) == 3
+    assert result == pytest.approx([0.0, 0.5, 1.0])
+
+
+# ---------------------------------------------------------------------------
+# sparkline
+# ---------------------------------------------------------------------------
+
+
+def test_sparkline_empty():
+    assert sparkline([]) == ""
+
+
+def test_sparkline_zero():
+    result = sparkline([0.0])
+    assert result == "▁"
+
+
+def test_sparkline_one():
+    result = sparkline([1.0])
+    assert result == "█"
+
+
+def test_sparkline_length():
+    result = sparkline([0.0, 0.25, 0.5, 0.75, 1.0])
+    assert len(result) == 5
+
+
+def test_sparkline_increasing():
+    values = [0.0, 0.2, 0.5, 0.8, 1.0]
+    result = sparkline(values)
+    assert len(result) == 5
+    assert all(c in "▁▂▃▄▅▆▇█" for c in result)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_negative_precision():
+    args = argparse.Namespace(
+        value=None,
+        range=None,
+        inverse=False,
+        prob=None,
+        derivative=False,
+        plot=False,
+        precision=-1,
+    )
+    assert validate(args) == "--precision must be non-negative"
+
+
+def test_validate_no_mode():
+    args = argparse.Namespace(
+        value=None,
+        range=None,
+        inverse=False,
+        prob=None,
+        derivative=False,
+        plot=False,
+        precision=6,
+    )
+    assert validate(args) == "one of --value, --range, or --inverse is required"
+
+
+def test_validate_inverse_without_prob():
+    args = argparse.Namespace(
+        value=None,
+        range=None,
+        inverse=True,
+        prob=None,
+        derivative=False,
+        plot=False,
+        precision=6,
+    )
+    assert validate(args) == "--prob is required with --inverse"
+
+
+def test_validate_inverse_prob_out_of_range_high():
+    args = argparse.Namespace(
+        value=None,
+        range=None,
+        inverse=True,
+        prob=1.0,
+        derivative=False,
+        plot=False,
+        precision=6,
+    )
+    assert validate(args) == "--prob must be strictly between 0 and 1"
+
+
+def test_validate_inverse_prob_out_of_range_low():
+    args = argparse.Namespace(
+        value=None,
+        range=None,
+        inverse=True,
+        prob=0.0,
+        derivative=False,
+        plot=False,
+        precision=6,
+    )
+    assert validate(args) == "--prob must be strictly between 0 and 1"
+
+
+def test_validate_inverse_valid():
+    args = argparse.Namespace(
+        value=None,
+        range=None,
+        inverse=True,
+        prob=0.75,
+        derivative=False,
+        plot=False,
+        precision=6,
+    )
+    assert validate(args) is None
+
+
+def test_validate_range_zero_step():
+    args = argparse.Namespace(
+        value=None,
+        range=[-5.0, 5.0, 0.0],
+        inverse=False,
+        prob=None,
+        derivative=False,
+        plot=False,
+        precision=6,
+    )
+    assert validate(args) == "STEP must be greater than 0"
+
+
+def test_validate_range_negative_step():
+    args = argparse.Namespace(
+        value=None,
+        range=[-5.0, 5.0, -1.0],
+        inverse=False,
+        prob=None,
+        derivative=False,
+        plot=False,
+        precision=6,
+    )
+    assert validate(args) == "STEP must be greater than 0"
+
+
+def test_validate_range_min_ge_max():
+    args = argparse.Namespace(
+        value=None,
+        range=[5.0, -5.0, 1.0],
+        inverse=False,
+        prob=None,
+        derivative=False,
+        plot=False,
+        precision=6,
+    )
+    assert validate(args) == "MIN must be less than MAX"
+
+
+def test_validate_range_equal_min_max():
+    args = argparse.Namespace(
+        value=None,
+        range=[3.0, 3.0, 1.0],
+        inverse=False,
+        prob=None,
+        derivative=False,
+        plot=False,
+        precision=6,
+    )
+    assert validate(args) == "MIN must be less than MAX"
+
+
+def test_validate_value_valid():
+    args = argparse.Namespace(
+        value=1.0,
+        range=None,
+        inverse=False,
+        prob=None,
+        derivative=False,
+        plot=False,
+        precision=6,
+    )
+    assert validate(args) is None
+
+
+def test_validate_range_valid():
+    args = argparse.Namespace(
+        value=None,
+        range=[-5.0, 5.0, 1.0],
+        inverse=False,
+        prob=None,
+        derivative=False,
+        plot=False,
+        precision=6,
+    )
+    assert validate(args) is None
+
+
+# ---------------------------------------------------------------------------
+# format_single
+# ---------------------------------------------------------------------------
+
+
+def test_format_single_contains_value_and_sigmoid():
+    out = format_single(0.0, 0.5, 0.25, 4, show_deriv=False)
+    assert "0.0000" in out
+    assert "0.5000" in out
+    assert "σ'(x)" not in out
+
+
+def test_format_single_with_derivative():
+    out = format_single(0.0, 0.5, 0.25, 4, show_deriv=True)
+    assert "0.2500" in out
+    assert "σ'(x)" in out
+
+
+# ---------------------------------------------------------------------------
+# format_table
+# ---------------------------------------------------------------------------
+
+
+def test_format_table_no_deriv_no_plot():
+    xs = [-1.0, 0.0, 1.0]
+    sigs = [sigmoid(x) for x in xs]
+    dsigs = [sigmoid_derivative(x) for x in xs]
+    out = format_table(xs, sigs, dsigs, precision=4, show_deriv=False, show_plot=False)
+    assert "σ(x)" in out
+    assert "σ'(x)" not in out
+    assert "▁" not in out
+
+
+def test_format_table_with_deriv():
+    xs = [0.0]
+    sigs = [0.5]
+    dsigs = [0.25]
+    out = format_table(xs, sigs, dsigs, precision=4, show_deriv=True, show_plot=False)
+    assert "σ'(x)" in out
+    assert "0.2500" in out
+
+
+def test_format_table_with_plot():
+    xs = [-2.0, 0.0, 2.0]
+    sigs = [sigmoid(x) for x in xs]
+    dsigs = [sigmoid_derivative(x) for x in xs]
+    out = format_table(xs, sigs, dsigs, precision=4, show_deriv=False, show_plot=True)
+    assert any(c in out for c in "▁▂▃▄▅▆▇█")
+
+
+# ---------------------------------------------------------------------------
+# format_inverse
+# ---------------------------------------------------------------------------
+
+
+def test_format_inverse_contains_prob_and_logit():
+    x = inverse_logit(0.75)
+    out = format_inverse(0.75, x, precision=4)
+    assert "0.7500" in out
+    assert "logit" in out.lower() or "log" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_no_args_returns_2(capsys):
+    assert main([]) == 2
+
+
+def test_main_invalid_precision_returns_2(capsys):
+    assert main(["--value", "0", "--precision", "-1"]) == 2
+
+
+def test_main_single_value(capsys):
+    rc = main(["-x", "0", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0.5000" in out
+
+
+def test_main_single_value_with_derivative(capsys):
+    rc = main(["-x", "0", "--derivative", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0.2500" in out
+
+
+def test_main_single_value_with_plot(capsys):
+    rc = main(["-x", "0", "--plot"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert any(c in out for c in "▁▂▃▄▅▆▇█")
+
+
+def test_main_range(capsys):
+    rc = main(["--range", "-2", "2", "1", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "σ(x)" in out
+
+
+def test_main_range_with_derivative(capsys):
+    rc = main(["--range", "-1", "1", "1", "--derivative", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "σ'(x)" in out
+
+
+def test_main_range_with_plot(capsys):
+    rc = main(["--range", "-3", "3", "1", "--plot"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert any(c in out for c in "▁▂▃▄▅▆▇█")
+
+
+def test_main_inverse(capsys):
+    rc = main(["--inverse", "--prob", "0.75", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0.7500" in out
+
+
+def test_main_inverse_missing_prob_returns_2(capsys):
+    assert main(["--inverse"]) == 2
+
+
+def test_main_inverse_invalid_prob_returns_2(capsys):
+    assert main(["--inverse", "--prob", "1.5"]) == 2
+
+
+def test_main_inverse_error_path(monkeypatch, capsys):
+    """Cover the try/except branch in main for inverse_logit failure."""
+
+    def raise_value_error(_p: float) -> float:
+        raise ValueError("forced error")
+
+    monkeypatch.setattr(sigmoid_module, "inverse_logit", raise_value_error)
+    assert main(["--inverse", "--prob", "0.5"]) == 2
+    err = capsys.readouterr().err
+    assert "Error: forced error" in err
+
+
+def test_main_range_invalid_step_returns_2(capsys):
+    assert main(["--range", "-5", "5", "0"]) == 2
+
+
+def test_main_range_invalid_bounds_returns_2(capsys):
+    assert main(["--range", "5", "-5", "1"]) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "pythodds"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },

--- a/uv.lock
+++ b/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "pythodds"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- Adds `sigmoid` tool (closes #8): evaluates σ(x), derivative σ'(x), inverse logit, range tables, and Unicode sparkline
- Adds `euler` tool (closes #9): limit convergence to e, Taylor series for e^x and ln(x), Euler's identity, Euler-Mascheroni constant; supports table and JSON output
- Bumps version to `0.19.0`; updates `CHANGELOG.md` and `README.md`

## Test plan

- [ ] `uv run python3 -m pytest` — 898 tests pass, 100% coverage across all modules
- [ ] `sigmoid -x 0` → `Sigmoid σ(x): 0.500000`
- [ ] `sigmoid --range -3 3 1 --derivative --plot` → table with σ'(x) column and sparkline
- [ ] `sigmoid --inverse --prob 0.75` → logit ≈ 1.098612, round-trip check σ(logit) = 0.75
- [ ] `euler --approx 1000000` → convergence table ending near 2.71828...
- [ ] `euler --exp 1 --compare` → series ≈ math.exp(1) with near-zero error
- [ ] `euler --identity --precision 15` → real = -1.0, imaginary ≈ 0, sum ≈ 0
- [ ] `euler --ln 2 --compare` → series ≈ math.log(2) ≈ 0.693147
- [ ] `euler --mascheroni` → γ ≈ 0.5772156649
- [ ] `euler --exp 2 --format json --compare` → valid JSON with `math_exp` and `error` keys