### PR TITLE
feat: add `Gini coefficient` and `Sunzi's theorem` tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.20.0] — 2026-06-13
+
+### Added
+- Gini coefficient tool (`gini`) — inequality measurement from raw data, weighted samples, grouped shares, Lorenz curve, and multi-dataset comparison
+- Sunzi's Theorem tool (`crt`) — simultaneous congruence solver supporting coprime and non-coprime moduli
+
+---
+
 ## [0.19.0] — 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Sigmoid Function** | Evaluate σ(x) = 1/(1+e^(−x)), its derivative, and the inverse logit; range tables and Unicode sparkline |
 | **Euler's Number** | Explore e via limit convergence, Taylor series for e^x and ln(x), Euler's identity, and the Euler-Mascheroni constant |
 | **Monte Carlo Simulator** | Empirically estimate probabilities for `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, `linboot` experiments with confidence intervals and analytical comparison |
-| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, and `euler` commands |
+| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, and `crt` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
 
@@ -87,6 +87,8 @@ pip install -e .
 | `jevons` | Rebound effect and backfire analysis for resource efficiency improvements |
 | `sigmoid` | Sigmoid σ(x), derivative σ'(x), inverse logit, range tables, and Unicode sparkline |
 | `euler` | Euler's number via limit/series, e^x Taylor series, ln(x) series, Euler's identity, and γ constant |
+| `gini` | Gini coefficient and Lorenz curve from raw data, weighted samples, or grouped shares |
+| `crt` | Sunzi's Theorem solver for systems of simultaneous congruences |
 | `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
 
 ---
@@ -1351,6 +1353,8 @@ simulate --experiment linboot --params x=1,2,3,4,5 y=2.1,3.9,6.2,7.8,10.1 predic
 | Forecast | `src.utils.forecast_time_series` | `simple_exponential_smoothing`, `double_exponential_smoothing`, `holt_winters` |
 | Collatz | `src.utils.collatz_conjecture` | `CollatzChecker`, `collatz_next` |
 | Jevons | `src.utils.jevons_paradox` | `analyze`, `expected_savings`, `rebound_consumption`, `net_consumption`, `is_backfire` |
+| Gini | `src.utils.gini` | `gini_coefficient`, `lorenz_curve`, `relative_mad`, `gini_grouped` |
+| CRT | `src.utils.crt` | `extended_gcd`, `mod_inverse`, `crt` |
 | Monte Carlo | `src.utils.monte_carlo` | `simulate_binomial`, `simulate_birthday`, `simulate_streak`, `simulate_poisson`, `simulate_power`, `simulate_permutation`, `simulate_bayes`, `simulate_season`, `simulate_linboot` |
 
 ---
@@ -2205,6 +2209,56 @@ ci = wilson_ci(p_hat, len(results))
 
 </details>
 
+<details>
+<summary><strong><code>gini</code></strong> — Gini Coefficient and Lorenz Curve</summary>
+
+Computes the Gini coefficient and Lorenz curve for inequality measurement. Supports raw observations, optional positive weights for weighted samples, and pre-aggregated population/income share pairs (grouped mode). Groups are sorted internally by ascending per-capita income before constructing the Lorenz curve. Includes relative mean absolute difference (RMAD = 2 × Gini) and an optional n/(n−1) small-sample bias correction. Multi-dataset mode ranks all datasets by Gini from most equal to least equal.
+
+```bash
+# Single dataset — point estimate
+gini --data 1 2 3 4 5
+
+# Weighted samples
+gini --data 10 30 50 80 --weights 4 3 2 1
+
+# Lorenz curve coordinates
+gini --data 1 2 3 4 5 --lorenz --precision 4
+
+# With bias correction
+gini --data 1 2 3 4 5 --correct
+
+# Grouped (population share / income share pairs)
+gini --groups 0.2 0.05 0.3 0.15 0.5 0.80
+
+# Compare multiple datasets
+gini --data 1 2 3 --data 5 5 90 --data 30 35 35
+
+# JSON output
+gini --data 1 2 3 4 5 --format json
+```
+
+</details>
+
+<details>
+<summary><strong><code>crt</code></strong> — Sunzi's Theorem Solver</summary>
+
+Solves systems of simultaneous congruences using Sunzi's Theorem (general CRT). Handles both coprime and non-coprime moduli via pairwise merging (solution exists iff aᵢ ≡ aⱼ mod gcd(nᵢ, nⱼ) for all pairs). Remainders are normalized to [0, n) automatically. Returns the unique solution x in [0, N) and the combined modulus N = lcm(n₁, ..., nₖ). Supports listing all solutions up to a user-specified bound.
+
+```bash
+# Solve x≡2(mod 3), x≡3(mod 5), x≡2(mod 7) → 23 (mod 105)
+crt --solve 2 3 3 5 2 7
+
+# Non-coprime moduli (x≡0(mod 4), x≡2(mod 6))
+crt --solve 0 4 2 6
+
+# List all solutions up to 300
+crt --solve 2 3 3 5 2 7 --all 300
+
+# JSON output
+crt --solve 2 3 3 5 2 7 --format json
+```
+
+</details>
 
 ## Development
 

--- a/docs/tool_ideas.md
+++ b/docs/tool_ideas.md
@@ -16,8 +16,10 @@ For the full list of implemented tools and their CLI entry points, see `README.m
 | `bootci` | Bootstrap confidence intervals |
 | `collatz` | Collatz conjecture / hailstone sequences |
 | `confint` | Confidence interval calculator |
+| `crt` | Sunzi's Theorem (CRT) solver |
 | `expected` | Expected value and variance for discrete distributions |
 | `forecast` | Time series forecasting with prediction intervals |
+| `gini` | Gini coefficient and Lorenz curve |
 | `jevons` | Jevons paradox / rebound effect modeling |
 | `linreg` | Simple linear regression |
 | `normal` | Gaussian PDF, CDF, and quantile |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pythodds"
-version = "0.19.0"
+version = "0.20.0"
 description = "Command line utilities for statistics, odds, and probabilities"
 readme = "README.md"
 authors = [
@@ -52,6 +52,8 @@ ttest = "src.utils.t_test:main"
 jevons = "src.utils.jevons_paradox:main"
 sigmoid = "src.utils.sigmoid:main"
 euler = "src.utils.euler:main"
+gini = "src.utils.gini:main"
+crt = "src.utils.crt:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/utils/crt.py
+++ b/src/utils/crt.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Command-line utility for Sunzi's Theorem (CRT).
+
+Solves systems of simultaneous congruences:
+  x ≡ a₁ (mod n₁)
+  x ≡ a₂ (mod n₂)
+  ...
+
+Works for both coprime and non-coprime moduli (general CRT).  Remainders
+are normalized to [0, n) automatically.  Pure Python — no external
+dependencies.
+
+Usage examples:
+  crt --solve 2 3 3 5 2 7
+  crt --solve 0 4 3 6 --format json
+  crt --solve 2 3 3 5 2 7 --all 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def extended_gcd(a: int, b: int) -> tuple[int, int, int]:
+    """Compute the extended greatest common divisor.
+
+    Returns (g, s, t) such that a·s + b·t = g = gcd(a, b).
+
+    Args:
+        a: First integer.
+        b: Second integer.
+
+    Returns:
+        Tuple (g, s, t) with a·s + b·t = g.
+    """
+    if b == 0:
+        return a, 1, 0
+    g, x, y = extended_gcd(b, a % b)
+    return g, y, x - (a // b) * y
+
+
+def mod_inverse(a: int, m: int) -> int:
+    """Compute the modular inverse of a modulo m.
+
+    Args:
+        a: Integer to invert.
+        m: Modulus; must be >= 2.
+
+    Returns:
+        x in [0, m) such that a·x ≡ 1 (mod m).
+
+    Raises:
+        ValueError: If gcd(a, m) ≠ 1 (inverse does not exist) or m < 2.
+    """
+    if m < 2:
+        raise ValueError(f"modulus must be at least 2, got {m}")
+    g, s, _ = extended_gcd(a % m, m)
+    if g != 1:
+        raise ValueError(f"{a} has no inverse modulo {m} (gcd={g})")
+    return s % m
+
+
+def crt(remainders: list[int], moduli: list[int]) -> tuple[int, int]:
+    """Solve a system of congruences using Sunzi's Theorem (general CRT).
+
+    Handles both coprime and non-coprime moduli via pairwise merge.
+    Remainders are normalized to [0, nᵢ) internally.
+
+    Args:
+        remainders: Residues a₁, a₂, ..., aₖ (any integers).
+        moduli: Moduli n₁, n₂, ..., nₖ; each must be >= 1.
+
+    Returns:
+        Tuple (x, N) where x is the unique solution in [0, N) and
+        N = lcm(n₁, ..., nₖ).
+
+    Raises:
+        ValueError: If lengths differ, any modulus < 1, or the system is
+            inconsistent (no solution).
+    """
+    if len(remainders) != len(moduli):
+        raise ValueError("remainders and moduli must have the same length")
+    if not remainders:
+        raise ValueError("at least one congruence is required")
+    for n in moduli:
+        if n < 1:
+            raise ValueError(f"moduli must be >= 1, got {n}")
+
+    x = remainders[0] % moduli[0]
+    m = moduli[0]
+    for a, n in zip(remainders[1:], moduli[1:]):
+        a = a % n
+        g, p, _ = extended_gcd(m, n)
+        if (a - x) % g != 0:
+            raise ValueError(
+                f"No solution: x≡{x} (mod {m}) and x≡{a} (mod {n}) are inconsistent"
+            )
+        lcm = m * (n // g)
+        # Step k along m until congruent with a (mod n)
+        x = (x + m * ((a - x) // g * p % (n // g))) % lcm
+        m = lcm
+    return x, m
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Argument list; uses sys.argv[1:] when None.
+
+    Returns:
+        Parsed namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description="Sunzi's Theorem solver.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  crt --solve 2 3 3 5 2 7          # x≡2(3), x≡3(5), x≡2(7) → 23 (mod 105)
+  crt --solve 0 4 3 6              # non-coprime moduli (gcd=2, compatible)
+  crt --solve 2 3 3 5 2 7 --all 300
+  crt --solve 2 3 3 5 2 7 --format json
+""",
+    )
+    parser.add_argument(
+        "--solve",
+        type=int,
+        nargs="+",
+        metavar="VALUE",
+        help="flat list of remainder/modulus pairs: A1 N1 A2 N2 ...",
+    )
+    parser.add_argument(
+        "--all",
+        type=int,
+        metavar="MAX",
+        help="list all solutions in [0, MAX]",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        choices=["table", "json"],
+        default="table",
+        help="output format: table (default) or json",
+    )
+
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Validate parsed arguments.
+
+    Args:
+        args: Parsed namespace from parse_args.
+
+    Returns:
+        Error message if invalid; None if all arguments are valid.
+    """
+    if args.solve is None:
+        return "--solve is required"
+    if len(args.solve) < 2:
+        return "--solve requires at least one remainder/modulus pair (A N)"
+    if len(args.solve) % 2 != 0:
+        return "--solve requires an even number of values (A N pairs)"
+    vals = args.solve
+    for i in range(1, len(vals), 2):
+        if vals[i] < 1:
+            return f"moduli must be >= 1 (got {vals[i]} at position {i + 1})"
+    if args.all is not None and args.all < 0:
+        return "--all MAX must be non-negative"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def format_solution(
+    remainders: list[int],
+    moduli: list[int],
+    x: int,
+    N: int,
+    all_max: int | None,
+) -> str:
+    """Format CRT solution as a human-readable table.
+
+    Args:
+        remainders: Input residues (raw, before normalization).
+        moduli: Input moduli.
+        x: Unique solution in [0, N).
+        N: Period (lcm of moduli).
+        all_max: If not None, list all solutions up to this bound.
+
+    Returns:
+        Formatted string.
+    """
+    lines = [
+        "Sunzi's Theorem",
+        "=" * 40,
+        "Congruences:",
+    ]
+    for a, n in zip(remainders, moduli):
+        lines.append(f"  x ≡ {a} (mod {n})")
+
+    lines += [
+        "",
+        f"Solution:  x ≡ {x} (mod {N})",
+        "",
+        "Verification:",
+    ]
+    for a, n in zip(remainders, moduli):
+        check = x % n
+        tick = "✓" if check == (a % n) else "✗"
+        lines.append(f"  {x} mod {n} = {check} {tick}")
+
+    if all_max is not None:
+        solutions = list(range(x, all_max + 1, N))
+        lines += [
+            "",
+            f"All solutions in [0, {all_max}]:",
+            "  " + ", ".join(str(s) for s in solutions),
+        ]
+
+    return "\n".join(lines)
+
+
+def format_json(
+    remainders: list[int],
+    moduli: list[int],
+    x: int,
+    N: int,
+    all_max: int | None,
+) -> str:
+    """Format CRT solution as JSON.
+
+    Args:
+        remainders: Input residues.
+        moduli: Input moduli.
+        x: Unique solution in [0, N).
+        N: Period.
+        all_max: If not None, include all solutions up to this bound.
+
+    Returns:
+        JSON string.
+    """
+    payload: dict = {
+        "solution": x,
+        "modulus": N,
+        "congruences": [
+            {
+                "remainder": a,
+                "modulus": n,
+                "check": x % n,
+                "valid": (x % n) == (a % n),
+            }
+            for a, n in zip(remainders, moduli)
+        ],
+    }
+    if all_max is not None:
+        payload["all_solutions"] = list(range(x, all_max + 1, N))
+    return json.dumps(payload, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the crt CLI.
+
+    Args:
+        argv: Argument list; uses sys.argv[1:] when None.
+
+    Returns:
+        Exit code: 0 on success, 2 on input error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    vals = args.solve
+    remainders = [vals[i] for i in range(0, len(vals), 2)]
+    moduli = [vals[i] for i in range(1, len(vals), 2)]
+
+    try:
+        x, N = crt(remainders, moduli)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(format_json(remainders, moduli, x, N, args.all))
+    else:
+        print(format_solution(remainders, moduli, x, N, args.all))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/gini.py
+++ b/src/utils/gini.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Command-line utility for the Gini coefficient and Lorenz curve.
+
+Computes inequality metrics from raw observations, weighted samples, or
+pre-aggregated population/income share pairs.  Pure Python — no external
+dependencies.
+
+Usage examples:
+  gini --data 1 2 3 4 5
+  gini --data 1 2 3 4 5 --lorenz --precision 4
+  gini --data 1 2 3 --weights 1 2 1 --correct
+  gini --groups 0.2 0.05 0.3 0.15 0.5 0.80
+  gini --data 1 2 3 --data 4 5 6 7 --data 2 2 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def _gini_trapezoid(values: list[float], weights: list[float]) -> float:
+    """Compute Gini via sorted Lorenz-trapezoid formula.
+
+    Args:
+        values: Non-negative observation values.
+        weights: Positive weights parallel to values; must sum to a positive number.
+
+    Returns:
+        Gini coefficient in [0, 1).
+    """
+    pairs = sorted(zip(values, weights), key=lambda t: t[0])
+    W = sum(w for _, w in pairs)
+    total = sum(x * w for x, w in pairs)
+    if total == 0.0:
+        return 0.0
+    prev_F = 0.0
+    prev_L = 0.0
+    area = 0.0
+    cum_w = 0.0
+    cum_xw = 0.0
+    for x, w in pairs:
+        cum_w += w
+        cum_xw += x * w
+        F = cum_w / W
+        L = cum_xw / total
+        area += (F - prev_F) * (L + prev_L) / 2.0
+        prev_F = F
+        prev_L = L
+    return 1.0 - 2.0 * area
+
+
+def gini_coefficient(
+    data: list[float],
+    weights: list[float] | None = None,
+    corrected: bool = False,
+) -> float:
+    """Compute the Gini coefficient for a dataset.
+
+    Args:
+        data: Non-negative observations.  Must not be empty; sum must be > 0.
+        weights: Optional positive weights parallel to data.  When None, each
+            observation receives equal weight.
+        corrected: If True, apply the n/(n−1) small-sample bias correction.
+
+    Returns:
+        Gini coefficient; 0 = perfect equality, approaching 1 = maximum inequality.
+
+    Raises:
+        ValueError: If data is empty, contains negative values, sums to zero,
+            or weights are invalid.
+    """
+    if not data:
+        raise ValueError("data must not be empty")
+    if any(x < 0 for x in data):
+        raise ValueError("data values must be non-negative")
+    n = len(data)
+    if weights is None:
+        w = [1.0] * n
+    else:
+        if len(weights) != n:
+            raise ValueError("weights length must match data length")
+        if any(ww <= 0 for ww in weights):
+            raise ValueError("weights must be positive")
+        w = list(weights)
+    if sum(x * ww for x, ww in zip(data, w)) == 0.0:
+        raise ValueError("sum of values must be positive")
+    g = _gini_trapezoid(data, w)
+    if corrected and n > 1:
+        g = g * n / (n - 1)
+    return g
+
+
+def lorenz_curve(
+    data: list[float],
+    weights: list[float] | None = None,
+) -> list[tuple[float, float]]:
+    """Compute Lorenz curve coordinates.
+
+    Args:
+        data: Non-negative observations.
+        weights: Optional positive weights parallel to data.
+
+    Returns:
+        List of (cumulative_population_share, cumulative_income_share) tuples,
+        starting at (0.0, 0.0) and ending at (1.0, 1.0).
+
+    Raises:
+        ValueError: If data is invalid or sum is zero.
+    """
+    if not data:
+        raise ValueError("data must not be empty")
+    if any(x < 0 for x in data):
+        raise ValueError("data values must be non-negative")
+    n = len(data)
+    if weights is None:
+        w = [1.0] * n
+    else:
+        if len(weights) != n:
+            raise ValueError("weights length must match data length")
+        if any(ww <= 0 for ww in weights):
+            raise ValueError("weights must be positive")
+        w = list(weights)
+    W = sum(w)
+    total = sum(x * ww for x, ww in zip(data, w))
+    if total == 0.0:
+        raise ValueError("sum of values must be positive for Lorenz curve")
+    pairs = sorted(zip(data, w), key=lambda t: t[0])
+    points: list[tuple[float, float]] = [(0.0, 0.0)]
+    cum_w = 0.0
+    cum_xw = 0.0
+    for x, ww in pairs:
+        cum_w += ww
+        cum_xw += x * ww
+        points.append((cum_w / W, cum_xw / total))
+    return points
+
+
+def relative_mad(
+    data: list[float],
+    weights: list[float] | None = None,
+) -> float:
+    """Compute the relative mean absolute difference (= 2 × Gini coefficient).
+
+    Args:
+        data: Non-negative observations.
+        weights: Optional positive weights.
+
+    Returns:
+        Relative mean absolute difference.
+
+    Raises:
+        ValueError: See gini_coefficient.
+    """
+    return 2.0 * gini_coefficient(data, weights=weights, corrected=False)
+
+
+def gini_grouped(groups: list[tuple[float, float]]) -> float:
+    """Compute the Gini coefficient from pre-aggregated (pop_share, inc_share) pairs.
+
+    Groups are sorted internally by per-capita income (inc_share / pop_share).
+
+    Args:
+        groups: List of (population_share, income_share) tuples.  Population
+            shares must be positive and sum to 1; income shares must be
+            non-negative and sum to 1.
+
+    Returns:
+        Gini coefficient computed via Lorenz trapezoid area.
+
+    Raises:
+        ValueError: If groups are empty, shares are invalid, or sums deviate from 1.
+    """
+    if not groups:
+        raise ValueError("groups must not be empty")
+    if any(p <= 0 for p, _ in groups):
+        raise ValueError("population shares must be positive")
+    if any(s < 0 for _, s in groups):
+        raise ValueError("income shares must be non-negative")
+    total_pop = sum(p for p, _ in groups)
+    total_inc = sum(s for _, s in groups)
+    if not math.isclose(total_pop, 1.0, rel_tol=1e-5, abs_tol=1e-5):
+        raise ValueError(f"population shares must sum to 1.0 (got {total_pop:.6f})")
+    if not math.isclose(total_inc, 1.0, rel_tol=1e-5, abs_tol=1e-5):
+        raise ValueError(f"income shares must sum to 1.0 (got {total_inc:.6f})")
+    # Sort groups by ascending per-capita income
+    sorted_groups = sorted(groups, key=lambda g: g[1] / g[0])
+    area = 0.0
+    prev_x = 0.0
+    prev_y = 0.0
+    cum_pop = 0.0
+    cum_inc = 0.0
+    for pop, inc in sorted_groups:
+        cum_pop += pop
+        cum_inc += inc
+        area += (cum_pop - prev_x) * (cum_inc + prev_y) / 2.0
+        prev_x = cum_pop
+        prev_y = cum_inc
+    return 1.0 - 2.0 * area
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Argument list; uses sys.argv[1:] when None.
+
+    Returns:
+        Parsed namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description="Gini coefficient and Lorenz curve calculator.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  gini --data 1 2 3 4 5
+  gini --data 1 2 3 4 5 --lorenz
+  gini --data 1 2 3 --weights 2 1 1 --correct
+  gini --groups 0.2 0.05 0.3 0.15 0.5 0.80
+  gini --data 10 30 50 --data 5 5 90 --data 30 35 35
+""",
+    )
+
+    parser.add_argument(
+        "--data",
+        type=float,
+        nargs="+",
+        action="append",
+        metavar="VALUE",
+        help="observed values (repeat flag for multiple datasets)",
+    )
+    parser.add_argument(
+        "--groups",
+        type=float,
+        nargs="+",
+        metavar="VALUE",
+        help="alternating population and income shares: POP INC POP INC ...",
+    )
+    parser.add_argument(
+        "--weights",
+        type=float,
+        nargs="+",
+        metavar="W",
+        help="positive weights parallel to --data (single dataset only)",
+    )
+    parser.add_argument(
+        "--lorenz",
+        action="store_true",
+        help="display Lorenz curve coordinates (single dataset only)",
+    )
+    parser.add_argument(
+        "--correct",
+        action="store_true",
+        help="apply n/(n−1) small-sample bias correction",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        choices=["table", "json"],
+        default="table",
+        help="output format: table (default) or json",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=6,
+        metavar="DIGITS",
+        help="decimal places for printed values (default: 6)",
+    )
+
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Validate parsed arguments.
+
+    Args:
+        args: Parsed namespace from parse_args.
+
+    Returns:
+        Error message if invalid; None if all arguments are valid.
+    """
+    if args.precision < 0:
+        return "--precision must be non-negative"
+
+    has_data = bool(args.data)
+    has_groups = args.groups is not None
+
+    if not has_data and not has_groups:
+        return "one of --data or --groups is required"
+    if has_data and has_groups:
+        return "--data and --groups are mutually exclusive"
+
+    if has_groups:
+        if len(args.groups) < 2 or len(args.groups) % 2 != 0:
+            return "--groups requires an even number of values (POP INC pairs)"
+
+    if has_data:
+        n_datasets = len(args.data)
+        if args.weights is not None:
+            if n_datasets > 1:
+                return "--weights is only supported with a single --data group"
+            if len(args.weights) != len(args.data[0]):
+                return "--weights length must match --data length"
+            if any(w <= 0 for w in args.weights):
+                return "--weights values must be positive"
+        if n_datasets > 1 and args.lorenz:
+            return "--lorenz is only supported with a single dataset"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(x: float, p: int) -> str:
+    return f"{x:.{p}f}"
+
+
+def format_single(
+    n: int,
+    mean: float,
+    gini: float,
+    rmad: float,
+    corrected: float | None,
+    precision: int,
+) -> str:
+    """Format point-estimate output for a single dataset.
+
+    Args:
+        n: Number of observations.
+        mean: Arithmetic mean (or weighted mean).
+        gini: Gini coefficient.
+        rmad: Relative mean absolute difference.
+        corrected: Bias-corrected Gini, or None if not requested.
+        precision: Decimal places.
+
+    Returns:
+        Formatted string.
+    """
+    p = precision
+    lines = [
+        "Gini Coefficient Analysis",
+        "=" * 40,
+        f"Observations:           {n}",
+        f"Mean:                   {_fmt(mean, p)}",
+        f"Gini coefficient:       {_fmt(gini, p)}",
+    ]
+    if corrected is not None:
+        lines.append(f"Corrected Gini (n/n-1): {_fmt(corrected, p)}")
+    lines.append(f"Rel. mean abs. diff.:   {_fmt(rmad, p)}")
+    return "\n".join(lines)
+
+
+def format_lorenz(
+    points: list[tuple[float, float]],
+    gini: float,
+    precision: int,
+) -> str:
+    """Format Lorenz curve coordinates as a table.
+
+    Args:
+        points: List of (pop_share, inc_share) from lorenz_curve().
+        gini: Gini coefficient for the header.
+        precision: Decimal places.
+
+    Returns:
+        Formatted string with header and coordinate table.
+    """
+    p = precision
+    w = max(14, p + 8)
+    header = f"{'Population %':>{w}}  {'Income %':>{w}}"
+    sep = "-" * len(header)
+    rows = [f"{pop:{w}.{p}f}  {inc:{w}.{p}f}" for pop, inc in points]
+    lines = [
+        f"Lorenz Curve  (Gini = {_fmt(gini, p)})",
+        "=" * 40,
+        header,
+        sep,
+    ] + rows
+    return "\n".join(lines)
+
+
+def format_grouped(gini: float, n_groups: int, precision: int) -> str:
+    """Format output for grouped-data mode.
+
+    Args:
+        gini: Computed Gini coefficient.
+        n_groups: Number of input groups.
+        precision: Decimal places.
+
+    Returns:
+        Formatted string.
+    """
+    lines = [
+        "Gini Coefficient (Grouped Data)",
+        "=" * 40,
+        f"Groups:                 {n_groups}",
+        f"Gini coefficient:       {_fmt(gini, precision)}",
+        f"Rel. mean abs. diff.:   {_fmt(2.0 * gini, precision)}",
+    ]
+    return "\n".join(lines)
+
+
+def format_comparison(
+    results: list[dict[str, float | int]],
+    corrected: bool,
+    precision: int,
+) -> str:
+    """Format a multi-dataset comparison table ranked by Gini.
+
+    Args:
+        results: List of dicts with keys 'index', 'n', 'mean', 'gini',
+            'corrected', 'rank'.
+        corrected: Whether to include the corrected Gini column.
+        precision: Decimal places.
+
+    Returns:
+        Formatted comparison table string.
+    """
+    p = precision
+    w = max(12, p + 6)
+    if corrected:
+        header = (
+            f"{'Dataset':>10}  {'N':>6}  {'Mean':>{w}}  "
+            f"{'Gini':>{w}}  {'Corrected':>{w}}  {'Rank':>6}"
+        )
+    else:
+        header = f"{'Dataset':>10}  {'N':>6}  {'Mean':>{w}}  {'Gini':>{w}}  {'Rank':>6}"
+    sep = "-" * len(header)
+    rows = []
+    for r in results:
+        if corrected:
+            rows.append(
+                f"{r['index']:>10}  {r['n']:>6}  {r['mean']:{w}.{p}f}  "
+                f"{r['gini']:{w}.{p}f}  {r['corrected']:{w}.{p}f}  {r['rank']:>6}"
+            )
+        else:
+            rows.append(
+                f"{r['index']:>10}  {r['n']:>6}  {r['mean']:{w}.{p}f}  "
+                f"{r['gini']:{w}.{p}f}  {r['rank']:>6}"
+            )
+    lines = ["Dataset Comparison", "=" * 40, header, sep] + rows
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _weighted_mean(data: list[float], weights: list[float]) -> float:
+    W = sum(weights)
+    return sum(x * w for x, w in zip(data, weights)) / W
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the gini CLI.
+
+    Args:
+        argv: Argument list; uses sys.argv[1:] when None.
+
+    Returns:
+        Exit code: 0 on success, 2 on input error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    p = args.precision
+    fmt = args.format
+
+    # ---- grouped-data mode ----
+    if args.groups is not None:
+        vals = args.groups
+        groups = [(vals[i], vals[i + 1]) for i in range(0, len(vals), 2)]
+        try:
+            g = gini_grouped(groups)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+        if fmt == "json":
+            print(
+                json.dumps(
+                    {
+                        "mode": "grouped",
+                        "n_groups": len(groups),
+                        "gini": round(g, p + 4),
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(format_grouped(g, len(groups), p))
+        return 0
+
+    # ---- raw data mode ----
+    datasets: list[list[float]] = args.data
+    weights = args.weights
+
+    # Single dataset
+    if len(datasets) == 1:
+        data = datasets[0]
+        w = weights
+        try:
+            g = gini_coefficient(data, weights=w, corrected=False)
+            rmad = relative_mad(data, weights=w)
+            g_corr: float | None = None
+            if args.correct:
+                g_corr = gini_coefficient(data, weights=w, corrected=True)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+
+        if args.lorenz:
+            try:
+                points = lorenz_curve(data, weights=w)
+            except ValueError as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                return 2
+            if fmt == "json":
+                payload: dict = {
+                    "mode": "lorenz",
+                    "n": len(data),
+                    "gini": round(g, p + 4),
+                    "lorenz_curve": [
+                        [round(x, p + 4), round(y, p + 4)] for x, y in points
+                    ],
+                }
+                if g_corr is not None:
+                    payload["corrected_gini"] = round(g_corr, p + 4)
+                print(json.dumps(payload, indent=2))
+            else:
+                print(format_lorenz(points, g, p))
+            return 0
+
+        ew = w if w is not None else [1.0] * len(data)
+        mean = _weighted_mean(data, ew)
+        if fmt == "json":
+            payload = {
+                "mode": "single",
+                "n": len(data),
+                "mean": round(mean, p + 4),
+                "gini": round(g, p + 4),
+                "relative_mad": round(rmad, p + 4),
+            }
+            if g_corr is not None:
+                payload["corrected_gini"] = round(g_corr, p + 4)
+            print(json.dumps(payload, indent=2))
+        else:
+            print(format_single(len(data), mean, g, rmad, g_corr, p))
+        return 0
+
+    # Multiple datasets — comparison mode
+    try:
+        results = []
+        for i, data in enumerate(datasets, start=1):
+            g = gini_coefficient(data, corrected=False)
+            g_corr = gini_coefficient(data, corrected=True)
+            ew = [1.0] * len(data)
+            mean = _weighted_mean(data, ew)
+            results.append(
+                {
+                    "index": i,
+                    "n": len(data),
+                    "mean": mean,
+                    "gini": g,
+                    "corrected": g_corr,
+                }
+            )
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    # Assign ranks (1 = most equal)
+    ranked = sorted(results, key=lambda r: r["gini"])
+    for rank, r in enumerate(ranked, start=1):
+        r["rank"] = rank
+
+    if fmt == "json":
+        payload = {
+            "mode": "compare",
+            "datasets": [
+                {
+                    "index": r["index"],
+                    "n": r["n"],
+                    "mean": round(r["mean"], p + 4),
+                    "gini": round(r["gini"], p + 4),
+                    "corrected_gini": round(r["corrected"], p + 4),
+                    "rank": r["rank"],
+                }
+                for r in results
+            ],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(format_comparison(results, args.correct, p))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_crt.py
+++ b/tests/test_crt.py
@@ -1,0 +1,340 @@
+"""Tests for Sunzi's Theorem (CRT) utility."""
+
+import argparse
+import json
+
+import pytest
+
+import src.utils.crt as crt_module
+from src.utils.crt import (
+    crt,
+    extended_gcd,
+    format_json,
+    format_solution,
+    main,
+    mod_inverse,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# extended_gcd
+# ---------------------------------------------------------------------------
+
+
+def test_extended_gcd_basic():
+    g, s, t = extended_gcd(3, 5)
+    assert g == 1
+    assert 3 * s + 5 * t == 1
+
+
+def test_extended_gcd_gcd_twelve_eight():
+    g, s, t = extended_gcd(12, 8)
+    assert g == 4
+    assert 12 * s + 8 * t == 4
+
+
+def test_extended_gcd_zero_b():
+    g, s, t = extended_gcd(7, 0)
+    assert g == 7
+    assert s == 1
+    assert t == 0
+
+
+def test_extended_gcd_both_equal():
+    g, s, t = extended_gcd(5, 5)
+    assert g == 5
+    assert 5 * s + 5 * t == 5
+
+
+def test_extended_gcd_identity():
+    for a, b in [(35, 15), (100, 37), (13, 5)]:
+        g, s, t = extended_gcd(a, b)
+        assert a * s + b * t == g
+
+
+# ---------------------------------------------------------------------------
+# mod_inverse
+# ---------------------------------------------------------------------------
+
+
+def test_mod_inverse_basic():
+    assert mod_inverse(3, 7) == 5  # 3*5 = 15 ≡ 1 (mod 7)
+
+
+def test_mod_inverse_result_in_range():
+    x = mod_inverse(4, 9)
+    assert 0 <= x < 9
+    assert (4 * x) % 9 == 1
+
+
+def test_mod_inverse_no_inverse_raises():
+    with pytest.raises(ValueError, match="no inverse"):
+        mod_inverse(4, 6)  # gcd(4,6) = 2 ≠ 1
+
+
+def test_mod_inverse_modulus_too_small_raises():
+    with pytest.raises(ValueError, match="at least 2"):
+        mod_inverse(3, 1)
+
+
+def test_mod_inverse_modulus_zero_raises():
+    with pytest.raises(ValueError, match="at least 2"):
+        mod_inverse(3, 0)
+
+
+# ---------------------------------------------------------------------------
+# crt
+# ---------------------------------------------------------------------------
+
+
+def test_crt_sunzi_classic():
+    # x≡2(3), x≡3(5), x≡2(7) → 23 (mod 105)
+    x, N = crt([2, 3, 2], [3, 5, 7])
+    assert x == 23
+    assert N == 105
+
+
+def test_crt_single_congruence():
+    x, N = crt([3], [7])
+    assert x == 3
+    assert N == 7
+
+
+def test_crt_solution_satisfies_all():
+    remainders = [2, 3, 2]
+    moduli = [3, 5, 7]
+    x, N = crt(remainders, moduli)
+    for a, n in zip(remainders, moduli):
+        assert x % n == a % n
+
+
+def test_crt_negative_remainder_normalized():
+    x, N = crt([-1, 0], [3, 5])
+    assert x % 3 == 2  # -1 mod 3 = 2
+    assert x % 5 == 0
+
+
+def test_crt_large_remainders_normalized():
+    x, N = crt([11, 13], [3, 5])
+    assert x % 3 == 11 % 3
+    assert x % 5 == 13 % 5
+
+
+def test_crt_non_coprime_compatible():
+    # x≡0(4), x≡3(6) → gcd(4,6)=2; (3-0)%2=1 ≠ 0 → inconsistent
+    # x≡0(4), x≡2(6) → gcd(4,6)=2; (2-0)%2=0 ✓ → solution exists
+    x, N = crt([0, 2], [4, 6])
+    assert x % 4 == 0
+    assert x % 6 == 2
+
+
+def test_crt_non_coprime_inconsistent_raises():
+    with pytest.raises(ValueError, match="inconsistent"):
+        crt([0, 3], [4, 6])
+
+
+def test_crt_length_mismatch_raises():
+    with pytest.raises(ValueError, match="same length"):
+        crt([1, 2], [3])
+
+
+def test_crt_empty_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        crt([], [])
+
+
+def test_crt_modulus_zero_raises():
+    with pytest.raises(ValueError, match=">= 1"):
+        crt([1, 2], [3, 0])
+
+
+def test_crt_modulus_negative_raises():
+    with pytest.raises(ValueError, match=">= 1"):
+        crt([1, 2], [3, -2])
+
+
+def test_crt_result_in_range():
+    x, N = crt([2, 3, 2], [3, 5, 7])
+    assert 0 <= x < N
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_no_solve():
+    args = argparse.Namespace(solve=None, all=None, format="table")
+    assert "--solve" in validate(args)
+
+
+def test_validate_single_value():
+    args = argparse.Namespace(solve=[3], all=None, format="table")
+    assert "pair" in validate(args)
+
+
+def test_validate_odd_values():
+    args = argparse.Namespace(solve=[2, 3, 4], all=None, format="table")
+    assert "even" in validate(args)
+
+
+def test_validate_modulus_zero():
+    # Moduli are at odd indices; index 1 is the first modulus
+    args = argparse.Namespace(solve=[2, 0, 3, 5], all=None, format="table")
+    assert ">= 1" in validate(args)
+
+
+def test_validate_modulus_negative():
+    args = argparse.Namespace(solve=[2, 3, 1, -5], all=None, format="table")
+    assert ">= 1" in validate(args)
+
+
+def test_validate_all_negative():
+    args = argparse.Namespace(solve=[2, 3, 3, 5], all=-1, format="table")
+    assert "--all" in validate(args)
+
+
+def test_validate_valid():
+    args = argparse.Namespace(solve=[2, 3, 3, 5, 2, 7], all=None, format="table")
+    assert validate(args) is None
+
+
+def test_validate_valid_with_all():
+    args = argparse.Namespace(solve=[2, 3, 3, 5], all=100, format="table")
+    assert validate(args) is None
+
+
+# ---------------------------------------------------------------------------
+# format_solution
+# ---------------------------------------------------------------------------
+
+
+def test_format_solution_contains_congruences():
+    out = format_solution([2, 3, 2], [3, 5, 7], 23, 105, None)
+    assert "x ≡ 2 (mod 3)" in out
+    assert "x ≡ 3 (mod 5)" in out
+    assert "x ≡ 2 (mod 7)" in out
+
+
+def test_format_solution_shows_result():
+    out = format_solution([2, 3, 2], [3, 5, 7], 23, 105, None)
+    assert "23" in out
+    assert "105" in out
+
+
+def test_format_solution_verification_marks():
+    out = format_solution([2, 3, 2], [3, 5, 7], 23, 105, None)
+    assert "✓" in out
+
+
+def test_format_solution_with_all():
+    out = format_solution([2, 3], [3, 5], 2, 15, 50)
+    assert "All solutions" in out
+    assert "2" in out
+    assert "17" in out
+    assert "32" in out
+    assert "47" in out
+
+
+def test_format_solution_no_all():
+    out = format_solution([2, 3], [3, 5], 2, 15, None)
+    assert "All solutions" not in out
+
+
+# ---------------------------------------------------------------------------
+# format_json
+# ---------------------------------------------------------------------------
+
+
+def test_format_json_basic():
+    out = format_json([2, 3, 2], [3, 5, 7], 23, 105, None)
+    data = json.loads(out)
+    assert data["solution"] == 23
+    assert data["modulus"] == 105
+    assert len(data["congruences"]) == 3
+    assert all(c["valid"] for c in data["congruences"])
+
+
+def test_format_json_with_all():
+    out = format_json([2, 3], [3, 5], 2, 15, 50)
+    data = json.loads(out)
+    assert "all_solutions" in data
+    assert 2 in data["all_solutions"]
+    assert 17 in data["all_solutions"]
+
+
+def test_format_json_no_all():
+    out = format_json([2, 3, 2], [3, 5, 7], 23, 105, None)
+    data = json.loads(out)
+    assert "all_solutions" not in data
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_no_args_returns_2(capsys):
+    assert main([]) == 2
+
+
+def test_main_odd_values_returns_2(capsys):
+    assert main(["--solve", "2", "3", "4"]) == 2
+
+
+def test_main_bad_modulus_returns_2(capsys):
+    assert main(["--solve", "2", "0"]) == 2
+
+
+def test_main_sunzi_table(capsys):
+    rc = main(["--solve", "2", "3", "3", "5", "2", "7"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "23" in out
+    assert "105" in out
+
+
+def test_main_sunzi_json(capsys):
+    rc = main(["--solve", "2", "3", "3", "5", "2", "7", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["solution"] == 23
+
+
+def test_main_with_all_table(capsys):
+    rc = main(["--solve", "2", "3", "3", "5", "--all", "100"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "All solutions" in out
+
+
+def test_main_with_all_json(capsys):
+    rc = main(["--solve", "2", "3", "3", "5", "--all", "50", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert "all_solutions" in data
+
+
+def test_main_all_negative_returns_2(capsys):
+    assert main(["--solve", "2", "3", "3", "5", "--all", "-1"]) == 2
+
+
+def test_main_inconsistent_system_returns_2(capsys):
+    # x≡0(4) and x≡3(6) are inconsistent
+    assert main(["--solve", "0", "4", "3", "6"]) == 2
+    err = capsys.readouterr().err
+    assert "Error" in err
+
+
+def test_main_crt_error_path(monkeypatch, capsys):
+    """Cover the ValueError branch in main when crt() raises."""
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("forced crt error")
+
+    monkeypatch.setattr(crt_module, "crt", raise_value_error)
+    assert main(["--solve", "2", "3", "3", "5"]) == 2
+    err = capsys.readouterr().err
+    assert "forced crt error" in err

--- a/tests/test_gini.py
+++ b/tests/test_gini.py
@@ -1,0 +1,672 @@
+"""Tests for Gini coefficient utility."""
+
+import argparse
+import json
+
+import pytest
+
+import src.utils.gini as gini_module
+from src.utils.gini import (
+    _gini_trapezoid,
+    _weighted_mean,
+    format_comparison,
+    format_grouped,
+    format_lorenz,
+    format_single,
+    gini_coefficient,
+    gini_grouped,
+    lorenz_curve,
+    main,
+    relative_mad,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# _gini_trapezoid
+# ---------------------------------------------------------------------------
+
+
+def test_gini_trapezoid_known():
+    vals = [1.0, 2.0, 3.0, 4.0, 5.0]
+    w = [1.0] * 5
+    assert _gini_trapezoid(vals, w) == pytest.approx(4 / 15, abs=1e-12)
+
+
+def test_gini_trapezoid_zero_total():
+    assert _gini_trapezoid([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# gini_coefficient
+# ---------------------------------------------------------------------------
+
+
+def test_gini_coefficient_known():
+    assert gini_coefficient([1, 2, 3, 4, 5]) == pytest.approx(4 / 15, abs=1e-12)
+
+
+def test_gini_coefficient_perfect_equality():
+    assert gini_coefficient([3.0, 3.0, 3.0]) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_gini_coefficient_max_inequality():
+    assert gini_coefficient([0.0, 0.0, 0.0, 1.0]) == pytest.approx(0.75, abs=1e-12)
+
+
+def test_gini_coefficient_corrected():
+    g = gini_coefficient([1, 2, 3, 4, 5], corrected=True)
+    assert g == pytest.approx(4 / 15 * 5 / 4, abs=1e-12)
+
+
+def test_gini_coefficient_corrected_n2():
+    g = gini_coefficient([1.0, 3.0], corrected=True)
+    g_raw = gini_coefficient([1.0, 3.0], corrected=False)
+    assert g == pytest.approx(g_raw * 2 / 1, abs=1e-12)
+
+
+def test_gini_coefficient_corrected_n1():
+    # n=1: correction skipped (n-1 = 0)
+    assert gini_coefficient([5.0], corrected=True) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_gini_coefficient_weighted():
+    # Equal data but unequal weights → non-zero Gini
+    g = gini_coefficient([1.0, 3.0], weights=[3.0, 1.0])
+    assert 0.0 < g < 1.0
+
+
+def test_gini_coefficient_empty_raises():
+    with pytest.raises(ValueError, match="empty"):
+        gini_coefficient([])
+
+
+def test_gini_coefficient_negative_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        gini_coefficient([-1.0, 2.0, 3.0])
+
+
+def test_gini_coefficient_all_zero_raises():
+    with pytest.raises(ValueError, match="positive"):
+        gini_coefficient([0.0, 0.0, 0.0])
+
+
+def test_gini_coefficient_weights_wrong_length():
+    with pytest.raises(ValueError, match="length"):
+        gini_coefficient([1.0, 2.0], weights=[1.0])
+
+
+def test_gini_coefficient_weights_nonpositive():
+    with pytest.raises(ValueError, match="positive"):
+        gini_coefficient([1.0, 2.0], weights=[0.0, 1.0])
+
+
+# ---------------------------------------------------------------------------
+# lorenz_curve
+# ---------------------------------------------------------------------------
+
+
+def test_lorenz_curve_starts_at_origin():
+    pts = lorenz_curve([1, 2, 3, 4, 5])
+    assert pts[0] == (0.0, 0.0)
+
+
+def test_lorenz_curve_ends_at_one():
+    pts = lorenz_curve([1, 2, 3, 4, 5])
+    assert pts[-1][0] == pytest.approx(1.0, abs=1e-12)
+    assert pts[-1][1] == pytest.approx(1.0, abs=1e-12)
+
+
+def test_lorenz_curve_length():
+    data = [1, 2, 3, 4, 5]
+    pts = lorenz_curve(data)
+    assert len(pts) == len(data) + 1
+
+
+def test_lorenz_curve_monotone():
+    pts = lorenz_curve([1, 2, 3, 4, 5])
+    pops = [p for p, _ in pts]
+    incs = [i for _, i in pts]
+    assert all(pops[j] <= pops[j + 1] for j in range(len(pops) - 1))
+    assert all(incs[j] <= incs[j + 1] for j in range(len(incs) - 1))
+
+
+def test_lorenz_curve_perfect_equality():
+    pts = lorenz_curve([3.0, 3.0, 3.0])
+    for pop, inc in pts[1:]:
+        assert pop == pytest.approx(inc, abs=1e-12)
+
+
+def test_lorenz_curve_weighted():
+    pts = lorenz_curve([1.0, 2.0], weights=[2.0, 1.0])
+    assert pts[0] == (0.0, 0.0)
+    assert len(pts) == 3
+
+
+def test_lorenz_curve_empty_raises():
+    with pytest.raises(ValueError, match="empty"):
+        lorenz_curve([])
+
+
+def test_lorenz_curve_negative_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        lorenz_curve([-1.0, 2.0])
+
+
+def test_lorenz_curve_all_zero_raises():
+    with pytest.raises(ValueError, match="positive"):
+        lorenz_curve([0.0, 0.0])
+
+
+def test_lorenz_curve_weights_wrong_length():
+    with pytest.raises(ValueError, match="length"):
+        lorenz_curve([1.0, 2.0], weights=[1.0])
+
+
+def test_lorenz_curve_weights_nonpositive():
+    with pytest.raises(ValueError, match="positive"):
+        lorenz_curve([1.0, 2.0], weights=[0.0, 1.0])
+
+
+# ---------------------------------------------------------------------------
+# relative_mad
+# ---------------------------------------------------------------------------
+
+
+def test_relative_mad_equals_two_times_gini():
+    data = [1.0, 2.0, 3.0, 4.0, 5.0]
+    assert relative_mad(data) == pytest.approx(2 * gini_coefficient(data), abs=1e-12)
+
+
+def test_relative_mad_weighted():
+    data = [1.0, 3.0]
+    w = [2.0, 1.0]
+    assert relative_mad(data, weights=w) == pytest.approx(
+        2 * gini_coefficient(data, weights=w), abs=1e-12
+    )
+
+
+# ---------------------------------------------------------------------------
+# gini_grouped
+# ---------------------------------------------------------------------------
+
+
+def test_gini_grouped_perfect_equality():
+    groups = [(1 / 3, 1 / 3), (1 / 3, 1 / 3), (1 / 3, 1 / 3)]
+    assert gini_grouped(groups) == pytest.approx(0.0, abs=1e-10)
+
+
+def test_gini_grouped_two_groups_known():
+    # Bottom 40% earns 10%, top 60% earns 90%
+    groups = [(0.4, 0.1), (0.6, 0.9)]
+    g = gini_grouped(groups)
+    assert 0.0 < g < 1.0
+
+
+def test_gini_grouped_sorted_by_per_capita():
+    # Same groups in different order should yield same result
+    groups_a = [(0.4, 0.1), (0.6, 0.9)]
+    groups_b = [(0.6, 0.9), (0.4, 0.1)]
+    assert gini_grouped(groups_a) == pytest.approx(gini_grouped(groups_b), abs=1e-12)
+
+
+def test_gini_grouped_empty_raises():
+    with pytest.raises(ValueError, match="empty"):
+        gini_grouped([])
+
+
+def test_gini_grouped_negative_pop_raises():
+    with pytest.raises(ValueError, match="positive"):
+        gini_grouped([(-0.1, 0.5), (1.1, 0.5)])
+
+
+def test_gini_grouped_negative_inc_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        gini_grouped([(0.5, -0.1), (0.5, 1.1)])
+
+
+def test_gini_grouped_pop_sum_not_one_raises():
+    with pytest.raises(ValueError, match="sum to 1"):
+        gini_grouped([(0.3, 0.5), (0.3, 0.5)])
+
+
+def test_gini_grouped_inc_sum_not_one_raises():
+    with pytest.raises(ValueError, match="sum to 1"):
+        gini_grouped([(0.5, 0.3), (0.5, 0.3)])
+
+
+# ---------------------------------------------------------------------------
+# _weighted_mean
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_mean_equal_weights():
+    assert _weighted_mean([1.0, 2.0, 3.0], [1.0, 1.0, 1.0]) == pytest.approx(2.0)
+
+
+def test_weighted_mean_unequal_weights():
+    # Mean of [1, 3] with weights [3, 1] = (3+3)/4 = 1.5
+    assert _weighted_mean([1.0, 3.0], [3.0, 1.0]) == pytest.approx(1.5)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_no_mode():
+    args = argparse.Namespace(
+        data=None,
+        groups=None,
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "required" in validate(args)
+
+
+def test_validate_negative_precision():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0]],
+        groups=None,
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=-1,
+        format="table",
+    )
+    assert "--precision" in validate(args)
+
+
+def test_validate_data_and_groups_exclusive():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0]],
+        groups=[0.5, 0.5, 0.5, 0.5],
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "mutually exclusive" in validate(args)
+
+
+def test_validate_groups_odd_count():
+    args = argparse.Namespace(
+        data=None,
+        groups=[0.5, 0.5, 0.5],
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "--groups" in validate(args)
+
+
+def test_validate_groups_single_value():
+    args = argparse.Namespace(
+        data=None,
+        groups=[0.5],
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "--groups" in validate(args)
+
+
+def test_validate_weights_multi_dataset():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0], [3.0, 4.0]],
+        groups=None,
+        weights=[1.0, 1.0],
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "--weights" in validate(args)
+
+
+def test_validate_weights_wrong_length():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0, 3.0]],
+        groups=None,
+        weights=[1.0, 1.0],
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "--weights" in validate(args)
+
+
+def test_validate_weights_nonpositive():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0]],
+        groups=None,
+        weights=[0.0, 1.0],
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "--weights" in validate(args)
+
+
+def test_validate_lorenz_multi_dataset():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0], [3.0, 4.0]],
+        groups=None,
+        weights=None,
+        lorenz=True,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert "--lorenz" in validate(args)
+
+
+def test_validate_valid_single_data():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0, 3.0]],
+        groups=None,
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+def test_validate_valid_groups():
+    args = argparse.Namespace(
+        data=None,
+        groups=[0.5, 0.3, 0.5, 0.7],
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+def test_validate_valid_multi_data():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0], [3.0, 4.0]],
+        groups=None,
+        weights=None,
+        lorenz=False,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+def test_validate_valid_data_with_weights():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0, 3.0]],
+        groups=None,
+        weights=[1.0, 2.0, 1.0],
+        lorenz=False,
+        correct=True,
+        precision=6,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+def test_validate_valid_lorenz_single():
+    args = argparse.Namespace(
+        data=[[1.0, 2.0, 3.0]],
+        groups=None,
+        weights=None,
+        lorenz=True,
+        correct=False,
+        precision=6,
+        format="table",
+    )
+    assert validate(args) is None
+
+
+# ---------------------------------------------------------------------------
+# format_single
+# ---------------------------------------------------------------------------
+
+
+def test_format_single_no_corrected():
+    out = format_single(5, 3.0, 0.2667, 0.5333, None, 4)
+    assert "0.2667" in out
+    assert "Corrected" not in out
+    assert "5" in out
+
+
+def test_format_single_with_corrected():
+    out = format_single(5, 3.0, 0.2667, 0.5333, 0.3333, 4)
+    assert "0.3333" in out
+    assert "Corrected" in out
+
+
+# ---------------------------------------------------------------------------
+# format_lorenz
+# ---------------------------------------------------------------------------
+
+
+def test_format_lorenz_contains_header():
+    points = [(0.0, 0.0), (0.5, 0.3), (1.0, 1.0)]
+    out = format_lorenz(points, 0.2667, 4)
+    assert "Population" in out
+    assert "Income" in out
+    assert "0.2667" in out
+
+
+def test_format_lorenz_contains_rows():
+    points = [(0.0, 0.0), (1.0, 1.0)]
+    out = format_lorenz(points, 0.0, 4)
+    assert "0.0000" in out
+    assert "1.0000" in out
+
+
+# ---------------------------------------------------------------------------
+# format_grouped
+# ---------------------------------------------------------------------------
+
+
+def test_format_grouped_contains_gini():
+    out = format_grouped(0.3333, 3, 4)
+    assert "0.3333" in out
+    assert "3" in out
+
+
+def test_format_grouped_contains_rmad():
+    out = format_grouped(0.25, 2, 4)
+    rmad = 2 * 0.25
+    assert f"{rmad:.4f}" in out
+
+
+# ---------------------------------------------------------------------------
+# format_comparison
+# ---------------------------------------------------------------------------
+
+
+def test_format_comparison_no_corrected():
+    results = [
+        {"index": 1, "n": 5, "mean": 3.0, "gini": 0.27, "corrected": 0.33, "rank": 1},
+        {"index": 2, "n": 4, "mean": 2.5, "gini": 0.35, "corrected": 0.47, "rank": 2},
+    ]
+    out = format_comparison(results, corrected=False, precision=4)
+    assert "Gini" in out
+    assert "Corrected" not in out
+    assert "0.2700" in out
+
+
+def test_format_comparison_with_corrected():
+    results = [
+        {"index": 1, "n": 5, "mean": 3.0, "gini": 0.27, "corrected": 0.33, "rank": 1},
+    ]
+    out = format_comparison(results, corrected=True, precision=4)
+    assert "Corrected" in out
+    assert "0.3300" in out
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_no_args_returns_2(capsys):
+    assert main([]) == 2
+
+
+def test_main_negative_precision_returns_2(capsys):
+    assert main(["--data", "1", "2", "3", "--precision", "-1"]) == 2
+
+
+def test_main_single_data_table(capsys):
+    rc = main(["--data", "1", "2", "3", "4", "5", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0.2667" in out
+
+
+def test_main_single_data_json(capsys):
+    rc = main(["--data", "1", "2", "3", "4", "5", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "single"
+    assert abs(data["gini"] - 4 / 15) < 1e-4
+
+
+def test_main_single_data_json_with_correct(capsys):
+    rc = main(["--data", "1", "2", "3", "4", "5", "--format", "json", "--correct"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert "corrected_gini" in data
+
+
+def test_main_single_data_lorenz_table(capsys):
+    rc = main(["--data", "1", "2", "3", "4", "5", "--lorenz", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Population" in out
+
+
+def test_main_single_data_lorenz_json(capsys):
+    rc = main(["--data", "1", "2", "3", "--lorenz", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "lorenz"
+    assert "lorenz_curve" in data
+
+
+def test_main_single_data_lorenz_json_with_correct(capsys):
+    rc = main(["--data", "1", "2", "3", "--lorenz", "--format", "json", "--correct"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert "corrected_gini" in data
+
+
+def test_main_single_data_with_weights(capsys):
+    rc = main(["--data", "1", "2", "3", "--weights", "2", "1", "1", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Gini" in out
+
+
+def test_main_single_data_with_correct(capsys):
+    rc = main(["--data", "1", "2", "3", "4", "5", "--correct", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Corrected" in out
+
+
+def test_main_groups_table(capsys):
+    rc = main(
+        ["--groups", "0.2", "0.05", "0.3", "0.15", "0.5", "0.80", "--precision", "4"]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Gini" in out
+
+
+def test_main_groups_json(capsys):
+    rc = main(["--groups", "0.4", "0.1", "0.6", "0.9", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "grouped"
+    assert "gini" in data
+
+
+def test_main_groups_invalid_returns_2(capsys):
+    # Two groups but pop sums to 0.5 (not 1.0) → gini_grouped raises
+    assert main(["--groups", "0.2", "0.05", "0.3", "0.15"]) == 2
+
+
+def test_main_multi_data_table(capsys):
+    rc = main(["--data", "1", "2", "3", "--data", "4", "5", "6", "--precision", "4"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Dataset" in out
+
+
+def test_main_multi_data_json(capsys):
+    rc = main(["--data", "1", "2", "3", "--data", "4", "5", "6", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["mode"] == "compare"
+    assert len(data["datasets"]) == 2
+
+
+def test_main_multi_data_with_correct(capsys):
+    rc = main(
+        [
+            "--data",
+            "1",
+            "2",
+            "3",
+            "--data",
+            "4",
+            "5",
+            "6",
+            "--correct",
+            "--precision",
+            "4",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Corrected" in out
+
+
+def test_main_single_data_invalid_returns_2(capsys):
+    # Negative value passes validate but fails gini_coefficient
+    assert main(["--data", "-1", "2", "3"]) == 2
+
+
+def test_main_multi_data_invalid_returns_2(capsys):
+    # Negative in first dataset → ValueError in multi-dataset loop
+    assert main(["--data", "-1", "2", "3", "--data", "4", "5", "6"]) == 2
+
+
+def test_main_lorenz_error_path(monkeypatch, capsys):
+    """Cover the lorenz_curve ValueError branch in main."""
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("forced lorenz error")
+
+    monkeypatch.setattr(gini_module, "lorenz_curve", raise_value_error)
+    assert main(["--data", "1", "2", "3", "--lorenz"]) == 2
+    err = capsys.readouterr().err
+    assert "forced lorenz error" in err

--- a/uv.lock
+++ b/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "pythodds"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- Adds `gini` CLI tool: Gini coefficient from raw data, weighted samples, and grouped population/income shares; Lorenz curve coordinates; relative mean absolute difference; multi-dataset comparison ranked by inequality
- Adds `crt` CLI tool: general Sunzi's Theorem solver handling coprime and non-coprime moduli; normalises negative remainders; optional enumeration of all solutions up to a bound

## Test plan
- [ ] `gini --data 1 2 3 4 5` → Gini ≈ 0.266667 (4/15)
- [ ] `gini --data 1 2 3 4 5 --correct` → Corrected Gini ≈ 0.333333
- [ ] `gini --data 0 0 0 1` → Gini = 0.750000
- [ ] `gini --data 1 2 3 4 5 --lorenz` → Lorenz curve table
- [ ] `gini --data 1 2 3 --weights 2 1 1` → weighted Gini
- [ ] `gini --groups 0.2 0.05 0.3 0.15 0.5 0.80` → grouped Gini
- [ ] `gini --data 10 30 50 --data 5 5 90 --data 30 35 35` → comparison table
- [ ] `crt --solve 2 3 3 5 2 7` → x ≡ 23 (mod 105)
- [ ] `crt --solve 0 4 2 6` → non-coprime moduli, compatible solution
- [ ] `crt --solve 0 4 3 6` → inconsistent system error
- [ ] `crt --solve 2 3 3 5 2 7 --all 300` → lists solutions 23, 128, 233
- [ ] All 903 tests passing, 100% coverage

Closes #37
Closes #38