### PR TITLE
feat: add subnet mask calculator CLI tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ sigmoid = "src.utils.sigmoid:main"
 euler = "src.utils.euler:main"
 gini = "src.utils.gini:main"
 crt = "src.utils.crt:main"
+subnet = "src.utils.subnet:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/utils/subnet.py
+++ b/src/utils/subnet.py
@@ -114,8 +114,8 @@ def compute_subnet(ip_str: str, cidr: int | None = None) -> SubnetResult:
         first_ip=first_ip,
         last_ip=last_ip,
         subnet_mask=subnet_mask,
-        hosts=hosts,
         networks=networks,
+        hosts=hosts,
     )
 
 
@@ -168,13 +168,13 @@ def format_table(result: SubnetResult) -> str:
         "Subnet Information",
         "=" * 40,
         f"{'Input:':<{w}} {result.input_address}/{result.cidr}",
+        f"{'Subnet mask:':<{w}} {result.subnet_mask}\n",
         f"{'Network:':<{w}} {result.network_address}",
         f"{'Broadcast:':<{w}} {result.broadcast_address}",
         f"{'First IP:':<{w}} {result.first_ip}",
-        f"{'Last IP:':<{w}} {result.last_ip}",
-        f"{'Subnet mask:':<{w}} {result.subnet_mask}",
-        f"{'Hosts:':<{w}} {result.hosts:,}",
+        f"{'Last IP:':<{w}} {result.last_ip}\n",
         f"{'Networks:':<{w}} {result.networks:,}",
+        f"{'Hosts:':<{w}} {result.hosts:,}",
     ]
     return "\n".join(lines)
 

--- a/src/utils/subnet.py
+++ b/src/utils/subnet.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Command-line utility for subnet mask calculations.
+
+Given an IPv4 address with optional CIDR prefix length, computes the network
+address, broadcast address, first and last usable IP, subnet mask, usable
+host count, and number of classful networks.
+
+Usage examples:
+  subnet 192.168.1.50/24
+  subnet 10.0.0.1 --cidr 8
+  subnet 172.16.5.100/20
+  subnet 192.168.1.50/24 --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import sys
+from typing import NamedTuple
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+class SubnetResult(NamedTuple):
+    input_address: str
+    cidr: int
+    network_address: str
+    broadcast_address: str
+    first_ip: str
+    last_ip: str
+    subnet_mask: str
+    hosts: int
+    networks: int
+
+
+def _classful_prefix(ip: ipaddress.IPv4Address) -> int:
+    """Return classful prefix length: 8 (Class A), 16 (Class B), 24 (Class C/D/E)."""
+    first_octet = int(ip) >> 24
+    if first_octet < 128:
+        return 8
+    if first_octet < 192:
+        return 16
+    return 24
+
+
+def compute_subnet(ip_str: str, cidr: int | None = None) -> SubnetResult:
+    """Compute subnet information for a given IPv4 address and prefix length.
+
+    Args:
+        ip_str: IPv4 address, optionally with CIDR notation (e.g. "192.168.1.50/24").
+        cidr: Prefix length override (0–32); supersedes any CIDR embedded in ip_str.
+
+    Returns:
+        SubnetResult with all computed fields.
+
+    Raises:
+        ValueError: If the address or prefix length is invalid.
+    """
+    if "/" in ip_str:
+        raw_ip, suffix = ip_str.split("/", 1)
+        try:
+            embedded_cidr: int | None = int(suffix)
+        except ValueError:
+            raise ValueError(f"invalid CIDR prefix: {suffix!r}")
+    else:
+        raw_ip = ip_str
+        embedded_cidr = None
+
+    try:
+        ip = ipaddress.IPv4Address(raw_ip)
+    except ipaddress.AddressValueError as exc:
+        raise ValueError(f"invalid IPv4 address: {raw_ip!r}") from exc
+
+    prefix = (
+        cidr
+        if cidr is not None
+        else (embedded_cidr if embedded_cidr is not None else 32)
+    )
+
+    if not 0 <= prefix <= 32:
+        raise ValueError(f"CIDR prefix must be 0–32, got {prefix}")
+
+    network = ipaddress.IPv4Network(f"{raw_ip}/{prefix}", strict=False)
+
+    subnet_mask = str(network.netmask)
+    network_addr = str(network.network_address)
+    broadcast_addr = str(network.broadcast_address)
+
+    if prefix == 32:
+        first_ip = last_ip = str(ip)
+        hosts = 1
+    elif prefix == 31:
+        # RFC 3021: both addresses usable on point-to-point links
+        first_ip = network_addr
+        last_ip = broadcast_addr
+        hosts = 2
+    else:
+        first_ip = str(network.network_address + 1)
+        last_ip = str(network.broadcast_address - 1)
+        hosts = network.num_addresses - 2
+
+    classful = _classful_prefix(network.network_address)
+    networks = 2 ** (prefix - classful) if prefix >= classful else 1
+
+    return SubnetResult(
+        input_address=str(ip),
+        cidr=prefix,
+        network_address=network_addr,
+        broadcast_address=broadcast_addr,
+        first_ip=first_ip,
+        last_ip=last_ip,
+        subnet_mask=subnet_mask,
+        hosts=hosts,
+        networks=networks,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Subnet mask calculator: network, broadcast, host range, mask, and counts.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  subnet 192.168.1.50/24
+  subnet 10.0.0.1 --cidr 8
+  subnet 172.16.5.100/20 --format json
+""",
+    )
+    parser.add_argument(
+        "address",
+        metavar="ADDRESS",
+        help="IPv4 address with optional CIDR notation (e.g. 192.168.1.50/24)",
+    )
+    parser.add_argument(
+        "--cidr",
+        "-c",
+        type=int,
+        metavar="PREFIX",
+        help="prefix length 0–32; overrides any CIDR embedded in ADDRESS (default: 32)",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        choices=["table", "json"],
+        default="table",
+        help="output format: table (default) or json",
+    )
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def format_table(result: SubnetResult) -> str:
+    w = 18
+    lines = [
+        "Subnet Information",
+        "=" * 40,
+        f"{'Input:':<{w}} {result.input_address}/{result.cidr}",
+        f"{'Network:':<{w}} {result.network_address}",
+        f"{'Broadcast:':<{w}} {result.broadcast_address}",
+        f"{'First IP:':<{w}} {result.first_ip}",
+        f"{'Last IP:':<{w}} {result.last_ip}",
+        f"{'Subnet mask:':<{w}} {result.subnet_mask}",
+        f"{'Hosts:':<{w}} {result.hosts:,}",
+        f"{'Networks:':<{w}} {result.networks:,}",
+    ]
+    return "\n".join(lines)
+
+
+def format_json(result: SubnetResult) -> str:
+    return json.dumps(
+        {
+            "input_address": result.input_address,
+            "cidr": result.cidr,
+            "network_address": result.network_address,
+            "broadcast_address": result.broadcast_address,
+            "first_ip": result.first_ip,
+            "last_ip": result.last_ip,
+            "subnet_mask": result.subnet_mask,
+            "hosts": result.hosts,
+            "networks": result.networks,
+        },
+        indent=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        result = compute_subnet(args.address, cidr=args.cidr)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(format_json(result))
+    else:
+        print(format_table(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_subnet.py
+++ b/tests/test_subnet.py
@@ -1,0 +1,241 @@
+"""Tests for subnet mask calculator utility."""
+
+import ipaddress
+import json
+
+import pytest
+
+from src.utils.subnet import (
+    _classful_prefix,
+    compute_subnet,
+    format_json,
+    format_table,
+    main,
+)
+
+# ---------------------------------------------------------------------------
+# _classful_prefix
+# ---------------------------------------------------------------------------
+
+
+def test_classful_prefix_class_a():
+    assert _classful_prefix(ipaddress.IPv4Address("10.0.0.1")) == 8
+
+
+def test_classful_prefix_class_a_boundary():
+    assert _classful_prefix(ipaddress.IPv4Address("0.0.0.1")) == 8
+    assert _classful_prefix(ipaddress.IPv4Address("127.255.255.255")) == 8
+
+
+def test_classful_prefix_class_b():
+    assert _classful_prefix(ipaddress.IPv4Address("172.16.0.1")) == 16
+
+
+def test_classful_prefix_class_b_boundary():
+    assert _classful_prefix(ipaddress.IPv4Address("128.0.0.1")) == 16
+    assert _classful_prefix(ipaddress.IPv4Address("191.255.255.255")) == 16
+
+
+def test_classful_prefix_class_c():
+    assert _classful_prefix(ipaddress.IPv4Address("192.168.1.1")) == 24
+    assert _classful_prefix(ipaddress.IPv4Address("192.0.0.1")) == 24
+
+
+# ---------------------------------------------------------------------------
+# compute_subnet — input parsing
+# ---------------------------------------------------------------------------
+
+
+def test_compute_subnet_cidr_embedded():
+    r = compute_subnet("192.168.1.50/24")
+    assert r.cidr == 24
+    assert r.input_address == "192.168.1.50"
+
+
+def test_compute_subnet_cidr_override_takes_precedence():
+    r = compute_subnet("192.168.1.50/24", cidr=25)
+    assert r.cidr == 25
+
+
+def test_compute_subnet_bare_ip_defaults_to_32():
+    r = compute_subnet("10.1.2.3")
+    assert r.cidr == 32
+
+
+def test_compute_subnet_bare_ip_with_cidr_arg():
+    r = compute_subnet("10.0.0.1", cidr=8)
+    assert r.cidr == 8
+
+
+# ---------------------------------------------------------------------------
+# compute_subnet — address fields
+# ---------------------------------------------------------------------------
+
+
+def test_compute_subnet_class_c_24():
+    r = compute_subnet("192.168.1.50/24")
+    assert r.network_address == "192.168.1.0"
+    assert r.broadcast_address == "192.168.1.255"
+    assert r.first_ip == "192.168.1.1"
+    assert r.last_ip == "192.168.1.254"
+    assert r.subnet_mask == "255.255.255.0"
+    assert r.hosts == 254
+    assert r.networks == 1
+
+
+def test_compute_subnet_class_a_8():
+    r = compute_subnet("10.0.0.0/8")
+    assert r.subnet_mask == "255.0.0.0"
+    assert r.hosts == 2**24 - 2
+    assert r.networks == 1
+
+
+def test_compute_subnet_class_b_16():
+    r = compute_subnet("172.16.0.0/16")
+    assert r.subnet_mask == "255.255.0.0"
+    assert r.hosts == 2**16 - 2
+    assert r.networks == 1
+
+
+def test_compute_subnet_prefix_32():
+    r = compute_subnet("192.168.1.1/32")
+    assert r.first_ip == "192.168.1.1"
+    assert r.last_ip == "192.168.1.1"
+    assert r.hosts == 1
+    assert r.network_address == "192.168.1.1"
+    assert r.broadcast_address == "192.168.1.1"
+
+
+def test_compute_subnet_prefix_31():
+    r = compute_subnet("10.0.0.0/31")
+    assert r.first_ip == "10.0.0.0"
+    assert r.last_ip == "10.0.0.1"
+    assert r.hosts == 2
+
+
+# ---------------------------------------------------------------------------
+# compute_subnet — network count
+# ---------------------------------------------------------------------------
+
+
+def test_networks_class_c_subnets():
+    # /26 from class C (/24): 2^(26-24) = 4 networks
+    r = compute_subnet("192.168.1.0/26")
+    assert r.networks == 4
+    assert r.hosts == 62
+
+
+def test_networks_class_b_subnets():
+    # /24 from class B (/16): 2^(24-16) = 256 networks
+    r = compute_subnet("172.16.0.0/24")
+    assert r.networks == 256
+
+
+def test_networks_supernet():
+    # /6 is smaller than class A /8 → 1 (supernet)
+    r = compute_subnet("10.0.0.0/6")
+    assert r.networks == 1
+
+
+def test_networks_class_b_supernet():
+    # /12 is smaller than class B /16 → 1
+    r = compute_subnet("172.16.0.0/12")
+    assert r.networks == 1
+
+
+# ---------------------------------------------------------------------------
+# compute_subnet — error handling
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_ip_address():
+    with pytest.raises(ValueError, match="invalid IPv4 address"):
+        compute_subnet("999.999.999.999/24")
+
+
+def test_invalid_embedded_cidr_non_numeric():
+    with pytest.raises(ValueError, match="invalid CIDR prefix"):
+        compute_subnet("192.168.1.1/abc")
+
+
+def test_cidr_too_large():
+    with pytest.raises(ValueError, match="CIDR prefix must be 0"):
+        compute_subnet("192.168.1.1", cidr=33)
+
+
+def test_cidr_negative():
+    with pytest.raises(ValueError, match="CIDR prefix must be 0"):
+        compute_subnet("192.168.1.1", cidr=-1)
+
+
+# ---------------------------------------------------------------------------
+# format_table
+# ---------------------------------------------------------------------------
+
+
+def test_format_table_contains_all_fields():
+    r = compute_subnet("192.168.1.50/24")
+    out = format_table(r)
+    assert "192.168.1.0" in out
+    assert "192.168.1.255" in out
+    assert "192.168.1.1" in out
+    assert "192.168.1.254" in out
+    assert "255.255.255.0" in out
+    assert "254" in out
+    assert "Subnet Information" in out
+
+
+# ---------------------------------------------------------------------------
+# format_json
+# ---------------------------------------------------------------------------
+
+
+def test_format_json_structure():
+    r = compute_subnet("192.168.1.50/24")
+    data = json.loads(format_json(r))
+    assert data["network_address"] == "192.168.1.0"
+    assert data["broadcast_address"] == "192.168.1.255"
+    assert data["first_ip"] == "192.168.1.1"
+    assert data["last_ip"] == "192.168.1.254"
+    assert data["subnet_mask"] == "255.255.255.0"
+    assert data["hosts"] == 254
+    assert data["cidr"] == 24
+    assert data["input_address"] == "192.168.1.50"
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_table_output(capsys):
+    rc = main(["192.168.1.50/24"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "192.168.1.0" in out
+
+
+def test_main_json_output(capsys):
+    rc = main(["192.168.1.50/24", "--format", "json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["network_address"] == "192.168.1.0"
+
+
+def test_main_cidr_flag(capsys):
+    rc = main(["10.0.0.1", "--cidr", "16"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "10.0.0.0" in out
+
+
+def test_main_invalid_address_returns_2(capsys):
+    rc = main(["not.valid/24"])
+    assert rc == 2
+    assert "Error" in capsys.readouterr().err
+
+
+def test_main_invalid_cidr_returns_2(capsys):
+    rc = main(["192.168.1.1", "--cidr", "99"])
+    assert rc == 2
+    assert "Error" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Adds `subnet` CLI command backed by Python `ipaddress` stdlib (no external deps)
- Accepts `ADDRESS[/CIDR]` positional arg or separate `--cidr PREFIX` flag; defaults to `/32`
- Outputs: network address, broadcast address, first/last usable IP, subnet mask, host count, classful network count
- Supports `--format table` (default) and `--format json`

## Test plan

- [ ] `subnet 192.168.1.50/24` → correct network/broadcast/range/mask
- [ ] `subnet 10.0.0.1 --cidr 8` → class A output
- [ ] `subnet 192.168.1.1/32` → single-host route
- [ ] `subnet 10.0.0.0/31` → RFC 3021 point-to-point (both addresses usable)
- [ ] `subnet 192.168.1.0/26` → 4 classful networks, 62 hosts
- [ ] `subnet 172.16.0.0/24 --format json` → JSON output
- [ ] Invalid IP and out-of-range CIDR return exit code 2
- [ ] 29 tests, 100% coverage; full suite (1053 tests) passes

Closes #44