### PR TITLE
feat: add geometric, chisq, and anova CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Subnet Mask Calculator** | Compute network address, broadcast address, first/last usable IP, subnet mask, host count, and classful network count from an IPv4 address and CIDR prefix |
 | **Geometric Distribution** | Compute PMF, CDF, survival, mean, and variance for the number of trials until the first success; supports single-k reports and full probability tables |
 | **Chi-Square Tests** | Goodness-of-fit and independence (contingency table) chi-square tests via the exact regularised incomplete gamma function; per-cell contributions for residual diagnostics |
-| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, and `chisq` commands |
+| **One-Way ANOVA** | Test whether the means of three or more independent groups are equal; F-statistic via the regularised incomplete beta function, with Tukey HSD or Bonferroni-corrected pairwise post-hoc comparisons |
+| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, `chisq`, and `anova` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
 
@@ -95,6 +96,7 @@ pip install -e .
 | `subnet` | Network address, broadcast, first/last usable IP, subnet mask, host count, and classful network count from an IPv4 CIDR block |
 | `geometric` | PMF, CDF, survival, mean, and variance for the geometric distribution (trials until first success) |
 | `chisq` | Chi-square goodness-of-fit and independence tests with per-cell contributions |
+| `anova` | One-way ANOVA F-test with optional Tukey HSD or Bonferroni-corrected pairwise post-hoc comparisons |
 | `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
 
 ---
@@ -1521,6 +1523,42 @@ chisq --test gof --observed 52,48 --expected 50,50 --alpha 0.10
 ---
 
 <details>
+<summary><strong><code>anova</code></strong> — One-Way Analysis of Variance</summary>
+
+Tests whether the means of three or more independent groups are equal — the natural generalization of the two-sample t-test to multiple groups. The F-distribution CDF (and the pairwise t-tests used by the Bonferroni post-hoc) are computed via the regularised incomplete beta function. Tukey HSD uses the studentized range distribution, computed via nested numerical integration (Simpson's rule over the normal and scaled chi densities) — pure Python, no external dependencies. Accepts inline comma-separated groups or a CSV file with group/value columns.
+
+```bash
+# One-way ANOVA across three treatment groups
+anova --data "12.1,11.8,12.5,11.9" "9.8,10.3,10.1,9.7" "15.2,14.9,15.5,16.0"
+
+# With Tukey HSD post-hoc comparisons
+anova --data "12.1,11.8,12.5" "9.8,10.3,10.1" "15.2,14.9,15.5" --posthoc tukey
+
+# With Bonferroni-corrected post-hoc comparisons
+anova --data "12.1,11.8,12.5" "9.8,10.3,10.1" "15.2,14.9,15.5" --posthoc bonferroni
+
+# From CSV with group and value columns
+anova --file experiment.csv --group-col treatment --value-col response --alpha 0.01
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| | `--data GROUP [GROUP ...]` | One comma-separated list of values per group (2 or more groups) |
+| | `--file CSV` | Path to a CSV file (use with `--group-col` and `--value-col`) |
+| | `--group-col COL` | CSV column name holding the group label |
+| | `--value-col COL` | CSV column name holding the numeric observation |
+| `-a` | `--alpha` | Significance level (default: 0.05) |
+| | `--posthoc {tukey,bonferroni,none}` | Post-hoc pairwise comparison method (default: none) |
+| | `--format {table,json}` | Output format (default: table) |
+| `-P` | `--precision` | Decimal places for table output (default: 4) |
+
+</details>
+
+---
+
+<details>
 <summary><strong><code>simulate</code></strong> — Monte Carlo Probability Simulator</summary>
 
 Runs repeated random experiments to estimate probabilities empirically, with optional confidence intervals and analytical comparison against `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, and `linboot`.
@@ -1621,6 +1659,7 @@ simulate --experiment linboot --params x=1,2,3,4,5 y=2.1,3.9,6.2,7.8,10.1 predic
 | Subnet | `src.utils.subnet` | `compute_subnet`, `_classful_prefix` |
 | Geometric | `src.utils.geometric_distribution` | `geo_pmf`, `geo_cdf`, `geo_survival`, `geo_mean`, `geo_variance` |
 | Chi-Square | `src.utils.chi_squared` | `chisq_gof`, `chisq_independence`, `chi2_cdf`, `regularized_gamma_p` |
+| ANOVA | `src.utils.anova` | `anova_one_way`, `tukey_hsd`, `bonferroni`, `f_cdf`, `studentized_range_cdf` |
 | Monte Carlo | `src.utils.monte_carlo` | `simulate_binomial`, `simulate_birthday`, `simulate_streak`, `simulate_poisson`, `simulate_power`, `simulate_permutation`, `simulate_bayes`, `simulate_season`, `simulate_linboot` |
 
 ---
@@ -2535,6 +2574,35 @@ print(result.p_value)    # 0.8208...
 result = chisq_independence([[40, 30, 20], [25, 45, 30]])
 print(result.statistic)  # 7.9573...
 print(result.p_value)    # 0.0187...
+```
+
+</details>
+
+<details>
+<summary><strong>One-Way ANOVA</strong></summary>
+
+```python
+from src.utils.anova import anova_one_way, bonferroni, tukey_hsd
+
+groups = [
+    [12.1, 11.8, 12.5, 11.9],
+    [9.8, 10.3, 10.1, 9.7],
+    [15.2, 14.9, 15.5, 16.0],
+]
+
+result = anova_one_way(groups)
+print(result.f_stat)   # 229.2574...
+print(result.p_value)  # 1.9055e-08...
+
+# Tukey HSD pairwise comparisons
+tukey_result = tukey_hsd(groups, result)
+print(tukey_result.q_crit)
+for c in tukey_result.comparisons:
+    print(c.i, c.j, c.mean_diff, c.p_value, c.significant)
+
+# Bonferroni-corrected pairwise comparisons
+for c in bonferroni(groups, result):
+    print(c.i, c.j, c.mean_diff, c.p_adj, c.significant)
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Euler's Number** | Explore e via limit convergence, Taylor series for e^x and ln(x), Euler's identity, and the Euler-Mascheroni constant |
 | **Monte Carlo Simulator** | Empirically estimate probabilities for `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, `linboot` experiments with confidence intervals and analytical comparison |
 | **Subnet Mask Calculator** | Compute network address, broadcast address, first/last usable IP, subnet mask, host count, and classful network count from an IPv4 address and CIDR prefix |
-| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, and `subnet` commands |
+| **Geometric Distribution** | Compute PMF, CDF, survival, mean, and variance for the number of trials until the first success; supports single-k reports and full probability tables |
+| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, and `geometric` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
 
@@ -91,6 +92,7 @@ pip install -e .
 | `gini` | Gini coefficient and Lorenz curve from raw data, weighted samples, or grouped shares |
 | `crt` | Sunzi's Theorem solver for systems of simultaneous congruences |
 | `subnet` | Network address, broadcast, first/last usable IP, subnet mask, host count, and classful network count from an IPv4 CIDR block |
+| `geometric` | PMF, CDF, survival, mean, and variance for the geometric distribution (trials until first success) |
 | `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
 
 ---
@@ -1456,6 +1458,36 @@ subnet 192.168.1.50/24 --format json
 ---
 
 <details>
+<summary><strong><code>geometric</code></strong> — Geometric Distribution</summary>
+
+Computes PMF, CDF, survival, mean, and variance for the geometric distribution — the number of independent Bernoulli trials until the first success (support k = 1, 2, 3, ...). Pure Python, no external dependencies.
+
+```bash
+# P(first success on exactly the 5th trial, p=0.3)
+geometric -k 5 -p 0.3
+
+# P(needing more than 10 calls to close a sale with 20% close rate)
+geometric -k 10 -p 0.2 --survival
+
+# Range table: probability distribution for k = 1 to 15
+geometric -p 0.25 --table 1 15
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| `-k` | | Trial number of the first success (required unless `--table` is used) |
+| `-p` | | Success probability per trial, in (0, 1] |
+| | `--survival` | Report P(X > k) instead of the cumulative P(X <= k) |
+| | `--table MIN MAX` | Print PMF/CDF/survival for k = MIN..MAX instead of a single report |
+| `-P` | `--precision` | Decimal places for output (default: 4) |
+
+</details>
+
+---
+
+<details>
 <summary><strong><code>simulate</code></strong> — Monte Carlo Probability Simulator</summary>
 
 Runs repeated random experiments to estimate probabilities empirically, with optional confidence intervals and analytical comparison against `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, and `linboot`.
@@ -1554,6 +1586,7 @@ simulate --experiment linboot --params x=1,2,3,4,5 y=2.1,3.9,6.2,7.8,10.1 predic
 | Gini | `src.utils.gini` | `gini_coefficient`, `lorenz_curve`, `relative_mad`, `gini_grouped` |
 | CRT | `src.utils.crt` | `extended_gcd`, `mod_inverse`, `crt` |
 | Subnet | `src.utils.subnet` | `compute_subnet`, `_classful_prefix` |
+| Geometric | `src.utils.geometric_distribution` | `geo_pmf`, `geo_cdf`, `geo_survival`, `geo_mean`, `geo_variance` |
 | Monte Carlo | `src.utils.monte_carlo` | `simulate_binomial`, `simulate_birthday`, `simulate_streak`, `simulate_poisson`, `simulate_power`, `simulate_permutation`, `simulate_bayes`, `simulate_season`, `simulate_linboot` |
 
 ---
@@ -2418,6 +2451,33 @@ result = compute_subnet("10.0.0.5/32")
 
 # Classful prefix boundary
 prefix = _classful_prefix(result.network_address)  # 8 (Class A)
+```
+
+</details>
+
+<details>
+<summary><strong>Geometric Distribution</strong></summary>
+
+```python
+from src.utils.geometric_distribution import (
+    geo_cdf,
+    geo_mean,
+    geo_pmf,
+    geo_survival,
+    geo_variance,
+)
+
+# P(first success on exactly the 5th trial, p=0.3)
+geo_pmf(5, 0.3)       # 0.07203
+
+# P(first success within the first 5 trials)
+geo_cdf(5, 0.3)       # 0.83193
+
+# P(needing more than 10 trials, p=0.2)
+geo_survival(10, 0.2) # 0.10737
+
+geo_mean(0.2)         # 5.0
+geo_variance(0.2)     # 20.0
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Monte Carlo Simulator** | Empirically estimate probabilities for `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, `linboot` experiments with confidence intervals and analytical comparison |
 | **Subnet Mask Calculator** | Compute network address, broadcast address, first/last usable IP, subnet mask, host count, and classful network count from an IPv4 address and CIDR prefix |
 | **Geometric Distribution** | Compute PMF, CDF, survival, mean, and variance for the number of trials until the first success; supports single-k reports and full probability tables |
-| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, and `geometric` commands |
+| **Chi-Square Tests** | Goodness-of-fit and independence (contingency table) chi-square tests via the exact regularised incomplete gamma function; per-cell contributions for residual diagnostics |
+| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, and `chisq` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
 
@@ -93,6 +94,7 @@ pip install -e .
 | `crt` | Sunzi's Theorem solver for systems of simultaneous congruences |
 | `subnet` | Network address, broadcast, first/last usable IP, subnet mask, host count, and classful network count from an IPv4 CIDR block |
 | `geometric` | PMF, CDF, survival, mean, and variance for the geometric distribution (trials until first success) |
+| `chisq` | Chi-square goodness-of-fit and independence tests with per-cell contributions |
 | `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
 
 ---
@@ -1488,6 +1490,37 @@ geometric -p 0.25 --table 1 15
 ---
 
 <details>
+<summary><strong><code>chisq</code></strong> — Chi-Square Test Calculator</summary>
+
+Computes chi-square goodness-of-fit (do observed categorical frequencies match expected ones?) and independence (are two categorical variables associated, from a contingency table?) tests. The chi-square CDF is computed exactly via the regularised incomplete gamma function (series expansion / continued fraction) — pure Python, no external dependencies. Output includes per-cell χ² contributions for residual diagnostics.
+
+```bash
+# Goodness-of-fit: are die rolls uniformly distributed?
+chisq --test gof --observed 18,22,17,25,19,19 --expected 20,20,20,20,20,20
+
+# Independence: is product preference associated with age group? (2×3 table)
+chisq --test independence --table "40,30,20" --table "25,45,30"
+
+# With explicit significance level
+chisq --test gof --observed 52,48 --expected 50,50 --alpha 0.10
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| | `--test {gof,independence}` | Test type (required) |
+| | `--observed O1,O2,...` | Comma-separated observed frequencies (gof mode) |
+| | `--expected E1,E2,...` | Comma-separated expected frequencies (gof mode) |
+| | `--table R1,R2,...` | One contingency table row; repeat once per row (independence mode) |
+| `-a` | `--alpha` | Significance level (default: 0.05) |
+| `-P` | `--precision` | Decimal places for output (default: 4) |
+
+</details>
+
+---
+
+<details>
 <summary><strong><code>simulate</code></strong> — Monte Carlo Probability Simulator</summary>
 
 Runs repeated random experiments to estimate probabilities empirically, with optional confidence intervals and analytical comparison against `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, and `linboot`.
@@ -1587,6 +1620,7 @@ simulate --experiment linboot --params x=1,2,3,4,5 y=2.1,3.9,6.2,7.8,10.1 predic
 | CRT | `src.utils.crt` | `extended_gcd`, `mod_inverse`, `crt` |
 | Subnet | `src.utils.subnet` | `compute_subnet`, `_classful_prefix` |
 | Geometric | `src.utils.geometric_distribution` | `geo_pmf`, `geo_cdf`, `geo_survival`, `geo_mean`, `geo_variance` |
+| Chi-Square | `src.utils.chi_squared` | `chisq_gof`, `chisq_independence`, `chi2_cdf`, `regularized_gamma_p` |
 | Monte Carlo | `src.utils.monte_carlo` | `simulate_binomial`, `simulate_birthday`, `simulate_streak`, `simulate_poisson`, `simulate_power`, `simulate_permutation`, `simulate_bayes`, `simulate_season`, `simulate_linboot` |
 
 ---
@@ -2478,6 +2512,29 @@ geo_survival(10, 0.2) # 0.10737
 
 geo_mean(0.2)         # 5.0
 geo_variance(0.2)     # 20.0
+```
+
+</details>
+
+<details>
+<summary><strong>Chi-Square Test Calculator</strong></summary>
+
+```python
+from src.utils.chi_squared import chisq_gof, chisq_independence
+
+# Goodness-of-fit
+result = chisq_gof(
+    observed=[18, 22, 17, 25, 19, 19],
+    expected=[20, 20, 20, 20, 20, 20],
+)
+print(result.statistic)  # 2.2
+print(result.df)         # 5
+print(result.p_value)    # 0.8208...
+
+# Independence (contingency table)
+result = chisq_independence([[40, 30, 20], [25, 45, 30]])
+print(result.statistic)  # 7.9573...
+print(result.p_value)    # 0.0187...
 ```
 
 </details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ euler = "src.utils.euler:main"
 gini = "src.utils.gini:main"
 crt = "src.utils.crt:main"
 subnet = "src.utils.subnet:main"
+geometric = "src.utils.geometric_distribution:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ gini = "src.utils.gini:main"
 crt = "src.utils.crt:main"
 subnet = "src.utils.subnet:main"
 geometric = "src.utils.geometric_distribution:main"
+chisq = "src.utils.chi_squared:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ crt = "src.utils.crt:main"
 subnet = "src.utils.subnet:main"
 geometric = "src.utils.geometric_distribution:main"
 chisq = "src.utils.chi_squared:main"
+anova = "src.utils.anova:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/utils/anova.py
+++ b/src/utils/anova.py
@@ -1,0 +1,1039 @@
+#!/usr/bin/env python3
+"""Command-line utility for one-way analysis of variance (ANOVA).
+
+Tests whether the means of three or more independent groups are equal — the
+natural generalization of the two-sample t-test to multiple groups. Supports
+Tukey HSD and Bonferroni-corrected pairwise post-hoc comparisons.
+
+The F-distribution CDF (and the pairwise t-test p-values used by the
+Bonferroni post-hoc) are computed via the regularised incomplete beta
+function (`math.lgamma`). Tukey HSD uses the studentized range distribution,
+computed via numerical integration (nested Simpson's rule over the normal
+and scaled chi densities) — pure Python, no external dependencies.
+
+Usage examples:
+  anova --data "12.1,11.8,12.5,11.9" "9.8,10.3,10.1,9.7" "15.2,14.9,15.5,16.0"
+  anova --data "12.1,11.8,12.5" "9.8,10.3,10.1" "15.2,14.9,15.5" --posthoc tukey
+  anova --file experiment.csv --group-col treatment --value-col response --alpha 0.01
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import sys
+from typing import Callable, Sequence
+
+# ---------------------------------------------------------------------------
+# Regularised incomplete beta function (Numerical Recipes betai/betacf)
+# ---------------------------------------------------------------------------
+
+_ITMAX = 200
+_EPS = 1e-14
+_FPMIN = 1e-300
+
+
+def _beta_cf(a: float, b: float, x: float) -> float:
+    """Continued fraction used by :func:`regularized_incomplete_beta`.
+
+    Args:
+        a: First shape parameter; must be > 0.
+        b: Second shape parameter; must be > 0.
+        x: Evaluation point in [0, 1).
+
+    Returns:
+        Value of the continued fraction (not yet scaled by the leading term).
+    """
+    qab = a + b
+    qap = a + 1
+    qam = a - 1
+    c = 1.0
+    d = 1.0 - qab * x / qap
+    if abs(d) < _FPMIN:
+        d = _FPMIN
+    d = 1.0 / d
+    h = d
+    for m in range(1, _ITMAX + 1):
+        m2 = 2 * m
+        aa = m * (b - m) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if abs(d) < _FPMIN:
+            d = _FPMIN
+        c = 1.0 + aa / c
+        if abs(c) < _FPMIN:
+            c = _FPMIN
+        d = 1.0 / d
+        h *= d * c
+        aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if abs(d) < _FPMIN:
+            d = _FPMIN
+        c = 1.0 + aa / c
+        if abs(c) < _FPMIN:
+            c = _FPMIN
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < _EPS:
+            break
+    return h
+
+
+def regularized_incomplete_beta(x: float, a: float, b: float) -> float:
+    """Regularised incomplete beta function I_x(a, b).
+
+    Args:
+        x: Evaluation point; must be in [0, 1].
+        a: First shape parameter; must be > 0.
+        b: Second shape parameter; must be > 0.
+
+    Returns:
+        I_x(a, b) in [0, 1].
+
+    Raises:
+        ValueError: If ``x`` is not in [0, 1], or ``a``/``b`` are not > 0.
+    """
+    if not (0 <= x <= 1):
+        raise ValueError(f"x must be in [0, 1], got {x}")
+    if a <= 0 or b <= 0:
+        raise ValueError(f"a and b must be > 0, got a={a}, b={b}")
+
+    if x == 0 or x == 1:
+        return x
+
+    log_bt = (
+        math.lgamma(a + b)
+        - math.lgamma(a)
+        - math.lgamma(b)
+        + a * math.log(x)
+        + b * math.log(1 - x)
+    )
+    bt = math.exp(log_bt)
+
+    if x < (a + 1) / (a + b + 2):
+        return bt * _beta_cf(a, b, x) / a
+    return 1.0 - bt * _beta_cf(b, a, 1 - x) / b
+
+
+def f_cdf(f_stat: float, df1: int, df2: int) -> float:
+    """Cumulative distribution function P(F <= f_stat) for F(df1, df2).
+
+    Args:
+        f_stat: Observed F-statistic; must be >= 0.
+        df1: Numerator degrees of freedom; must be >= 1.
+        df2: Denominator degrees of freedom; must be >= 1.
+
+    Returns:
+        P(F <= f_stat) in [0, 1].
+
+    Raises:
+        ValueError: If ``df1``/``df2`` < 1 or ``f_stat`` < 0.
+    """
+    if df1 < 1 or df2 < 1:
+        raise ValueError(f"df1 and df2 must be >= 1, got df1={df1}, df2={df2}")
+    if f_stat < 0:
+        raise ValueError(f"f_stat must be >= 0, got {f_stat}")
+    if f_stat == 0:
+        return 0.0
+    if math.isinf(f_stat):
+        return 1.0
+    x = df1 * f_stat / (df1 * f_stat + df2)
+    return regularized_incomplete_beta(x, df1 / 2, df2 / 2)
+
+
+def f_sf(f_stat: float, df1: int, df2: int) -> float:
+    """Survival function (upper tail p-value) for F(df1, df2).
+
+    Args:
+        f_stat: Observed F-statistic; must be >= 0.
+        df1: Numerator degrees of freedom; must be >= 1.
+        df2: Denominator degrees of freedom; must be >= 1.
+
+    Returns:
+        P(F > f_stat), clipped to [0, 1].
+    """
+    return max(0.0, min(1.0, 1.0 - f_cdf(f_stat, df1, df2)))
+
+
+def t_sf_two_sided(t_stat: float, df: float) -> float:
+    """Two-sided p-value P(|T| > |t_stat|) for Student's t(df).
+
+    Computed via the incomplete-beta identity for the t-distribution, so no
+    separate t-distribution implementation is needed.
+
+    Args:
+        t_stat: Observed t-statistic.
+        df: Degrees of freedom; must be > 0.
+
+    Returns:
+        Two-sided p-value in [0, 1].
+
+    Raises:
+        ValueError: If ``df`` <= 0.
+    """
+    if df <= 0:
+        raise ValueError(f"df must be > 0, got {df}")
+    if t_stat == 0:
+        return 1.0
+    x = df / (df + t_stat * t_stat)
+    return max(0.0, min(1.0, regularized_incomplete_beta(x, df / 2, 0.5)))
+
+
+# ---------------------------------------------------------------------------
+# Studentized range distribution (for Tukey HSD)
+#
+# P(Q <= q | k groups, df) is computed as a nested numerical integral:
+#   P(Q <= q | k, df) = ∫₀^∞ h(u; df) · R(q·u, k) du
+#   R(x, k) = k · ∫_{-∞}^{∞} φ(z) · [Φ(z) − Φ(z − x)]^(k−1) dz   (known-variance
+#             range CDF for k standard normal variates; φ/Φ are the standard
+#             normal PDF/CDF)
+#   h(u; df) = 2·(df/2)^(df/2) / Γ(df/2) · u^(df−1) · exp(−df·u²/2)   (density
+#             of U = S/σ, the scaled sample standard deviation)
+#
+# Both integrals use a fixed-step Simpson's rule; the outer (u) integral's
+# bounds are centered on U's exact mean/std so the peak stays resolved even
+# when it becomes very narrow at large df.
+# ---------------------------------------------------------------------------
+
+_SQRT2 = math.sqrt(2.0)
+_SQRT2PI = math.sqrt(2.0 * math.pi)
+
+
+def _standard_normal_pdf(z: float) -> float:
+    """Standard normal probability density function φ(z)."""
+    return math.exp(-z * z / 2.0) / _SQRT2PI
+
+
+def _standard_normal_cdf(z: float) -> float:
+    """Standard normal cumulative distribution function Φ(z)."""
+    return 0.5 * (1.0 + math.erf(z / _SQRT2))
+
+
+def _simpson(f: Callable[[float], float], a: float, b: float, n: int) -> float:
+    """Composite Simpson's rule for ∫ f over [a, b] using n subintervals.
+
+    Args:
+        f: Integrand.
+        a: Lower bound.
+        b: Upper bound.
+        n: Number of subintervals (rounded up to even).
+
+    Returns:
+        Approximate value of the integral; 0.0 if ``b <= a``.
+    """
+    if b <= a:
+        return 0.0
+    if n % 2:
+        n += 1
+    h = (b - a) / n
+    total = f(a) + f(b)
+    for i in range(1, n):
+        x = a + i * h
+        total += (4 if i % 2 else 2) * f(x)
+    return total * h / 3.0
+
+
+def _range_cdf_known_variance(
+    x: float, k: int, n_z: int = 100, zlim: float = 8.0
+) -> float:
+    """CDF of the range of k standard normal variates (known-variance case).
+
+    Args:
+        x: Range value; must be >= 0.
+        k: Number of groups; must be >= 2.
+        n_z: Number of Simpson subintervals for the z-integral.
+        zlim: Integration bound for z (the standard normal tail beyond this
+            is negligible).
+
+    Returns:
+        P(range <= x) in [0, 1].
+    """
+    if x <= 0:
+        return 0.0
+
+    def integrand(z: float) -> float:
+        return _standard_normal_pdf(z) * (
+            _standard_normal_cdf(z) - _standard_normal_cdf(z - x)
+        ) ** (k - 1)
+
+    integral = _simpson(integrand, -zlim, zlim, n_z)
+    return max(0.0, min(1.0, k * integral))
+
+
+def _u_mean_std(df: float) -> tuple[float, float]:
+    """Exact mean and standard deviation of U = S/σ (U²·df ~ chi-square(df)).
+
+    Args:
+        df: Degrees of freedom; must be > 0.
+
+    Returns:
+        Tuple (mean, std) of U.
+    """
+    mean_u = math.sqrt(2.0 / df) * math.exp(
+        math.lgamma((df + 1) / 2.0) - math.lgamma(df / 2.0)
+    )
+    var_u = max(1e-12, 1.0 - mean_u * mean_u)
+    return mean_u, math.sqrt(var_u)
+
+
+def studentized_range_cdf(
+    q: float,
+    k: int,
+    df: float,
+    n_z: int = 100,
+    n_u: int = 200,
+    width_sigmas: float = 12.0,
+) -> float:
+    """Cumulative distribution function P(Q <= q) for the studentized range.
+
+    Args:
+        q: Studentized range value; must be >= 0.
+        k: Number of groups (means being compared); must be >= 2.
+        df: Degrees of freedom of the variance estimate; must be >= 1.
+        n_z: Simpson subintervals for the inner (known-variance) integral.
+        n_u: Simpson subintervals for the outer (variance-mixing) integral.
+        width_sigmas: Half-width of the outer integration window, in standard
+            deviations of U, centered on U's exact mean.
+
+    Returns:
+        P(Q <= q) in [0, 1].
+
+    Raises:
+        ValueError: If ``k`` < 2, ``df`` < 1, or ``q`` < 0.
+    """
+    if k < 2:
+        raise ValueError(f"k must be >= 2, got {k}")
+    if df < 1:
+        raise ValueError(f"df must be >= 1, got {df}")
+    if q < 0:
+        raise ValueError(f"q must be >= 0, got {q}")
+    if q == 0:
+        return 0.0
+
+    log_const = math.log(2.0) + (df / 2.0) * math.log(df / 2.0) - math.lgamma(df / 2.0)
+
+    def integrand(u: float) -> float:
+        # u > 0 always holds here: the outer Simpson call below is bounded
+        # below by `lo`, which is clamped to >= 1e-10.
+        log_h = log_const + (df - 1) * math.log(u) - df * u * u / 2.0
+        return math.exp(log_h) * _range_cdf_known_variance(q * u, k, n_z=n_z)
+
+    mean_u, std_u = _u_mean_std(df)
+    lo = max(1e-10, mean_u - width_sigmas * std_u)
+    hi = mean_u + width_sigmas * std_u
+
+    return max(0.0, min(1.0, _simpson(integrand, lo, hi, n_u)))
+
+
+def studentized_range_sf(q: float, k: int, df: float) -> float:
+    """Survival function (upper tail p-value) for the studentized range.
+
+    Args:
+        q: Studentized range value; must be >= 0.
+        k: Number of groups; must be >= 2.
+        df: Degrees of freedom; must be >= 1.
+
+    Returns:
+        P(Q > q), clipped to [0, 1].
+    """
+    return max(0.0, min(1.0, 1.0 - studentized_range_cdf(q, k, df)))
+
+
+def studentized_range_ppf(
+    p: float, k: int, df: float, tol: float = 1e-6, max_iter: int = 60
+) -> float:
+    """Quantile (inverse CDF) of the studentized range via bisection.
+
+    Args:
+        p: Target cumulative probability; must be in (0, 1).
+        k: Number of groups; must be >= 2.
+        df: Degrees of freedom; must be >= 1.
+        tol: Bisection stops early once |CDF(mid) - p| < tol.
+        max_iter: Maximum bisection iterations.
+
+    Returns:
+        q such that P(Q <= q) ≈ p.
+
+    Raises:
+        ValueError: If ``p`` is not in (0, 1).
+    """
+    if not (0 < p < 1):
+        raise ValueError(f"p must be in (0, 1), got {p}")
+
+    lo, hi = 0.0, 60.0
+    mid = hi / 2.0
+    for _ in range(max_iter):
+        mid = (lo + hi) / 2.0
+        c = studentized_range_cdf(mid, k, df)
+        if abs(c - p) < tol:
+            break
+        if c < p:
+            lo = mid
+        else:
+            hi = mid
+    return mid
+
+
+# ---------------------------------------------------------------------------
+# Result containers
+# ---------------------------------------------------------------------------
+
+
+class AnovaResult:
+    """Result of a one-way ANOVA F-test."""
+
+    def __init__(
+        self,
+        f_stat: float,
+        p_value: float,
+        df_between: int,
+        df_within: int,
+        ss_between: float,
+        ss_within: float,
+        ms_between: float,
+        ms_within: float,
+        group_means: list[float],
+        group_sizes: list[int],
+        grand_mean: float,
+        alpha: float,
+    ) -> None:
+        """Store all computed quantities."""
+        self.f_stat = f_stat
+        self.p_value = p_value
+        self.df_between = df_between
+        self.df_within = df_within
+        self.ss_between = ss_between
+        self.ss_within = ss_within
+        self.ms_between = ms_between
+        self.ms_within = ms_within
+        self.group_means = group_means
+        self.group_sizes = group_sizes
+        self.grand_mean = grand_mean
+        self.alpha = alpha
+
+
+class PairwiseComparison:
+    """A single pairwise post-hoc comparison between two groups."""
+
+    def __init__(
+        self,
+        i: int,
+        j: int,
+        mean_diff: float,
+        t_stat: float,
+        p_raw: float,
+        p_adj: float,
+        significant: bool,
+    ) -> None:
+        """Store all computed quantities for one pairwise comparison."""
+        self.i = i
+        self.j = j
+        self.mean_diff = mean_diff
+        self.t_stat = t_stat
+        self.p_raw = p_raw
+        self.p_adj = p_adj
+        self.significant = significant
+
+
+class TukeyComparison:
+    """A single pairwise Tukey HSD comparison between two groups."""
+
+    def __init__(
+        self,
+        i: int,
+        j: int,
+        mean_diff: float,
+        q_stat: float,
+        p_value: float,
+        significant: bool,
+    ) -> None:
+        """Store all computed quantities for one pairwise comparison."""
+        self.i = i
+        self.j = j
+        self.mean_diff = mean_diff
+        self.q_stat = q_stat
+        self.p_value = p_value
+        self.significant = significant
+
+
+class TukeyResult:
+    """Result of a full Tukey HSD post-hoc analysis."""
+
+    def __init__(self, comparisons: list[TukeyComparison], q_crit: float) -> None:
+        """Store the pairwise comparisons and the family-wise critical value."""
+        self.comparisons = comparisons
+        self.q_crit = q_crit
+
+
+# ---------------------------------------------------------------------------
+# Core statistical functions
+# ---------------------------------------------------------------------------
+
+
+def _mean(values: Sequence[float]) -> float:
+    """Compute the arithmetic mean of a non-empty sequence."""
+    return sum(values) / len(values)
+
+
+def anova_one_way(
+    groups: Sequence[Sequence[float]], alpha: float = 0.05
+) -> AnovaResult:
+    """Perform a one-way ANOVA F-test.
+
+    Tests H₀: μ₁ = μ₂ = ... = μₖ across k independent groups.
+
+    Args:
+        groups: At least 2 groups, each with at least 1 observation; the
+            total number of observations must exceed the number of groups.
+        alpha: Significance level (default 0.05).
+
+    Returns:
+        :class:`AnovaResult` with the ANOVA table and per-group summaries.
+
+    Raises:
+        ValueError: If fewer than 2 groups are given, any group is empty,
+            df_within is not positive, or alpha is not in (0, 1).
+    """
+    if len(groups) < 2:
+        raise ValueError(f"need at least 2 groups, got {len(groups)}")
+    if any(len(g) == 0 for g in groups):
+        raise ValueError("every group must have at least 1 observation")
+    if not (0 < alpha < 1):
+        raise ValueError(f"alpha must be in (0, 1), got {alpha}")
+
+    k = len(groups)
+    n_total = sum(len(g) for g in groups)
+    df_between = k - 1
+    df_within = n_total - k
+    if df_within < 1:
+        raise ValueError(
+            f"df_within must be >= 1 (need more observations than groups), "
+            f"got {df_within}"
+        )
+
+    group_means = [_mean(g) for g in groups]
+    group_sizes = [len(g) for g in groups]
+    grand_mean = sum(sum(g) for g in groups) / n_total
+
+    ss_between = sum(
+        n * (m - grand_mean) ** 2 for n, m in zip(group_sizes, group_means)
+    )
+    ss_within = sum(sum((x - m) ** 2 for x in g) for g, m in zip(groups, group_means))
+
+    ms_between = ss_between / df_between
+    ms_within = ss_within / df_within
+
+    if ms_within == 0:
+        f_stat = 0.0 if ms_between == 0 else math.inf
+        p_value = 1.0 if ms_between == 0 else 0.0
+    else:
+        f_stat = ms_between / ms_within
+        p_value = f_sf(f_stat, df_between, df_within)
+
+    return AnovaResult(
+        f_stat=f_stat,
+        p_value=p_value,
+        df_between=df_between,
+        df_within=df_within,
+        ss_between=ss_between,
+        ss_within=ss_within,
+        ms_between=ms_between,
+        ms_within=ms_within,
+        group_means=group_means,
+        group_sizes=group_sizes,
+        grand_mean=grand_mean,
+        alpha=alpha,
+    )
+
+
+def bonferroni(
+    groups: Sequence[Sequence[float]], result: AnovaResult, alpha: float = 0.05
+) -> list[PairwiseComparison]:
+    """Bonferroni-corrected pairwise post-hoc comparisons.
+
+    Each pair uses a t-test against the pooled within-group variance
+    (MS_within) from the ANOVA, with df_within degrees of freedom. The raw
+    p-value is multiplied by the number of comparisons and clipped to 1.0.
+
+    Args:
+        groups: The same groups passed to :func:`anova_one_way`.
+        result: The :class:`AnovaResult` computed from ``groups``.
+        alpha: Family-wise significance level (default 0.05).
+
+    Returns:
+        List of :class:`PairwiseComparison`, one per unordered group pair.
+
+    Raises:
+        ValueError: If ``alpha`` is not in (0, 1).
+    """
+    if not (0 < alpha < 1):
+        raise ValueError(f"alpha must be in (0, 1), got {alpha}")
+
+    k = len(groups)
+    n_pairs = k * (k - 1) // 2
+    comparisons: list[PairwiseComparison] = []
+
+    for i in range(k):
+        for j in range(i + 1, k):
+            mean_diff = result.group_means[i] - result.group_means[j]
+            n_i, n_j = result.group_sizes[i], result.group_sizes[j]
+            se = math.sqrt(result.ms_within * (1 / n_i + 1 / n_j))
+
+            if se == 0:
+                t_stat = 0.0 if mean_diff == 0 else math.copysign(math.inf, mean_diff)
+                p_raw = 1.0 if mean_diff == 0 else 0.0
+            else:
+                t_stat = mean_diff / se
+                p_raw = t_sf_two_sided(t_stat, result.df_within)
+
+            p_adj = min(1.0, p_raw * n_pairs)
+            comparisons.append(
+                PairwiseComparison(
+                    i=i,
+                    j=j,
+                    mean_diff=mean_diff,
+                    t_stat=t_stat,
+                    p_raw=p_raw,
+                    p_adj=p_adj,
+                    significant=p_adj < alpha,
+                )
+            )
+
+    return comparisons
+
+
+def tukey_hsd(
+    groups: Sequence[Sequence[float]], result: AnovaResult, alpha: float = 0.05
+) -> TukeyResult:
+    """Tukey HSD (Tukey-Kramer) pairwise post-hoc comparisons.
+
+    Each pair uses the studentized range statistic
+    ``q = |mean_i - mean_j| / sqrt(MS_within / 2 * (1/n_i + 1/n_j))``
+    (the Tukey-Kramer generalization for unequal group sizes), tested against
+    the studentized range distribution with ``k`` groups and ``df_within``
+    degrees of freedom. Unlike Bonferroni, the resulting p-value is already
+    family-wise adjusted.
+
+    Args:
+        groups: The same groups passed to :func:`anova_one_way`.
+        result: The :class:`AnovaResult` computed from ``groups``.
+        alpha: Family-wise significance level (default 0.05).
+
+    Returns:
+        :class:`TukeyResult` with the pairwise comparisons and the critical
+        studentized range value q_crit at the given alpha.
+
+    Raises:
+        ValueError: If ``alpha`` is not in (0, 1).
+    """
+    if not (0 < alpha < 1):
+        raise ValueError(f"alpha must be in (0, 1), got {alpha}")
+
+    k = len(groups)
+    q_crit = studentized_range_ppf(1 - alpha, k, result.df_within)
+    comparisons: list[TukeyComparison] = []
+
+    for i in range(k):
+        for j in range(i + 1, k):
+            mean_diff = result.group_means[i] - result.group_means[j]
+            n_i, n_j = result.group_sizes[i], result.group_sizes[j]
+            se = math.sqrt(result.ms_within / 2 * (1 / n_i + 1 / n_j))
+
+            if se == 0:
+                q_stat = 0.0 if mean_diff == 0 else math.inf
+                p_value = 1.0 if mean_diff == 0 else 0.0
+            else:
+                q_stat = abs(mean_diff) / se
+                p_value = studentized_range_sf(q_stat, k, result.df_within)
+
+            comparisons.append(
+                TukeyComparison(
+                    i=i,
+                    j=j,
+                    mean_diff=mean_diff,
+                    q_stat=q_stat,
+                    p_value=p_value,
+                    significant=p_value < alpha,
+                )
+            )
+
+    return TukeyResult(comparisons=comparisons, q_crit=q_crit)
+
+
+def read_csv_groups(
+    path: str, group_col: str, value_col: str
+) -> dict[str, list[float]]:
+    """Load grouped observations from a CSV file.
+
+    Args:
+        path: Path to a CSV file with a header row.
+        group_col: Name of the column holding the group label.
+        value_col: Name of the column holding the numeric observation.
+
+    Returns:
+        Mapping of group label to its list of observed values, in the order
+        groups first appear in the file.
+
+    Raises:
+        ValueError: If either column is missing from the header, or a value
+            cannot be parsed as a finite float.
+    """
+    groups: dict[str, list[float]] = {}
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        if reader.fieldnames is None or (
+            group_col not in reader.fieldnames or value_col not in reader.fieldnames
+        ):
+            raise ValueError(
+                f"CSV must contain columns {group_col!r} and {value_col!r}"
+            )
+        for row in reader:
+            label = row[group_col]
+            try:
+                value = float(row[value_col])
+            except ValueError as exc:
+                raise ValueError(
+                    f"non-numeric value {row[value_col]!r} in column {value_col!r}"
+                ) from exc
+            if not math.isfinite(value):
+                raise ValueError(f"non-finite value in column {value_col!r}")
+            groups.setdefault(label, []).append(value)
+    return groups
+
+
+def parse_number_list(raw: str) -> list[float]:
+    """Parse a comma-separated string of finite numbers.
+
+    Args:
+        raw: Comma-separated numeric string (e.g. ``"12.1,11.8,12.5"``).
+
+    Returns:
+        List of parsed floats.
+
+    Raises:
+        ValueError: If the string is empty, non-numeric, or contains non-finite values.
+    """
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    if not parts:
+        raise ValueError("at least one value is required")
+    values = [float(p) for p in parts]
+    if any(not math.isfinite(v) for v in values):
+        raise ValueError("all values must be finite")
+    return values
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and return the argument parser namespace.
+
+    Args:
+        argv: Argument list (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        Parsed :class:`argparse.Namespace`.
+    """
+    parser = argparse.ArgumentParser(
+        description="One-way ANOVA calculator with Tukey HSD / Bonferroni post-hoc comparisons.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  anova --data "12.1,11.8,12.5,11.9" "9.8,10.3,10.1,9.7" "15.2,14.9,15.5,16.0"
+  anova --data "12.1,11.8,12.5" "9.8,10.3,10.1" "15.2,14.9,15.5" --posthoc tukey
+  anova --file experiment.csv --group-col treatment --value-col response --alpha 0.01
+""",
+    )
+    parser.add_argument(
+        "--data",
+        nargs="+",
+        metavar="GROUP",
+        help="one comma-separated list of values per group (2 or more groups)",
+    )
+    parser.add_argument(
+        "--file",
+        type=str,
+        metavar="CSV",
+        help="path to a CSV file (use with --group-col and --value-col)",
+    )
+    parser.add_argument(
+        "--group-col",
+        type=str,
+        metavar="COL",
+        help="CSV column name holding the group label",
+    )
+    parser.add_argument(
+        "--value-col",
+        type=str,
+        metavar="COL",
+        help="CSV column name holding the numeric observation",
+    )
+    parser.add_argument(
+        "--alpha",
+        "-a",
+        type=float,
+        default=0.05,
+        metavar="F",
+        help="significance level (default: 0.05)",
+    )
+    parser.add_argument(
+        "--posthoc",
+        choices=["tukey", "bonferroni", "none"],
+        default="none",
+        help="post-hoc pairwise comparison method (default: none)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="output format (default: table)",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=4,
+        metavar="PREC",
+        help="decimal places for table output (default: 4)",
+    )
+    return parser.parse_args(argv)
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Return an error message string, or ``None`` if arguments are valid.
+
+    Args:
+        args: Parsed argument namespace from :func:`parse_args`.
+
+    Returns:
+        Error description string, or ``None`` when validation passes.
+    """
+    if not (0 < args.alpha < 1):
+        return f"--alpha must be in (0, 1), got {args.alpha}"
+    if args.precision < 0:
+        return "--precision must be non-negative"
+
+    using_data = args.data is not None
+    using_file = (
+        args.file is not None
+        or args.group_col is not None
+        or args.value_col is not None
+    )
+
+    if using_data and using_file:
+        return "provide either --data or --file/--group-col/--value-col, not both"
+    if not using_data and not using_file:
+        return "provide either --data or --file/--group-col/--value-col"
+
+    if using_data and len(args.data) < 2:
+        return "--data requires at least 2 groups"
+
+    if using_file:
+        if args.file is None or args.group_col is None or args.value_col is None:
+            return "--file requires both --group-col and --value-col"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(value: float, precision: int) -> str:
+    """Format a float to the requested number of decimal places."""
+    if math.isinf(value):
+        return "inf" if value > 0 else "-inf"
+    return f"{value:.{precision}f}"
+
+
+def _decision(p_value: float, alpha: float) -> str:
+    """Return reject / fail-to-reject decision string."""
+    if p_value < alpha:
+        return f"Reject H₀  (p < α = {alpha})"
+    return f"Fail to reject H₀  (p ≥ α = {alpha})"
+
+
+def format_table(
+    result: AnovaResult,
+    posthoc: str,
+    comparisons: list[PairwiseComparison] | TukeyResult | None,
+    precision: int,
+) -> str:
+    """Format the ANOVA table (and optional post-hoc comparisons) for display.
+
+    Args:
+        result: Computed :class:`AnovaResult`.
+        posthoc: One of ``"none"``, ``"bonferroni"``, or ``"tukey"``.
+        comparisons: ``None`` for no post-hoc; a list of
+            :class:`PairwiseComparison` for Bonferroni; a :class:`TukeyResult`
+            for Tukey HSD.
+        precision: Decimal places for all floating-point output.
+
+    Returns:
+        Multi-line string ready to print.
+    """
+    f = lambda v: _fmt(v, precision)  # noqa: E731
+    lines = [
+        "One-way ANOVA",
+        "H₀: all group means are equal",
+        "",
+        f"  {'source':>10}  {'SS':>10}  {'df':>6}  {'MS':>10}  {'F':>10}  {'p-value':>10}",
+        f"  {'between':>10}  {f(result.ss_between):>10}  {result.df_between:>6}  "
+        f"{f(result.ms_between):>10}  {f(result.f_stat):>10}  {f(result.p_value):>10}",
+        f"  {'within':>10}  {f(result.ss_within):>10}  {result.df_within:>6}  "
+        f"{f(result.ms_within):>10}",
+        "",
+        f"  {_decision(result.p_value, result.alpha)}",
+        "",
+        "  Group means:",
+    ]
+    for idx, (mean, size) in enumerate(zip(result.group_means, result.group_sizes)):
+        lines.append(f"    group {idx + 1}:  n={size},  mean={f(mean)}")
+
+    if posthoc == "bonferroni" and isinstance(comparisons, list):
+        lines += [
+            "",
+            "  Bonferroni pairwise comparisons:",
+            f"    {'pair':>10}  {'mean diff':>10}  {'t-stat':>10}  "
+            f"{'p (raw)':>10}  {'p (adj)':>10}  sig",
+        ]
+        for c in comparisons:
+            sig = "*" if c.significant else ""
+            lines.append(
+                f"    {c.i + 1} vs {c.j + 1:<4}  {f(c.mean_diff):>10}  {f(c.t_stat):>10}  "
+                f"{f(c.p_raw):>10}  {f(c.p_adj):>10}  {sig}"
+            )
+    elif posthoc == "tukey" and isinstance(comparisons, TukeyResult):
+        lines += [
+            "",
+            f"  Tukey HSD pairwise comparisons  (q_crit={f(comparisons.q_crit)}):",
+            f"    {'pair':>10}  {'mean diff':>10}  {'q-stat':>10}  "
+            f"{'p (adj)':>10}  sig",
+        ]
+        for tc in comparisons.comparisons:
+            sig = "*" if tc.significant else ""
+            lines.append(
+                f"    {tc.i + 1} vs {tc.j + 1:<4}  {f(tc.mean_diff):>10}  {f(tc.q_stat):>10}  "
+                f"{f(tc.p_value):>10}  {sig}"
+            )
+
+    return "\n".join(lines)
+
+
+def format_json(
+    result: AnovaResult,
+    posthoc: str,
+    comparisons: list[PairwiseComparison] | TukeyResult | None,
+) -> str:
+    """Format the ANOVA result (and optional post-hoc comparisons) as JSON.
+
+    Args:
+        result: Computed :class:`AnovaResult`.
+        posthoc: One of ``"none"``, ``"bonferroni"``, or ``"tukey"``.
+        comparisons: ``None`` for no post-hoc; a list of
+            :class:`PairwiseComparison` for Bonferroni; a :class:`TukeyResult`
+            for Tukey HSD.
+
+    Returns:
+        JSON string.
+    """
+    data: dict[str, object] = {
+        "f_stat": result.f_stat,
+        "p_value": result.p_value,
+        "df_between": result.df_between,
+        "df_within": result.df_within,
+        "ss_between": result.ss_between,
+        "ss_within": result.ss_within,
+        "ms_between": result.ms_between,
+        "ms_within": result.ms_within,
+        "group_means": result.group_means,
+        "group_sizes": result.group_sizes,
+        "alpha": result.alpha,
+        "reject_null": result.p_value < result.alpha,
+    }
+    if posthoc == "bonferroni" and isinstance(comparisons, list):
+        data["bonferroni"] = [
+            {
+                "i": c.i,
+                "j": c.j,
+                "mean_diff": c.mean_diff,
+                "t_stat": c.t_stat,
+                "p_raw": c.p_raw,
+                "p_adj": c.p_adj,
+                "significant": c.significant,
+            }
+            for c in comparisons
+        ]
+    elif posthoc == "tukey" and isinstance(comparisons, TukeyResult):
+        data["tukey"] = {
+            "q_crit": comparisons.q_crit,
+            "comparisons": [
+                {
+                    "i": c.i,
+                    "j": c.j,
+                    "mean_diff": c.mean_diff,
+                    "q_stat": c.q_stat,
+                    "p_value": c.p_value,
+                    "significant": c.significant,
+                }
+                for c in comparisons.comparisons
+            ],
+        }
+    return json.dumps(data, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the ANOVA CLI.
+
+    Args:
+        argv: Argument list override for testing (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        0 on success, 2 on input or computation error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        if args.data is not None:
+            groups = [parse_number_list(g) for g in args.data]
+        else:
+            grouped = read_csv_groups(args.file, args.group_col, args.value_col)
+            groups = list(grouped.values())
+
+        result = anova_one_way(groups, args.alpha)
+        comparisons: list[PairwiseComparison] | TukeyResult | None
+        if args.posthoc == "bonferroni":
+            comparisons = bonferroni(groups, result, args.alpha)
+        elif args.posthoc == "tukey":
+            comparisons = tukey_hsd(groups, result, args.alpha)
+        else:
+            comparisons = None
+
+        if args.format == "json":
+            print(format_json(result, args.posthoc, comparisons))
+        else:
+            print(format_table(result, args.posthoc, comparisons, args.precision))
+    except (ValueError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/chi_squared.py
+++ b/src/utils/chi_squared.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""Command-line utility for chi-square statistics.
+
+Supports goodness-of-fit tests (do observed categorical frequencies match
+expected ones?) and tests of independence (are two categorical variables
+associated?) on a contingency table.
+
+The chi-square CDF is computed via the regularised incomplete gamma function
+(series expansion / continued fraction, using ``math.lgamma``) — pure Python,
+no external dependencies.
+
+Usage examples:
+  chisq --test gof --observed 18,22,17,25,19,19 --expected 20,20,20,20,20,20
+  chisq --test independence --table "40,30,20" --table "25,45,30"
+  chisq --test gof --observed 52,48 --expected 50,50 --alpha 0.10
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from typing import Sequence
+
+# ---------------------------------------------------------------------------
+# Regularised incomplete gamma function (Numerical Recipes gser/gcf)
+# ---------------------------------------------------------------------------
+
+_ITMAX = 200
+_EPS = 1e-14
+_FPMIN = 1e-300
+
+
+def _gamma_series(a: float, x: float) -> float:
+    """Regularised lower incomplete gamma P(a, x) via series expansion.
+
+    Valid and rapidly convergent for x < a + 1.
+
+    Args:
+        a: Shape parameter; must be > 0.
+        x: Upper integration bound; must be >= 0.
+
+    Returns:
+        P(a, x) in [0, 1].
+    """
+    gln = math.lgamma(a)
+    ap = a
+    delta = total = 1.0 / a
+    for _ in range(_ITMAX):
+        ap += 1
+        delta *= x / ap
+        total += delta
+        if abs(delta) < abs(total) * _EPS:
+            break
+    return total * math.exp(-x + a * math.log(x) - gln)
+
+
+def _gamma_cf(a: float, x: float) -> float:
+    """Regularised upper incomplete gamma Q(a, x) via continued fraction.
+
+    Valid and rapidly convergent for x >= a + 1.
+
+    Args:
+        a: Shape parameter; must be > 0.
+        x: Lower integration bound; must be >= a.
+
+    Returns:
+        Q(a, x) in [0, 1].
+    """
+    gln = math.lgamma(a)
+    b = x + 1 - a
+    c = 1.0 / _FPMIN
+    d = 1.0 / b
+    h = d
+    for i in range(1, _ITMAX + 1):
+        an = -i * (i - a)
+        b += 2
+        d = an * d + b
+        if abs(d) < _FPMIN:
+            d = _FPMIN
+        c = b + an / c
+        if abs(c) < _FPMIN:
+            c = _FPMIN
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < _EPS:
+            break
+    return math.exp(-x + a * math.log(x) - gln) * h
+
+
+def regularized_gamma_p(a: float, x: float) -> float:
+    """Regularised lower incomplete gamma function P(a, x).
+
+    Args:
+        a: Shape parameter; must be > 0.
+        x: Upper integration bound; must be >= 0.
+
+    Returns:
+        P(a, x) in [0, 1].
+
+    Raises:
+        ValueError: If ``a`` <= 0 or ``x`` < 0.
+    """
+    if a <= 0:
+        raise ValueError(f"a must be > 0, got {a}")
+    if x < 0:
+        raise ValueError(f"x must be >= 0, got {x}")
+    if x == 0:
+        return 0.0
+    if x < a + 1:
+        return _gamma_series(a, x)
+    return 1.0 - _gamma_cf(a, x)
+
+
+def chi2_cdf(x: float, df: int) -> float:
+    """Cumulative distribution function P(X <= x) for chi-square(df).
+
+    Args:
+        x: Observed chi-square statistic; must be >= 0.
+        df: Degrees of freedom; must be >= 1.
+
+    Returns:
+        P(X <= x), the regularised lower incomplete gamma P(df/2, x/2).
+
+    Raises:
+        ValueError: If ``df`` < 1 or ``x`` < 0.
+    """
+    if df < 1:
+        raise ValueError(f"df must be >= 1, got {df}")
+    return regularized_gamma_p(df / 2, x / 2)
+
+
+def chi2_sf(x: float, df: int) -> float:
+    """Survival function (upper tail p-value) for chi-square(df).
+
+    Args:
+        x: Observed chi-square statistic; must be >= 0.
+        df: Degrees of freedom; must be >= 1.
+
+    Returns:
+        P(X > x) = 1 - chi2_cdf(x, df), clipped to [0, 1].
+    """
+    return max(0.0, min(1.0, 1.0 - chi2_cdf(x, df)))
+
+
+# ---------------------------------------------------------------------------
+# Result containers
+# ---------------------------------------------------------------------------
+
+
+class GofResult:
+    """Result of a chi-square goodness-of-fit test."""
+
+    def __init__(
+        self,
+        statistic: float,
+        df: int,
+        p_value: float,
+        contributions: list[float],
+        observed: list[float],
+        expected: list[float],
+        alpha: float,
+    ) -> None:
+        """Store all computed quantities."""
+        self.statistic = statistic
+        self.df = df
+        self.p_value = p_value
+        self.contributions = contributions
+        self.observed = observed
+        self.expected = expected
+        self.alpha = alpha
+
+
+class IndependenceResult:
+    """Result of a chi-square test of independence."""
+
+    def __init__(
+        self,
+        statistic: float,
+        df: int,
+        p_value: float,
+        contributions: list[list[float]],
+        expected: list[list[float]],
+        table: list[list[float]],
+        alpha: float,
+    ) -> None:
+        """Store all computed quantities."""
+        self.statistic = statistic
+        self.df = df
+        self.p_value = p_value
+        self.contributions = contributions
+        self.expected = expected
+        self.table = table
+        self.alpha = alpha
+
+
+# ---------------------------------------------------------------------------
+# Core statistical functions
+# ---------------------------------------------------------------------------
+
+
+def chisq_gof(
+    observed: Sequence[float], expected: Sequence[float], alpha: float = 0.05
+) -> GofResult:
+    """Perform a chi-square goodness-of-fit test.
+
+    Tests H₀: the observed frequencies follow the given expected distribution.
+
+    Args:
+        observed: Observed category counts/frequencies (non-negative).
+        expected: Expected category counts/frequencies (strictly positive).
+        alpha: Significance level (default 0.05).
+
+    Returns:
+        :class:`GofResult` with statistic, df, p-value, and per-cell contributions.
+
+    Raises:
+        ValueError: If lengths mismatch, fewer than 2 categories, any observed
+            value is negative, or any expected value is not strictly positive.
+    """
+    if len(observed) != len(expected):
+        raise ValueError(
+            f"observed and expected must have the same length, "
+            f"got {len(observed)} and {len(expected)}"
+        )
+    if len(observed) < 2:
+        raise ValueError(f"need at least 2 categories, got {len(observed)}")
+    if any(o < 0 for o in observed):
+        raise ValueError("observed values must be non-negative")
+    if any(e <= 0 for e in expected):
+        raise ValueError("expected values must be strictly positive")
+    if not (0 < alpha < 1):
+        raise ValueError(f"alpha must be in (0, 1), got {alpha}")
+
+    contributions = [(o - e) ** 2 / e for o, e in zip(observed, expected)]
+    statistic = sum(contributions)
+    df = len(observed) - 1
+    p_value = chi2_sf(statistic, df)
+
+    return GofResult(
+        statistic=statistic,
+        df=df,
+        p_value=p_value,
+        contributions=contributions,
+        observed=list(observed),
+        expected=list(expected),
+        alpha=alpha,
+    )
+
+
+def chisq_independence(
+    table: Sequence[Sequence[float]], alpha: float = 0.05
+) -> IndependenceResult:
+    """Perform a chi-square test of independence on a contingency table.
+
+    Tests H₀: the row and column categorical variables are independent.
+
+    Args:
+        table: Rows of observed cell counts/frequencies (non-negative);
+            at least 2 rows and 2 columns, each row the same length.
+        alpha: Significance level (default 0.05).
+
+    Returns:
+        :class:`IndependenceResult` with statistic, df, p-value, expected
+        cell values, and per-cell contributions.
+
+    Raises:
+        ValueError: If the table has fewer than 2 rows/columns, ragged rows,
+            negative values, or a zero row/column total (expected cell = 0).
+    """
+    if len(table) < 2:
+        raise ValueError(f"need at least 2 rows, got {len(table)}")
+    ncols = len(table[0])
+    if ncols < 2:
+        raise ValueError(f"need at least 2 columns, got {ncols}")
+    if any(len(row) != ncols for row in table):
+        raise ValueError("all rows must have the same number of columns")
+    if any(v < 0 for row in table for v in row):
+        raise ValueError("table values must be non-negative")
+
+    row_totals = [sum(row) for row in table]
+    col_totals = [sum(row[j] for row in table) for j in range(ncols)]
+    grand_total = sum(row_totals)
+    if grand_total <= 0:
+        raise ValueError("grand total of table must be positive")
+    if any(rt <= 0 for rt in row_totals) or any(ct <= 0 for ct in col_totals):
+        raise ValueError("every row and column total must be positive")
+    if not (0 < alpha < 1):
+        raise ValueError(f"alpha must be in (0, 1), got {alpha}")
+
+    expected = [
+        [row_totals[i] * col_totals[j] / grand_total for j in range(ncols)]
+        for i in range(len(table))
+    ]
+    contributions = [
+        [(table[i][j] - expected[i][j]) ** 2 / expected[i][j] for j in range(ncols)]
+        for i in range(len(table))
+    ]
+    statistic = sum(sum(row) for row in contributions)
+    df = (len(table) - 1) * (ncols - 1)
+    p_value = chi2_sf(statistic, df)
+
+    return IndependenceResult(
+        statistic=statistic,
+        df=df,
+        p_value=p_value,
+        contributions=contributions,
+        expected=expected,
+        table=[list(row) for row in table],
+        alpha=alpha,
+    )
+
+
+def parse_number_list(raw: str) -> list[float]:
+    """Parse a comma-separated string of finite numbers.
+
+    Args:
+        raw: Comma-separated numeric string (e.g. ``"18,22,17"``).
+
+    Returns:
+        List of parsed floats.
+
+    Raises:
+        ValueError: If the string is empty, non-numeric, or contains non-finite values.
+    """
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    if not parts:
+        raise ValueError("at least one value is required")
+    values = [float(p) for p in parts]
+    if any(not math.isfinite(v) for v in values):
+        raise ValueError("all values must be finite")
+    return values
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and return the argument parser namespace.
+
+    Args:
+        argv: Argument list (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        Parsed :class:`argparse.Namespace`.
+    """
+    parser = argparse.ArgumentParser(
+        description="Chi-square test calculator (goodness-of-fit, independence).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  chisq --test gof --observed 18,22,17,25,19,19 --expected 20,20,20,20,20,20
+  chisq --test independence --table "40,30,20" --table "25,45,30"
+  chisq --test gof --observed 52,48 --expected 50,50 --alpha 0.10
+""",
+    )
+    parser.add_argument(
+        "--test",
+        choices=["gof", "independence"],
+        required=True,
+        help="test type: 'gof' (goodness-of-fit) or 'independence' (contingency table)",
+    )
+    parser.add_argument(
+        "--observed",
+        type=str,
+        metavar="O1,O2,...",
+        help="comma-separated observed frequencies (gof mode)",
+    )
+    parser.add_argument(
+        "--expected",
+        type=str,
+        metavar="E1,E2,...",
+        help="comma-separated expected frequencies (gof mode)",
+    )
+    parser.add_argument(
+        "--table",
+        action="append",
+        type=str,
+        metavar="R1,R2,...",
+        help="one contingency table row of comma-separated values; "
+        "repeat --table once per row (independence mode)",
+    )
+    parser.add_argument(
+        "--alpha",
+        "-a",
+        type=float,
+        default=0.05,
+        metavar="ALPHA",
+        help="significance level (default: 0.05)",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=4,
+        metavar="PREC",
+        help="decimal places for output (default: 4)",
+    )
+    return parser.parse_args(argv)
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Return an error message string, or ``None`` if arguments are valid.
+
+    Args:
+        args: Parsed argument namespace from :func:`parse_args`.
+
+    Returns:
+        Error description string, or ``None`` when validation passes.
+    """
+    if not (0 < args.alpha < 1):
+        return f"--alpha must be in (0, 1), got {args.alpha}"
+    if args.precision < 0:
+        return "--precision must be non-negative"
+
+    if args.test == "gof":
+        if args.observed is None or args.expected is None:
+            return "--test gof requires both --observed and --expected"
+        if args.table is not None:
+            return "--table is not used with --test gof"
+        return None
+
+    # independence
+    if args.table is None or len(args.table) < 2:
+        return "--test independence requires at least two --table rows"
+    if args.observed is not None or args.expected is not None:
+        return "--observed/--expected are not used with --test independence"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(value: float, precision: int) -> str:
+    """Format a float to the requested number of decimal places."""
+    return f"{value:.{precision}f}"
+
+
+def _decision(p_value: float, alpha: float) -> str:
+    """Return reject / fail-to-reject decision string."""
+    if p_value < alpha:
+        return f"Reject H₀  (p < α = {alpha})"
+    return f"Fail to reject H₀  (p ≥ α = {alpha})"
+
+
+def format_gof(result: GofResult, precision: int) -> str:
+    """Format a goodness-of-fit result for display.
+
+    Args:
+        result: Computed :class:`GofResult`.
+        precision: Decimal places for all floating-point output.
+
+    Returns:
+        Multi-line string ready to print.
+    """
+    f = lambda v: _fmt(v, precision)  # noqa: E731
+    lines = [
+        "Chi-square goodness-of-fit test",
+        "H₀: observed frequencies match the expected distribution",
+        "",
+        f"  {'category':>10}  {'observed':>10}  {'expected':>10}  {'χ² contrib':>12}",
+    ]
+    for i, (o, e, c) in enumerate(
+        zip(result.observed, result.expected, result.contributions), start=1
+    ):
+        lines.append(f"  {i:>10}  {f(o):>10}  {f(e):>10}  {f(c):>12}")
+    lines += [
+        "",
+        f"  χ² statistic:  {f(result.statistic)}",
+        f"  df:            {result.df}",
+        f"  p-value:       {f(result.p_value)}",
+        "",
+        f"  {_decision(result.p_value, result.alpha)}",
+    ]
+    return "\n".join(lines)
+
+
+def format_independence(result: IndependenceResult, precision: int) -> str:
+    """Format an independence test result for display.
+
+    Args:
+        result: Computed :class:`IndependenceResult`.
+        precision: Decimal places for all floating-point output.
+
+    Returns:
+        Multi-line string ready to print.
+    """
+    f = lambda v: _fmt(v, precision)  # noqa: E731
+    lines = [
+        "Chi-square test of independence",
+        "H₀: the row and column variables are independent",
+        "",
+        "  Observed:",
+    ]
+    for row in result.table:
+        lines.append("    " + "  ".join(f"{f(v):>10}" for v in row))
+    lines.append("")
+    lines.append("  Expected:")
+    for row in result.expected:
+        lines.append("    " + "  ".join(f"{f(v):>10}" for v in row))
+    lines += [
+        "",
+        f"  χ² statistic:  {f(result.statistic)}",
+        f"  df:            {result.df}",
+        f"  p-value:       {f(result.p_value)}",
+        "",
+        f"  {_decision(result.p_value, result.alpha)}",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the chi-square test CLI.
+
+    Args:
+        argv: Argument list override for testing (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        0 on success, 2 on input or computation error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        if args.test == "gof":
+            observed = parse_number_list(args.observed)
+            expected = parse_number_list(args.expected)
+            result_gof = chisq_gof(observed, expected, args.alpha)
+            print(format_gof(result_gof, args.precision))
+        else:
+            table = [parse_number_list(row) for row in args.table]
+            result_ind = chisq_independence(table, args.alpha)
+            print(format_independence(result_ind, args.precision))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/geometric_distribution.py
+++ b/src/utils/geometric_distribution.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Command-line utility for the geometric distribution.
+
+Models the number of independent Bernoulli trials until the first success
+(support k = 1, 2, 3, ...).  Pure Python via ``math`` — no external
+dependencies.
+
+Usage examples:
+  geometric -k 5 -p 0.3
+  geometric -k 10 -p 0.2 --survival
+  geometric -p 0.25 --table 1 15
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def geo_pmf(k: int, p: float) -> float:
+    """Probability mass function P(X = k) for Geometric(p).
+
+    Args:
+        k: Trial number of the first success; must be >= 1.
+        p: Success probability per trial; must be in (0, 1].
+
+    Returns:
+        P(X = k) = (1 - p)^(k - 1) * p.
+
+    Raises:
+        ValueError: If ``k`` < 1 or ``p`` is not in (0, 1].
+    """
+    _validate_k(k)
+    _validate_p(p)
+    return ((1 - p) ** (k - 1)) * p
+
+
+def geo_cdf(k: int, p: float) -> float:
+    """Cumulative distribution function P(X <= k) for Geometric(p).
+
+    Args:
+        k: Trial number; values < 1 yield 0.0.
+        p: Success probability per trial; must be in (0, 1].
+
+    Returns:
+        P(X <= k) = 1 - (1 - p)^k, clipped to [0, 1].
+
+    Raises:
+        ValueError: If ``p`` is not in (0, 1].
+    """
+    _validate_p(p)
+    if k < 1:
+        return 0.0
+    return max(0.0, min(1.0, 1 - (1 - p) ** k))
+
+
+def geo_survival(k: int, p: float) -> float:
+    """Survival function P(X > k) for Geometric(p).
+
+    Args:
+        k: Trial number; values < 0 yield 1.0.
+        p: Success probability per trial; must be in (0, 1].
+
+    Returns:
+        P(X > k) = (1 - p)^k, clipped to [0, 1].
+
+    Raises:
+        ValueError: If ``p`` is not in (0, 1].
+    """
+    _validate_p(p)
+    if k < 0:
+        return 1.0
+    return max(0.0, min(1.0, (1 - p) ** k))
+
+
+def geo_mean(p: float) -> float:
+    """Expected number of trials until the first success.
+
+    Args:
+        p: Success probability per trial; must be in (0, 1].
+
+    Returns:
+        Mean = 1 / p.
+
+    Raises:
+        ValueError: If ``p`` is not in (0, 1].
+    """
+    _validate_p(p)
+    return 1 / p
+
+
+def geo_variance(p: float) -> float:
+    """Variance of the number of trials until the first success.
+
+    Args:
+        p: Success probability per trial; must be in (0, 1].
+
+    Returns:
+        Variance = (1 - p) / p^2.
+
+    Raises:
+        ValueError: If ``p`` is not in (0, 1].
+    """
+    _validate_p(p)
+    return (1 - p) / (p**2)
+
+
+def _validate_k(k: int) -> None:
+    """Raise if ``k`` is not a valid trial number (>= 1)."""
+    if k < 1:
+        raise ValueError(f"k must be >= 1, got {k}")
+
+
+def _validate_p(p: float) -> None:
+    """Raise if ``p`` is not a valid success probability in (0, 1]."""
+    if not (0 < p <= 1):
+        raise ValueError(f"p must be in (0, 1], got {p}")
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and return the argument parser namespace.
+
+    Args:
+        argv: Argument list (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        Parsed :class:`argparse.Namespace`.
+    """
+    parser = argparse.ArgumentParser(
+        description="Geometric distribution calculator (trials until first success).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  geometric -k 5 -p 0.3
+  geometric -k 10 -p 0.2 --survival
+  geometric -p 0.25 --table 1 15
+""",
+    )
+    parser.add_argument(
+        "-k",
+        type=int,
+        default=None,
+        metavar="INT",
+        help="trial number of the first success (required unless --table is used)",
+    )
+    parser.add_argument(
+        "-p",
+        type=float,
+        required=True,
+        metavar="F",
+        help="success probability per trial, in (0, 1]",
+    )
+    parser.add_argument(
+        "--survival",
+        action="store_true",
+        help="report P(X > k) instead of the cumulative P(X <= k)",
+    )
+    parser.add_argument(
+        "--table",
+        type=int,
+        nargs=2,
+        default=None,
+        metavar=("MIN", "MAX"),
+        help="print PMF/CDF/survival for k = MIN..MAX instead of a single report",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=4,
+        metavar="PREC",
+        help="decimal places for output (default: 4)",
+    )
+    return parser.parse_args(argv)
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Return an error message string, or ``None`` if arguments are valid.
+
+    Args:
+        args: Parsed argument namespace from :func:`parse_args`.
+
+    Returns:
+        Error description string, or ``None`` when validation passes.
+    """
+    if not (0 < args.p <= 1):
+        return f"-p must be in (0, 1], got {args.p}"
+    if args.precision < 0:
+        return "--precision must be non-negative"
+
+    if args.table is not None:
+        min_k, max_k = args.table
+        if min_k < 1:
+            return f"--table MIN must be >= 1, got {min_k}"
+        if max_k < min_k:
+            return f"--table MAX must be >= MIN, got MIN={min_k}, MAX={max_k}"
+        return None
+
+    if args.k is None:
+        return "-k is required unless --table is used"
+    if args.k < 1:
+        return f"-k must be >= 1, got {args.k}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(value: float, precision: int) -> str:
+    """Format a float to the requested number of decimal places."""
+    return f"{value:.{precision}f}"
+
+
+def format_single(k: int, p: float, survival: bool, precision: int) -> str:
+    """Format a single-k geometric distribution report.
+
+    Args:
+        k: Trial number of the first success.
+        p: Success probability per trial.
+        survival: If True, report P(X > k) instead of P(X <= k).
+        precision: Decimal places for all floating-point output.
+
+    Returns:
+        Multi-line string ready to print.
+    """
+    f = lambda v: _fmt(v, precision)  # noqa: E731
+    lines = [
+        f"Geometric distribution  (p={f(p)})",
+        "",
+        f"  PMF  P(X = {k}):  {f(geo_pmf(k, p))}",
+    ]
+    if survival:
+        lines.append(f"  P(X > {k}):        {f(geo_survival(k, p))}")
+    else:
+        lines.append(f"  CDF  P(X <= {k}):  {f(geo_cdf(k, p))}")
+    lines += [
+        "",
+        f"  mean:      {f(geo_mean(p))}",
+        f"  variance:  {f(geo_variance(p))}",
+    ]
+    return "\n".join(lines)
+
+
+def format_table(
+    min_k: int, max_k: int, p: float, survival: bool, precision: int
+) -> str:
+    """Format a PMF/CDF-or-survival table for k = min_k..max_k.
+
+    Args:
+        min_k: First trial number in the table (>= 1).
+        max_k: Last trial number in the table (>= min_k).
+        p: Success probability per trial.
+        survival: If True, show P(X > k) instead of P(X <= k).
+        precision: Decimal places for all floating-point output.
+
+    Returns:
+        Multi-line string ready to print.
+    """
+    f = lambda v: _fmt(v, precision)  # noqa: E731
+    third_header = "P(X > k)" if survival else "P(X <= k)"
+    lines = [
+        f"Geometric distribution  (p={f(p)})",
+        "",
+        f"  {'k':>4}  {'PMF':>10}  {third_header:>10}",
+    ]
+    for k in range(min_k, max_k + 1):
+        third = geo_survival(k, p) if survival else geo_cdf(k, p)
+        lines.append(f"  {k:>4}  {f(geo_pmf(k, p)):>10}  {f(third):>10}")
+    lines += [
+        "",
+        f"  mean:      {f(geo_mean(p))}",
+        f"  variance:  {f(geo_variance(p))}",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the geometric distribution CLI.
+
+    Args:
+        argv: Argument list override for testing (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        0 on success, 2 on input or computation error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        if args.table is not None:
+            min_k, max_k = args.table
+            print(format_table(min_k, max_k, args.p, args.survival, args.precision))
+        else:
+            print(format_single(args.k, args.p, args.survival, args.precision))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_anova.py
+++ b/tests/test_anova.py
@@ -1,0 +1,685 @@
+"""Tests for the one-way ANOVA utility."""
+
+import argparse
+import json
+import math
+
+import pytest
+
+import src.utils.anova as anova_module
+from src.utils.anova import (
+    anova_one_way,
+    bonferroni,
+    f_cdf,
+    f_sf,
+    format_json,
+    format_table,
+    main,
+    parse_number_list,
+    read_csv_groups,
+    regularized_incomplete_beta,
+    studentized_range_cdf,
+    studentized_range_ppf,
+    studentized_range_sf,
+    t_sf_two_sided,
+    tukey_hsd,
+    validate,
+)
+
+G1 = [12.1, 11.8, 12.5, 11.9]
+G2 = [9.8, 10.3, 10.1, 9.7]
+G3 = [15.2, 14.9, 15.5, 16.0]
+
+# ---------------------------------------------------------------------------
+# regularized_incomplete_beta / f_cdf / f_sf / t_sf_two_sided
+# ---------------------------------------------------------------------------
+
+
+def test_regularized_incomplete_beta_endpoints():
+    assert regularized_incomplete_beta(0.0, 2.0, 3.0) == 0.0
+    assert regularized_incomplete_beta(1.0, 2.0, 3.0) == 1.0
+
+
+def test_regularized_incomplete_beta_series_and_symmetric_branches():
+    # x < (a+1)/(a+b+2) triggers the direct branch; the complementary
+    # region (x closer to 1) exercises the symmetry-transformed branch.
+    lo = regularized_incomplete_beta(0.1, 2.0, 5.0)
+    hi = regularized_incomplete_beta(0.9, 2.0, 5.0)
+    assert 0.0 <= lo <= 1.0
+    assert 0.0 <= hi <= 1.0
+
+
+def test_regularized_incomplete_beta_bounds_error():
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        regularized_incomplete_beta(-0.1, 1.0, 1.0)
+
+
+def test_regularized_incomplete_beta_shape_error():
+    with pytest.raises(ValueError, match="a and b must be"):
+        regularized_incomplete_beta(0.5, 0.0, 1.0)
+
+
+def test_beta_cf_fpmin_guards_hit(monkeypatch):
+    """Force the near-zero denominator safety branches in the continued fraction."""
+    monkeypatch.setattr(anova_module, "_FPMIN", 1e5)
+    result = anova_module._beta_cf(2.0, 5.0, 0.1)
+    assert math.isfinite(result)
+
+
+def test_f_cdf_matches_scipy_oracle():
+    scipy_stats = pytest.importorskip("scipy.stats")
+    for d1 in (1, 2, 5, 20):
+        for d2 in (1, 5, 30, 100):
+            for x in (0.1, 1.0, 5.0, 20.0):
+                got = f_cdf(x, d1, d2)
+                want = scipy_stats.f.cdf(x, d1, d2)
+                assert got == pytest.approx(want, abs=1e-7)
+
+
+def test_f_cdf_zero_is_zero():
+    assert f_cdf(0.0, 2, 5) == 0.0
+
+
+def test_f_cdf_infinite_is_one():
+    assert f_cdf(math.inf, 2, 5) == 1.0
+
+
+def test_f_cdf_invalid_df_raises():
+    with pytest.raises(ValueError, match="df1 and df2"):
+        f_cdf(1.0, 0, 5)
+
+
+def test_f_cdf_negative_f_raises():
+    with pytest.raises(ValueError, match="f_stat must be"):
+        f_cdf(-1.0, 2, 5)
+
+
+def test_f_sf_complements_cdf():
+    assert f_cdf(3.0, 2, 10) + f_sf(3.0, 2, 10) == pytest.approx(1.0)
+
+
+def test_t_sf_two_sided_matches_scipy_oracle():
+    scipy_stats = pytest.importorskip("scipy.stats")
+    for df in (1, 2, 10, 50, 200):
+        for t in (0.0, 0.5, 1.0, 2.5, 5.0):
+            got = t_sf_two_sided(t, df)
+            want = 2 * scipy_stats.t.sf(abs(t), df)
+            assert got == pytest.approx(want, abs=1e-7)
+
+
+def test_t_sf_two_sided_zero_t_is_one():
+    assert t_sf_two_sided(0.0, 10) == 1.0
+
+
+def test_t_sf_two_sided_invalid_df_raises():
+    with pytest.raises(ValueError, match="df must be > 0"):
+        t_sf_two_sided(1.0, 0)
+
+
+# ---------------------------------------------------------------------------
+# anova_one_way
+# ---------------------------------------------------------------------------
+
+
+def test_anova_one_way_matches_scipy_oracle():
+    scipy_stats = pytest.importorskip("scipy.stats")
+    result = anova_one_way([G1, G2, G3])
+    want = scipy_stats.f_oneway(G1, G2, G3)
+    assert result.f_stat == pytest.approx(want.statistic)
+    assert result.p_value == pytest.approx(want.pvalue)
+    assert result.df_between == 2
+    assert result.df_within == 9
+
+
+def test_anova_one_way_group_means():
+    result = anova_one_way([G1, G2, G3])
+    assert result.group_means[0] == pytest.approx(sum(G1) / len(G1))
+    assert result.group_sizes == [4, 4, 4]
+
+
+def test_anova_one_way_too_few_groups_raises():
+    with pytest.raises(ValueError, match="at least 2 groups"):
+        anova_one_way([G1])
+
+
+def test_anova_one_way_empty_group_raises():
+    with pytest.raises(ValueError, match="at least 1 observation"):
+        anova_one_way([G1, []])
+
+
+def test_anova_one_way_insufficient_df_within_raises():
+    with pytest.raises(ValueError, match="df_within"):
+        anova_one_way([[1.0], [2.0]])
+
+
+def test_anova_one_way_invalid_alpha_raises():
+    with pytest.raises(ValueError, match="alpha must be"):
+        anova_one_way([G1, G2], alpha=1.5)
+
+
+def test_anova_one_way_zero_within_variance_equal_means():
+    result = anova_one_way([[5.0, 5.0], [5.0, 5.0]])
+    assert result.f_stat == 0.0
+    assert result.p_value == 1.0
+
+
+def test_anova_one_way_zero_within_variance_different_means():
+    result = anova_one_way([[1.0, 1.0], [5.0, 5.0]])
+    assert math.isinf(result.f_stat)
+    assert result.p_value == 0.0
+
+
+# ---------------------------------------------------------------------------
+# bonferroni
+# ---------------------------------------------------------------------------
+
+
+def test_bonferroni_pair_count():
+    result = anova_one_way([G1, G2, G3])
+    comparisons = bonferroni([G1, G2, G3], result)
+    assert len(comparisons) == 3  # C(3, 2)
+
+
+def test_bonferroni_matches_manual_two_group_case():
+    groups = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+    result = anova_one_way(groups)
+    comparisons = bonferroni(groups, result)
+    assert len(comparisons) == 1
+    c = comparisons[0]
+    # For 2 groups, t^2 == F
+    assert c.t_stat**2 == pytest.approx(result.f_stat)
+    assert c.p_adj == pytest.approx(c.p_raw)  # single comparison, no correction
+
+
+def test_bonferroni_adjusted_pvalue_capped_at_one():
+    groups = [[1.0, 1.1, 0.9], [1.05, 0.95, 1.0], [1.02, 0.98, 1.0]]
+    result = anova_one_way(groups)
+    comparisons = bonferroni(groups, result)
+    assert all(0.0 <= c.p_adj <= 1.0 for c in comparisons)
+
+
+def test_bonferroni_zero_se_equal_means():
+    # All groups have zero within-group variance, so ms_within == 0 and se == 0
+    # for every pair; groups 0 and 1 additionally share the same mean.
+    groups = [[5.0, 5.0], [5.0, 5.0], [3.0, 3.0]]
+    result = anova_one_way(groups)
+    comparisons = bonferroni(groups, result)
+    zero_se_pair = next(c for c in comparisons if c.i == 0 and c.j == 1)
+    assert zero_se_pair.t_stat == 0.0
+    assert zero_se_pair.p_raw == 1.0
+
+
+def test_bonferroni_zero_se_different_means():
+    groups = [[1.0, 1.0], [9.0, 9.0], [3.0, 3.0]]
+    result = anova_one_way(groups)
+    comparisons = bonferroni(groups, result)
+    pair = next(c for c in comparisons if c.i == 0 and c.j == 1)
+    assert math.isinf(pair.t_stat)
+    assert pair.p_raw == 0.0
+
+
+def test_bonferroni_invalid_alpha_raises():
+    result = anova_one_way([G1, G2])
+    with pytest.raises(ValueError, match="alpha must be"):
+        bonferroni([G1, G2], result, alpha=0.0)
+
+
+def test_bonferroni_significance_flag():
+    result = anova_one_way([G1, G2, G3])
+    comparisons = bonferroni([G1, G2, G3], result)
+    assert all(c.significant for c in comparisons)
+
+
+# ---------------------------------------------------------------------------
+# _simpson / _range_cdf_known_variance (private numerical helpers)
+# ---------------------------------------------------------------------------
+
+
+def test_simpson_empty_interval_is_zero():
+    assert anova_module._simpson(lambda x: x, 5.0, 5.0, 10) == 0.0
+    assert anova_module._simpson(lambda x: x, 5.0, 2.0, 10) == 0.0
+
+
+def test_simpson_odd_n_rounds_up():
+    # n=3 (odd) should be bumped to 4 internally without raising.
+    result = anova_module._simpson(lambda x: x * x, 0.0, 1.0, 3)
+    assert result == pytest.approx(1.0 / 3.0, abs=1e-6)
+
+
+def test_range_cdf_known_variance_non_positive_x_is_zero():
+    assert anova_module._range_cdf_known_variance(0.0, 3) == 0.0
+    assert anova_module._range_cdf_known_variance(-1.0, 3) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# studentized_range_cdf / studentized_range_sf / studentized_range_ppf
+# ---------------------------------------------------------------------------
+
+
+def test_studentized_range_cdf_matches_scipy_oracle():
+    scipy_stats = pytest.importorskip("scipy.stats")
+    cases = [
+        (3.5, 3, 10),
+        (2.5, 4, 20),
+        (4.0, 5, 8),
+        (3.0, 3, 200),
+        (2.0, 6, 30),
+        (3.0, 2, 5),
+        (2.5, 3, 1),
+        (1.5, 8, 15),
+        (4.5, 10, 50),
+    ]
+    for q, k, df in cases:
+        got = studentized_range_cdf(q, k, df)
+        want = scipy_stats.studentized_range.cdf(q, k, df)
+        assert got == pytest.approx(want, abs=1e-6)
+
+
+def test_studentized_range_cdf_zero_q_is_zero():
+    assert studentized_range_cdf(0.0, 3, 10) == 0.0
+
+
+def test_studentized_range_cdf_invalid_k_raises():
+    with pytest.raises(ValueError, match="k must be >= 2"):
+        studentized_range_cdf(1.0, 1, 10)
+
+
+def test_studentized_range_cdf_invalid_df_raises():
+    with pytest.raises(ValueError, match="df must be >= 1"):
+        studentized_range_cdf(1.0, 3, 0)
+
+
+def test_studentized_range_cdf_negative_q_raises():
+    with pytest.raises(ValueError, match="q must be >= 0"):
+        studentized_range_cdf(-1.0, 3, 10)
+
+
+def test_studentized_range_sf_complements_cdf():
+    total = studentized_range_cdf(3.0, 3, 10) + studentized_range_sf(3.0, 3, 10)
+    assert total == pytest.approx(1.0)
+
+
+def test_studentized_range_ppf_matches_scipy_oracle():
+    scipy_stats = pytest.importorskip("scipy.stats")
+    for k, df in [(3, 10), (4, 20), (2, 5)]:
+        got = studentized_range_ppf(0.95, k, df)
+        want = scipy_stats.studentized_range.ppf(0.95, k, df)
+        assert got == pytest.approx(want, abs=1e-4)
+
+
+def test_studentized_range_ppf_roundtrips_cdf():
+    q = studentized_range_ppf(0.9, 4, 15)
+    assert studentized_range_cdf(q, 4, 15) == pytest.approx(0.9, abs=1e-4)
+
+
+def test_studentized_range_ppf_invalid_p_raises():
+    with pytest.raises(ValueError, match="p must be in"):
+        studentized_range_ppf(0.0, 3, 10)
+    with pytest.raises(ValueError, match="p must be in"):
+        studentized_range_ppf(1.0, 3, 10)
+
+
+# ---------------------------------------------------------------------------
+# tukey_hsd
+# ---------------------------------------------------------------------------
+
+
+def test_tukey_hsd_matches_scipy_oracle():
+    scipy_stats = pytest.importorskip("scipy.stats")
+    result = anova_one_way([G1, G2, G3])
+    tukey_result = tukey_hsd([G1, G2, G3], result)
+    want = scipy_stats.tukey_hsd(G1, G2, G3)
+    for c in tukey_result.comparisons:
+        assert c.p_value == pytest.approx(want.pvalue[c.i][c.j], abs=1e-6)
+
+
+def test_tukey_hsd_pair_count():
+    result = anova_one_way([G1, G2, G3])
+    tukey_result = tukey_hsd([G1, G2, G3], result)
+    assert len(tukey_result.comparisons) == 3
+
+
+def test_tukey_hsd_two_group_matches_t_test():
+    # For k=2, the Tukey p-value equals the pooled two-sided t-test p-value.
+    groups = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+    result = anova_one_way(groups)
+    tukey_result = tukey_hsd(groups, result)
+    n_i, n_j = result.group_sizes[0], result.group_sizes[1]
+    se = math.sqrt(result.ms_within * (1 / n_i + 1 / n_j))
+    t_stat = (result.group_means[0] - result.group_means[1]) / se
+    want_p = t_sf_two_sided(t_stat, result.df_within)
+    assert tukey_result.comparisons[0].p_value == pytest.approx(want_p, abs=1e-6)
+
+
+def test_tukey_hsd_invalid_alpha_raises():
+    result = anova_one_way([G1, G2])
+    with pytest.raises(ValueError, match="alpha must be"):
+        tukey_hsd([G1, G2], result, alpha=0.0)
+
+
+def test_tukey_hsd_zero_se_equal_means():
+    groups = [[5.0, 5.0], [5.0, 5.0], [3.0, 3.0]]
+    result = anova_one_way(groups)
+    tukey_result = tukey_hsd(groups, result)
+    pair = next(c for c in tukey_result.comparisons if c.i == 0 and c.j == 1)
+    assert pair.q_stat == 0.0
+    assert pair.p_value == 1.0
+
+
+def test_tukey_hsd_zero_se_different_means():
+    groups = [[1.0, 1.0], [9.0, 9.0], [3.0, 3.0]]
+    result = anova_one_way(groups)
+    tukey_result = tukey_hsd(groups, result)
+    pair = next(c for c in tukey_result.comparisons if c.i == 0 and c.j == 1)
+    assert math.isinf(pair.q_stat)
+    assert pair.p_value == 0.0
+
+
+def test_tukey_hsd_significance_flag():
+    result = anova_one_way([G1, G2, G3])
+    tukey_result = tukey_hsd([G1, G2, G3], result)
+    assert all(c.significant for c in tukey_result.comparisons)
+
+
+# ---------------------------------------------------------------------------
+# read_csv_groups
+# ---------------------------------------------------------------------------
+
+
+def test_read_csv_groups_basic(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text(
+        "treatment,response\nA,1.0\nA,2.0\nB,3.0\nB,4.0\n", encoding="utf-8"
+    )
+    groups = read_csv_groups(str(csv_path), "treatment", "response")
+    assert groups == {"A": [1.0, 2.0], "B": [3.0, 4.0]}
+
+
+def test_read_csv_groups_missing_column_raises(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("group,val\nA,1.0\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="must contain columns"):
+        read_csv_groups(str(csv_path), "treatment", "response")
+
+
+def test_read_csv_groups_non_numeric_value_raises(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("treatment,response\nA,oops\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="non-numeric"):
+        read_csv_groups(str(csv_path), "treatment", "response")
+
+
+def test_read_csv_groups_non_finite_value_raises(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("treatment,response\nA,nan\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="non-finite"):
+        read_csv_groups(str(csv_path), "treatment", "response")
+
+
+# ---------------------------------------------------------------------------
+# parse_number_list
+# ---------------------------------------------------------------------------
+
+
+def test_parse_number_list_basic():
+    assert parse_number_list("1,2.5,3") == [1.0, 2.5, 3.0]
+
+
+def test_parse_number_list_empty_raises():
+    with pytest.raises(ValueError, match="at least one value"):
+        parse_number_list("")
+
+
+def test_parse_number_list_non_finite_raises():
+    with pytest.raises(ValueError, match="finite"):
+        parse_number_list("1,inf,3")
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def _ns(**kwargs):
+    defaults = dict(
+        data=None,
+        file=None,
+        group_col=None,
+        value_col=None,
+        alpha=0.05,
+        posthoc="none",
+        format="table",
+        precision=4,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def test_validate_alpha_out_of_range():
+    assert "--alpha" in validate(_ns(alpha=0.0))
+
+
+def test_validate_precision_negative():
+    assert "--precision" in validate(_ns(precision=-1))
+
+
+def test_validate_no_input_source():
+    assert "provide either" in validate(_ns())
+
+
+def test_validate_both_input_sources():
+    assert "not both" in validate(
+        _ns(data=["1,2", "3,4"], file="x.csv", group_col="g", value_col="v")
+    )
+
+
+def test_validate_data_too_few_groups():
+    assert "at least 2 groups" in validate(_ns(data=["1,2,3"]))
+
+
+def test_validate_file_missing_columns():
+    assert "requires both" in validate(_ns(file="x.csv"))
+
+
+def test_validate_valid_data_tukey():
+    assert validate(_ns(data=["1,2", "3,4"], posthoc="tukey")) is None
+
+
+def test_validate_valid_data():
+    assert validate(_ns(data=["1,2", "3,4"])) is None
+
+
+def test_validate_valid_file():
+    assert validate(_ns(file="x.csv", group_col="g", value_col="v")) is None
+
+
+# ---------------------------------------------------------------------------
+# format_table / format_json
+# ---------------------------------------------------------------------------
+
+
+def test_format_table_no_posthoc():
+    result = anova_one_way([G1, G2, G3])
+    out = format_table(result, "none", None, 4)
+    assert "Reject H" in out
+    assert "Bonferroni" not in out
+    assert "Tukey" not in out
+
+
+def test_format_table_fail_to_reject():
+    result = anova_one_way([[1.0, 1.1, 0.9], [1.05, 0.95, 1.0]])
+    out = format_table(result, "none", None, 4)
+    assert "Fail to reject" in out
+
+
+def test_format_table_infinite_f_stat():
+    result = anova_one_way([[1.0, 1.0], [9.0, 9.0]])
+    out = format_table(result, "none", None, 4)
+    assert "inf" in out
+
+
+def test_format_table_with_bonferroni():
+    result = anova_one_way([G1, G2, G3])
+    comparisons = bonferroni([G1, G2, G3], result)
+    out = format_table(result, "bonferroni", comparisons, 4)
+    assert "Bonferroni pairwise comparisons" in out
+    assert "*" in out
+
+
+def test_format_table_with_tukey():
+    result = anova_one_way([G1, G2, G3])
+    tukey_result = tukey_hsd([G1, G2, G3], result)
+    out = format_table(result, "tukey", tukey_result, 4)
+    assert "Tukey HSD pairwise comparisons" in out
+    assert "q_crit" in out
+    assert "*" in out
+
+
+def test_format_json_no_posthoc():
+    result = anova_one_way([G1, G2, G3])
+    out = format_json(result, "none", None)
+    data = json.loads(out)
+    assert "bonferroni" not in data
+    assert "tukey" not in data
+    assert data["reject_null"] is True
+
+
+def test_format_json_with_bonferroni():
+    result = anova_one_way([G1, G2, G3])
+    comparisons = bonferroni([G1, G2, G3], result)
+    out = format_json(result, "bonferroni", comparisons)
+    data = json.loads(out)
+    assert len(data["bonferroni"]) == 3
+
+
+def test_format_json_with_tukey():
+    result = anova_one_way([G1, G2, G3])
+    tukey_result = tukey_hsd([G1, G2, G3], result)
+    out = format_json(result, "tukey", tukey_result)
+    data = json.loads(out)
+    assert len(data["tukey"]["comparisons"]) == 3
+    assert "q_crit" in data["tukey"]
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_data_table(capsys):
+    rc = main(
+        ["--data", "12.1,11.8,12.5,11.9", "9.8,10.3,10.1,9.7", "15.2,14.9,15.5,16.0"]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Reject H" in out
+
+
+def test_main_data_bonferroni(capsys):
+    rc = main(
+        [
+            "--data",
+            "12.1,11.8,12.5",
+            "9.8,10.3,10.1",
+            "15.2,14.9,15.5",
+            "--posthoc",
+            "bonferroni",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Bonferroni" in out
+
+
+def test_main_data_json(capsys):
+    rc = main(["--data", "1,2,3", "4,5,6", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert "f_stat" in data
+
+
+def test_main_file_input(tmp_path, capsys):
+    csv_path = tmp_path / "experiment.csv"
+    csv_path.write_text(
+        "treatment,response\n"
+        "A,12.1\nA,11.8\nA,12.5\nA,11.9\n"
+        "B,9.8\nB,10.3\nB,10.1\nB,9.7\n"
+        "C,15.2\nC,14.9\nC,15.5\nC,16.0\n",
+        encoding="utf-8",
+    )
+    rc = main(
+        [
+            "--file",
+            str(csv_path),
+            "--group-col",
+            "treatment",
+            "--value-col",
+            "response",
+            "--alpha",
+            "0.01",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0.01" in out
+
+
+def test_main_data_tukey(capsys):
+    rc = main(
+        [
+            "--data",
+            "12.1,11.8,12.5",
+            "9.8,10.3,10.1",
+            "15.2,14.9,15.5",
+            "--posthoc",
+            "tukey",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Tukey HSD" in out
+
+
+def test_main_data_tukey_json(capsys):
+    rc = main(["--data", "1,2,3", "4,5,6", "--posthoc", "tukey", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert "tukey" in data
+
+
+def test_main_no_input_returns_2(capsys):
+    assert main([]) == 2
+    err = capsys.readouterr().err
+    assert "Error" in err
+
+
+def test_main_missing_csv_file_returns_2(capsys):
+    assert (
+        main(
+            [
+                "--file",
+                "/nonexistent/path/data.csv",
+                "--group-col",
+                "g",
+                "--value-col",
+                "v",
+            ]
+        )
+        == 2
+    )
+    err = capsys.readouterr().err
+    assert "Error" in err
+
+
+def test_main_computation_error_returns_2(monkeypatch, capsys):
+    """Cover the ValueError branch in main when a core function raises."""
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("forced anova error")
+
+    monkeypatch.setattr(anova_module, "anova_one_way", raise_value_error)
+    assert main(["--data", "1,2,3", "4,5,6"]) == 2
+    err = capsys.readouterr().err
+    assert "forced anova error" in err

--- a/tests/test_chi_squared.py
+++ b/tests/test_chi_squared.py
@@ -1,0 +1,362 @@
+"""Tests for the chi-square test calculator utility."""
+
+import argparse
+import math
+
+import pytest
+
+import src.utils.chi_squared as chisq_module
+from src.utils.chi_squared import (
+    chi2_cdf,
+    chi2_sf,
+    chisq_gof,
+    chisq_independence,
+    format_gof,
+    format_independence,
+    main,
+    parse_number_list,
+    regularized_gamma_p,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# regularized_gamma_p / chi2_cdf / chi2_sf
+# ---------------------------------------------------------------------------
+
+
+def test_regularized_gamma_p_zero_x():
+    assert regularized_gamma_p(2.0, 0.0) == 0.0
+
+
+def test_regularized_gamma_p_series_branch():
+    # x < a + 1 triggers the series expansion
+    assert regularized_gamma_p(5.0, 2.0) == pytest.approx(0.0526530, abs=1e-6)
+
+
+def test_regularized_gamma_p_cf_branch():
+    # x >= a + 1 triggers the continued-fraction branch
+    assert regularized_gamma_p(2.0, 10.0) == pytest.approx(0.9995006, abs=1e-6)
+
+
+def test_regularized_gamma_p_bounds():
+    assert 0.0 <= regularized_gamma_p(3.0, 3.0) <= 1.0
+
+
+def test_gamma_cf_fpmin_guards_hit(monkeypatch):
+    """Force the near-zero denominator safety branches in the continued fraction."""
+    monkeypatch.setattr(chisq_module, "_FPMIN", 1e5)
+    result = chisq_module._gamma_cf(2.0, 10.0)
+    assert math.isfinite(result)
+
+
+def test_regularized_gamma_p_a_non_positive_raises():
+    with pytest.raises(ValueError, match="a must be > 0"):
+        regularized_gamma_p(0.0, 1.0)
+
+
+def test_regularized_gamma_p_x_negative_raises():
+    with pytest.raises(ValueError, match="x must be >= 0"):
+        regularized_gamma_p(1.0, -1.0)
+
+
+def test_chi2_cdf_matches_scipy_oracle():
+    scipy_stats = pytest.importorskip("scipy.stats")
+    for df in (1, 2, 5, 10, 30, 100):
+        for x in (0.5, 1.0, df * 0.5, df, df * 2.0, df * 5.0 + 10):
+            got = chi2_cdf(x, df)
+            want = scipy_stats.chi2.cdf(x, df)
+            assert got == pytest.approx(want, abs=1e-9)
+
+
+def test_chi2_cdf_invalid_df_raises():
+    with pytest.raises(ValueError, match="df must be >= 1"):
+        chi2_cdf(1.0, 0)
+
+
+def test_chi2_sf_complements_cdf():
+    assert chi2_cdf(5.0, 3) + chi2_sf(5.0, 3) == pytest.approx(1.0)
+
+
+def test_chi2_sf_clips_to_unit_interval():
+    assert 0.0 <= chi2_sf(0.0, 1) <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# chisq_gof
+# ---------------------------------------------------------------------------
+
+
+def test_chisq_gof_matches_scipy_oracle():
+    scipy_stats = pytest.importorskip("scipy.stats")
+    observed = [18, 22, 17, 25, 19, 19]
+    expected = [20, 20, 20, 20, 20, 20]
+    result = chisq_gof(observed, expected)
+    want = scipy_stats.chisquare(observed, f_exp=expected)
+    assert result.statistic == pytest.approx(want.statistic)
+    assert result.p_value == pytest.approx(want.pvalue)
+    assert result.df == 5
+
+
+def test_chisq_gof_contributions_sum_to_statistic():
+    result = chisq_gof([52, 48], [50, 50])
+    assert sum(result.contributions) == pytest.approx(result.statistic)
+
+
+def test_chisq_gof_length_mismatch_raises():
+    with pytest.raises(ValueError, match="same length"):
+        chisq_gof([1, 2, 3], [1, 2])
+
+
+def test_chisq_gof_too_few_categories_raises():
+    with pytest.raises(ValueError, match="at least 2"):
+        chisq_gof([10], [10])
+
+
+def test_chisq_gof_negative_observed_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        chisq_gof([-1, 5], [2, 2])
+
+
+def test_chisq_gof_non_positive_expected_raises():
+    with pytest.raises(ValueError, match="strictly positive"):
+        chisq_gof([1, 5], [0, 2])
+
+
+def test_chisq_gof_invalid_alpha_raises():
+    with pytest.raises(ValueError, match="alpha must be"):
+        chisq_gof([1, 2], [1, 2], alpha=1.5)
+
+
+# ---------------------------------------------------------------------------
+# chisq_independence
+# ---------------------------------------------------------------------------
+
+
+def test_chisq_independence_matches_scipy_oracle():
+    scipy_stats = pytest.importorskip("scipy.stats")
+    table = [[40, 30, 20], [25, 45, 30]]
+    result = chisq_independence(table)
+    want = scipy_stats.chi2_contingency(table)
+    assert result.statistic == pytest.approx(want.statistic)
+    assert result.p_value == pytest.approx(want.pvalue)
+    assert result.df == want.dof
+
+
+def test_chisq_independence_expected_totals_match_observed():
+    table = [[40, 30, 20], [25, 45, 30]]
+    result = chisq_independence(table)
+    assert sum(sum(row) for row in result.expected) == pytest.approx(
+        sum(sum(row) for row in table)
+    )
+
+
+def test_chisq_independence_too_few_rows_raises():
+    with pytest.raises(ValueError, match="at least 2 rows"):
+        chisq_independence([[1, 2, 3]])
+
+
+def test_chisq_independence_too_few_columns_raises():
+    with pytest.raises(ValueError, match="at least 2 columns"):
+        chisq_independence([[5], [6]])
+
+
+def test_chisq_independence_ragged_rows_raises():
+    with pytest.raises(ValueError, match="same number of columns"):
+        chisq_independence([[1, 2, 3], [4, 5]])
+
+
+def test_chisq_independence_negative_value_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        chisq_independence([[1, -2], [3, 4]])
+
+
+def test_chisq_independence_zero_grand_total_raises():
+    with pytest.raises(ValueError):
+        chisq_independence([[0, 0], [0, 0]])
+
+
+def test_chisq_independence_zero_row_total_raises():
+    with pytest.raises(ValueError, match="row and column total"):
+        chisq_independence([[0, 0], [3, 4]])
+
+
+def test_chisq_independence_zero_col_total_raises():
+    with pytest.raises(ValueError, match="row and column total"):
+        chisq_independence([[0, 3], [0, 4]])
+
+
+def test_chisq_independence_invalid_alpha_raises():
+    with pytest.raises(ValueError, match="alpha must be"):
+        chisq_independence([[1, 2], [3, 4]], alpha=0.0)
+
+
+# ---------------------------------------------------------------------------
+# parse_number_list
+# ---------------------------------------------------------------------------
+
+
+def test_parse_number_list_basic():
+    assert parse_number_list("1,2.5,3") == [1.0, 2.5, 3.0]
+
+
+def test_parse_number_list_empty_raises():
+    with pytest.raises(ValueError, match="at least one value"):
+        parse_number_list("")
+
+
+def test_parse_number_list_non_finite_raises():
+    with pytest.raises(ValueError, match="finite"):
+        parse_number_list("1,nan,3")
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def _ns(**kwargs):
+    defaults = dict(
+        test="gof", observed=None, expected=None, table=None, alpha=0.05, precision=4
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def test_validate_alpha_out_of_range():
+    assert "--alpha" in validate(_ns(alpha=0.0))
+
+
+def test_validate_precision_negative():
+    assert "--precision" in validate(_ns(precision=-1))
+
+
+def test_validate_gof_missing_observed():
+    assert "requires both" in validate(_ns(test="gof", expected="1,2"))
+
+
+def test_validate_gof_with_table_errors():
+    assert "--table" in validate(
+        _ns(test="gof", observed="1,2", expected="1,2", table=["1,2"])
+    )
+
+
+def test_validate_gof_valid():
+    assert validate(_ns(test="gof", observed="1,2", expected="1,2")) is None
+
+
+def test_validate_independence_missing_table():
+    assert "at least two" in validate(_ns(test="independence", table=None))
+
+
+def test_validate_independence_single_row():
+    assert "at least two" in validate(_ns(test="independence", table=["1,2"]))
+
+
+def test_validate_independence_with_observed_errors():
+    assert "not used" in validate(
+        _ns(test="independence", table=["1,2", "3,4"], observed="1,2")
+    )
+
+
+def test_validate_independence_valid():
+    assert validate(_ns(test="independence", table=["1,2", "3,4"])) is None
+
+
+# ---------------------------------------------------------------------------
+# format_gof / format_independence
+# ---------------------------------------------------------------------------
+
+
+def test_format_gof_contains_statistic():
+    result = chisq_gof([18, 22, 17, 25, 19, 19], [20, 20, 20, 20, 20, 20])
+    out = format_gof(result, 4)
+    assert "χ² statistic" in out
+    assert "Fail to reject" in out
+
+
+def test_format_gof_reject_decision():
+    result = chisq_gof([90, 10], [50, 50])
+    out = format_gof(result, 4)
+    assert "Reject H" in out
+
+
+def test_format_independence_contains_tables():
+    result = chisq_independence([[40, 30, 20], [25, 45, 30]])
+    out = format_independence(result, 4)
+    assert "Observed:" in out
+    assert "Expected:" in out
+    assert "Reject H" in out
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_gof_success(capsys):
+    rc = main(
+        [
+            "--test",
+            "gof",
+            "--observed",
+            "18,22,17,25,19,19",
+            "--expected",
+            "20,20,20,20,20,20",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "χ² statistic" in out
+
+
+def test_main_independence_success(capsys):
+    rc = main(["--test", "independence", "--table", "40,30,20", "--table", "25,45,30"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Observed:" in out
+
+
+def test_main_alpha_sweep(capsys):
+    rc = main(
+        [
+            "--test",
+            "gof",
+            "--observed",
+            "52,48",
+            "--expected",
+            "50,50",
+            "--alpha",
+            "0.10",
+        ]
+    )
+    assert rc == 0
+
+
+def test_main_validate_error_returns_2(capsys):
+    assert main(["--test", "gof"]) == 2
+    err = capsys.readouterr().err
+    assert "Error" in err
+
+
+def test_main_computation_error_returns_2(monkeypatch, capsys):
+    """Cover the ValueError branch in main when a core function raises."""
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("forced chisq error")
+
+    monkeypatch.setattr(chisq_module, "chisq_gof", raise_value_error)
+    assert main(["--test", "gof", "--observed", "1,2", "--expected", "1,2"]) == 2
+    err = capsys.readouterr().err
+    assert "forced chisq error" in err
+
+
+def test_main_computation_error_independence(monkeypatch, capsys):
+    """Cover the ValueError branch in main for the independence path."""
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("forced independence error")
+
+    monkeypatch.setattr(chisq_module, "chisq_independence", raise_value_error)
+    assert main(["--test", "independence", "--table", "1,2", "--table", "3,4"]) == 2
+    err = capsys.readouterr().err
+    assert "forced independence error" in err

--- a/tests/test_geometric_distribution.py
+++ b/tests/test_geometric_distribution.py
@@ -1,0 +1,239 @@
+"""Tests for the geometric distribution utility."""
+
+import argparse
+
+import pytest
+
+import src.utils.geometric_distribution as geometric_module
+from src.utils.geometric_distribution import (
+    format_single,
+    format_table,
+    geo_cdf,
+    geo_mean,
+    geo_pmf,
+    geo_survival,
+    geo_variance,
+    main,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# geo_pmf
+# ---------------------------------------------------------------------------
+
+
+def test_geo_pmf_first_trial():
+    assert geo_pmf(1, 0.3) == pytest.approx(0.3)
+
+
+def test_geo_pmf_matches_formula():
+    assert geo_pmf(5, 0.3) == pytest.approx((0.7**4) * 0.3)
+
+
+def test_geo_pmf_p_equals_one():
+    assert geo_pmf(1, 1.0) == pytest.approx(1.0)
+    assert geo_pmf(2, 1.0) == pytest.approx(0.0)
+
+
+def test_geo_pmf_k_below_one_raises():
+    with pytest.raises(ValueError, match=">= 1"):
+        geo_pmf(0, 0.5)
+
+
+def test_geo_pmf_p_zero_raises():
+    with pytest.raises(ValueError, match=r"\(0, 1\]"):
+        geo_pmf(1, 0.0)
+
+
+def test_geo_pmf_p_above_one_raises():
+    with pytest.raises(ValueError, match=r"\(0, 1\]"):
+        geo_pmf(1, 1.5)
+
+
+# ---------------------------------------------------------------------------
+# geo_cdf
+# ---------------------------------------------------------------------------
+
+
+def test_geo_cdf_matches_formula():
+    assert geo_cdf(5, 0.3) == pytest.approx(1 - 0.7**5)
+
+
+def test_geo_cdf_k_below_one_is_zero():
+    assert geo_cdf(0, 0.5) == 0.0
+    assert geo_cdf(-3, 0.5) == 0.0
+
+
+def test_geo_cdf_invalid_p_raises():
+    with pytest.raises(ValueError, match=r"\(0, 1\]"):
+        geo_cdf(5, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# geo_survival
+# ---------------------------------------------------------------------------
+
+
+def test_geo_survival_matches_formula():
+    assert geo_survival(10, 0.2) == pytest.approx(0.8**10)
+
+
+def test_geo_survival_k_negative_is_one():
+    assert geo_survival(-1, 0.5) == 1.0
+
+
+def test_geo_survival_invalid_p_raises():
+    with pytest.raises(ValueError, match=r"\(0, 1\]"):
+        geo_survival(1, 0.0)
+
+
+def test_geo_survival_and_cdf_complement():
+    assert geo_cdf(7, 0.25) + geo_survival(7, 0.25) == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# geo_mean / geo_variance
+# ---------------------------------------------------------------------------
+
+
+def test_geo_mean():
+    assert geo_mean(0.2) == pytest.approx(5.0)
+
+
+def test_geo_mean_invalid_p_raises():
+    with pytest.raises(ValueError, match=r"\(0, 1\]"):
+        geo_mean(0.0)
+
+
+def test_geo_variance():
+    assert geo_variance(0.2) == pytest.approx(0.8 / 0.04)
+
+
+def test_geo_variance_p_one_is_zero():
+    assert geo_variance(1.0) == pytest.approx(0.0)
+
+
+def test_geo_variance_invalid_p_raises():
+    with pytest.raises(ValueError, match=r"\(0, 1\]"):
+        geo_variance(0.0)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_p_out_of_range():
+    args = argparse.Namespace(k=1, p=0.0, table=None, precision=4)
+    assert "-p" in validate(args)
+
+
+def test_validate_precision_negative():
+    args = argparse.Namespace(k=1, p=0.5, table=None, precision=-1)
+    assert "--precision" in validate(args)
+
+
+def test_validate_table_min_below_one():
+    args = argparse.Namespace(k=None, p=0.5, table=[0, 5], precision=4)
+    assert "MIN" in validate(args)
+
+
+def test_validate_table_max_below_min():
+    args = argparse.Namespace(k=None, p=0.5, table=[5, 2], precision=4)
+    assert "MAX" in validate(args)
+
+
+def test_validate_table_valid():
+    args = argparse.Namespace(k=None, p=0.5, table=[1, 5], precision=4)
+    assert validate(args) is None
+
+
+def test_validate_k_missing_without_table():
+    args = argparse.Namespace(k=None, p=0.5, table=None, precision=4)
+    assert "-k is required" in validate(args)
+
+
+def test_validate_k_below_one():
+    args = argparse.Namespace(k=0, p=0.5, table=None, precision=4)
+    assert "-k must be" in validate(args)
+
+
+def test_validate_valid_single():
+    args = argparse.Namespace(k=5, p=0.5, table=None, precision=4)
+    assert validate(args) is None
+
+
+# ---------------------------------------------------------------------------
+# format_single / format_table
+# ---------------------------------------------------------------------------
+
+
+def test_format_single_cdf_mode():
+    out = format_single(5, 0.3, survival=False, precision=4)
+    assert "CDF" in out
+    assert "P(X > 5)" not in out
+
+
+def test_format_single_survival_mode():
+    out = format_single(5, 0.3, survival=True, precision=4)
+    assert "P(X > 5)" in out
+    assert "CDF" not in out
+
+
+def test_format_table_cdf_mode():
+    out = format_table(1, 3, 0.25, survival=False, precision=4)
+    assert "P(X <= k)" in out
+    assert "3" in out
+
+
+def test_format_table_survival_mode():
+    out = format_table(1, 3, 0.25, survival=True, precision=4)
+    assert "P(X > k)" in out
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_single_report(capsys):
+    rc = main(["-k", "5", "-p", "0.3"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "mean" in out
+
+
+def test_main_survival_flag(capsys):
+    rc = main(["-k", "10", "-p", "0.2", "--survival"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "P(X > 10)" in out
+
+
+def test_main_table(capsys):
+    rc = main(["-p", "0.25", "--table", "1", "15"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "15" in out
+
+
+def test_main_missing_k_returns_2(capsys):
+    assert main(["-p", "0.5"]) == 2
+    err = capsys.readouterr().err
+    assert "Error" in err
+
+
+def test_main_invalid_p_returns_2(capsys):
+    assert main(["-k", "1", "-p", "0"]) == 2
+
+
+def test_main_computation_error_returns_2(monkeypatch, capsys):
+    """Cover the ValueError branch in main when a core function raises."""
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("forced geometric error")
+
+    monkeypatch.setattr(geometric_module, "geo_pmf", raise_value_error)
+    assert main(["-k", "5", "-p", "0.3"]) == 2
+    err = capsys.readouterr().err
+    assert "forced geometric error" in err


### PR DESCRIPTION
## Summary

- `geometric` — geometric distribution PMF/CDF/survival/mean/variance (trials until first success).
- `chisq` — goodness-of-fit and independence chi-square tests, with per-cell contributions; exact CDF via a regularised incomplete gamma function.
- `anova` — one-way ANOVA F-test with **Tukey HSD** and Bonferroni post-hoc comparisons; F-test via a regularised incomplete beta function, Tukey HSD via the studentized range distribution computed through nested numerical integration (pure Python, no external dependencies for any of the three tools).

All three special-function implementations (incomplete gamma, incomplete beta, studentized range) were validated against scipy as a test oracle during development, matching to within ~1e-8–1e-13.

Closes #29
Closes #6
Closes #28

## Test plan

- [x] `python3 -m pytest --cov=src --cov-fail-under=100` — 1219 tests passing, 100% coverage
- [x] `ruff format` / `ruff check` clean on all changed files
- [x] `mypy` clean on all three new modules
- [x] Each tool exercised via its installed console-script entry point (`uv run geometric ...`, `uv run chisq ...`, `uv run anova ...`), not just module invocation
- [x] README updated with feature table rows, CLI usage table rows, detailed `<details>` sections, module reference rows, and Python usage examples for each tool