### PR TITLE
feat: add life-in-weeks grid visualizer CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Geometric Distribution** | Compute PMF, CDF, survival, mean, and variance for the number of trials until the first success; supports single-k reports and full probability tables |
 | **Chi-Square Tests** | Goodness-of-fit and independence (contingency table) chi-square tests via the exact regularised incomplete gamma function; per-cell contributions for residual diagnostics |
 | **One-Way ANOVA** | Test whether the means of three or more independent groups are equal; F-statistic via the regularised incomplete beta function, with Tukey HSD or Bonferroni-corrected pairwise post-hoc comparisons |
-| **Life in Weeks** | Render a human life as an ANSI grid of weeks, months, or years, color-coded elapsed vs remaining from a birthdate; includes a "Life of a Typical American" reference grid shaded by life phase with milestone markers |
+| **Life in Weeks** | Render a human life as an ANSI grid of weeks, months, or years, color-coded elapsed vs remaining from a birthdate; discrete shape glyphs with quarter and decade grouping keep individual cells countable, and a "Life of a Typical American" reference grid shades each life phase with milestone markers |
 | **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, `chisq`, `anova`, and `life` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
@@ -1565,7 +1565,9 @@ anova --file experiment.csv --group-col treatment --value-col response --alpha 0
 
 Renders a human life as a grid of time units — one cell per week, month, or year of a nominal 90-year lifespan — color-coded to distinguish elapsed units from remaining ones. Inspired by Wait But Why's [Your Life in Weeks](https://waitbutwhy.com/2014/05/life-weeks.html).
 
-`--reference` renders "The Life of a Typical American": the same grid shaded by life phase (childhood/school, higher education, working years, retirement, beyond life expectancy) with milestone markers. Phase boundaries and milestone ages are approximate US averages from public sources (US Census Bureau median age at first marriage; CDC/NCHS mean age at first birth and life expectancy; Gallup average actual retirement age) — see the module docstring for figures and years.
+Cells are discrete shape glyphs (`■` lived, `□` remaining) rather than solid blocks, separated into groups of 13 weeks (or 3 months, 5 years) with a blank line between decades, so individual units stay countable instead of merging into a bar. `--group` overrides the group size; `--group 1` puts a space between every cell and `--group 0` renders an unbroken row.
+
+`--reference` renders "The Life of a Typical American": the same grid with a distinct shape per life phase — `●` childhood/school, `▲` higher education, `■` working years, `◆` retirement, `○` beyond life expectancy — and `★` milestone markers. Phase boundaries and milestone ages are approximate US averages from public sources (US Census Bureau median age at first marriage; CDC/NCHS mean age at first birth and life expectancy; Gallup average actual retirement age) — see the module docstring for figures and years.
 
 `--as-of` measures elapsed time to a date other than today, which makes output reproducible and supports what-if projections. Color is suppressed automatically when output is not a terminal, when `NO_COLOR` is set, or with `--no-color`; the block glyphs alone remain readable.
 
@@ -1582,6 +1584,9 @@ life 1985-03-14 --mode years --lifespan 100
 # Typical-American reference grid (no birthdate needed)
 life --reference
 
+# Tighter cell grouping (one space between every cell)
+life 1985-03-14 --group 1
+
 # Reproducible / projected output
 life 1985-03-14 --as-of 2030-01-01 --format json
 ```
@@ -1594,6 +1599,7 @@ life 1985-03-14 --as-of 2030-01-01 --format json
 | `-m` | `--mode {weeks,months,years}` | Grid granularity, one cell per unit (default: weeks) |
 | `-l` | `--lifespan YEARS` | Nominal lifespan spanned by the grid, 1–150 (default: 90) |
 | | `--as-of DATE` | ISO date to measure elapsed time to (default: today) |
+| `-g` | `--group CELLS` | Cells per visual group, `0` to disable (default: 13 weeks, 3 months, 5 years) |
 | `-r` | `--reference` | Render the typical-American reference grid instead of a personal one |
 | | `--no-color` | Disable ANSI color; glyphs alone distinguish the cells |
 | `-f` | `--format {table,json}` | Output format (default: table) |
@@ -2680,7 +2686,7 @@ rows = grid_rows(grid.total_units, grid.elapsed_units, grid.cols)
 print(len(rows))  # 90
 
 # Typical-American reference grid: phase glyphs with milestone overlays
-print(reference_rows("years", 90)[2])  # ▃▃▅▅▅▅▅◆▅◆
+print(reference_rows("years", 90)[2])  # ▲▲■■■■■★■★
 
 # Milestone ages converted to unit indices
 print(milestone_units("weeks")[0])  # ('mean age at first birth (NCHS 2023)', 1430)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Geometric Distribution** | Compute PMF, CDF, survival, mean, and variance for the number of trials until the first success; supports single-k reports and full probability tables |
 | **Chi-Square Tests** | Goodness-of-fit and independence (contingency table) chi-square tests via the exact regularised incomplete gamma function; per-cell contributions for residual diagnostics |
 | **One-Way ANOVA** | Test whether the means of three or more independent groups are equal; F-statistic via the regularised incomplete beta function, with Tukey HSD or Bonferroni-corrected pairwise post-hoc comparisons |
-| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, `chisq`, and `anova` commands |
+| **Life in Weeks** | Render a human life as an ANSI grid of weeks, months, or years, color-coded elapsed vs remaining from a birthdate; includes a "Life of a Typical American" reference grid shaded by life phase with milestone markers |
+| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, `chisq`, `anova`, and `life` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
 
@@ -97,6 +98,7 @@ pip install -e .
 | `geometric` | PMF, CDF, survival, mean, and variance for the geometric distribution (trials until first success) |
 | `chisq` | Chi-square goodness-of-fit and independence tests with per-cell contributions |
 | `anova` | One-way ANOVA F-test with optional Tukey HSD or Bonferroni-corrected pairwise post-hoc comparisons |
+| `life` | ANSI grid of a human life in weeks, months, or years, elapsed vs remaining, with a typical-American reference grid |
 | `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
 
 ---
@@ -1559,6 +1561,48 @@ anova --file experiment.csv --group-col treatment --value-col response --alpha 0
 ---
 
 <details>
+<summary><strong><code>life</code></strong> — Life in Weeks</summary>
+
+Renders a human life as a grid of time units — one cell per week, month, or year of a nominal 90-year lifespan — color-coded to distinguish elapsed units from remaining ones. Inspired by Wait But Why's [Your Life in Weeks](https://waitbutwhy.com/2014/05/life-weeks.html).
+
+`--reference` renders "The Life of a Typical American": the same grid shaded by life phase (childhood/school, higher education, working years, retirement, beyond life expectancy) with milestone markers. Phase boundaries and milestone ages are approximate US averages from public sources (US Census Bureau median age at first marriage; CDC/NCHS mean age at first birth and life expectancy; Gallup average actual retirement age) — see the module docstring for figures and years.
+
+`--as-of` measures elapsed time to a date other than today, which makes output reproducible and supports what-if projections. Color is suppressed automatically when output is not a terminal, when `NO_COLOR` is set, or with `--no-color`; the block glyphs alone remain readable.
+
+```bash
+# Weeks grid (default), elapsed vs remaining
+life 1985-03-14
+
+# One cell per month
+life 1985-03-14 --mode months
+
+# One cell per year, over a 100-year lifespan
+life 1985-03-14 --mode years --lifespan 100
+
+# Typical-American reference grid (no birthdate needed)
+life --reference
+
+# Reproducible / projected output
+life 1985-03-14 --as-of 2030-01-01 --format json
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| | `BIRTHDATE` | Birthdate in ISO format (`YYYY-MM-DD`); required unless `--reference` is used |
+| `-m` | `--mode {weeks,months,years}` | Grid granularity, one cell per unit (default: weeks) |
+| `-l` | `--lifespan YEARS` | Nominal lifespan spanned by the grid, 1–150 (default: 90) |
+| | `--as-of DATE` | ISO date to measure elapsed time to (default: today) |
+| `-r` | `--reference` | Render the typical-American reference grid instead of a personal one |
+| | `--no-color` | Disable ANSI color; glyphs alone distinguish the cells |
+| `-f` | `--format {table,json}` | Output format (default: table) |
+
+</details>
+
+---
+
+<details>
 <summary><strong><code>simulate</code></strong> — Monte Carlo Probability Simulator</summary>
 
 Runs repeated random experiments to estimate probabilities empirically, with optional confidence intervals and analytical comparison against `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, and `linboot`.
@@ -1660,6 +1704,7 @@ simulate --experiment linboot --params x=1,2,3,4,5 y=2.1,3.9,6.2,7.8,10.1 predic
 | Geometric | `src.utils.geometric_distribution` | `geo_pmf`, `geo_cdf`, `geo_survival`, `geo_mean`, `geo_variance` |
 | Chi-Square | `src.utils.chi_squared` | `chisq_gof`, `chisq_independence`, `chi2_cdf`, `regularized_gamma_p` |
 | ANOVA | `src.utils.anova` | `anova_one_way`, `tukey_hsd`, `bonferroni`, `f_cdf`, `studentized_range_cdf` |
+| Life in Weeks | `src.utils.life_in_weeks` | `compute_grid`, `units_elapsed`, `grid_rows`, `reference_rows`, `milestone_units` |
 | Monte Carlo | `src.utils.monte_carlo` | `simulate_binomial`, `simulate_birthday`, `simulate_streak`, `simulate_poisson`, `simulate_power`, `simulate_permutation`, `simulate_bayes`, `simulate_season`, `simulate_linboot` |
 
 ---
@@ -2603,6 +2648,42 @@ for c in tukey_result.comparisons:
 # Bonferroni-corrected pairwise comparisons
 for c in bonferroni(groups, result):
     print(c.i, c.j, c.mean_diff, c.p_adj, c.significant)
+```
+
+</details>
+
+<details>
+<summary><strong>Life in Weeks</strong></summary>
+
+```python
+from datetime import date
+
+from src.utils.life_in_weeks import (
+    compute_grid,
+    grid_rows,
+    milestone_units,
+    reference_rows,
+    units_elapsed,
+)
+
+# Grid totals for a 90-year life measured to a fixed date
+grid = compute_grid(date(1985, 3, 14), date(2026, 8, 7))
+print(grid.total_units)      # 4680
+print(grid.elapsed_units)    # 2160
+print(grid.remaining_units)  # 2520
+
+# Elapsed units in any mode
+print(units_elapsed(date(1985, 3, 14), date(2026, 8, 7), "years"))  # 41
+
+# Glyph rows, one string per row, no ANSI escapes
+rows = grid_rows(grid.total_units, grid.elapsed_units, grid.cols)
+print(len(rows))  # 90
+
+# Typical-American reference grid: phase glyphs with milestone overlays
+print(reference_rows("years", 90)[2])  # ▃▃▅▅▅▅▅◆▅◆
+
+# Milestone ages converted to unit indices
+print(milestone_units("weeks")[0])  # ('mean age at first birth (NCHS 2023)', 1430)
 ```
 
 </details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ subnet = "src.utils.subnet:main"
 geometric = "src.utils.geometric_distribution:main"
 chisq = "src.utils.chi_squared:main"
 anova = "src.utils.anova:main"
+life = "src.utils.life_in_weeks:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/utils/life_in_weeks.py
+++ b/src/utils/life_in_weeks.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""Command-line utility for rendering a human life as a grid of time units.
+
+Inspired by Wait But Why's "Your Life in Weeks" (2014), this renders an ANSI
+grid where each cell is one week, month, or year of a nominal 90-year lifespan,
+color-coded to distinguish elapsed units from remaining ones.
+
+The --reference view renders "The Life of a Typical American": the same grid
+shaded by life phase, with milestone markers. Phase boundaries and milestone
+ages are approximate US averages drawn from public sources:
+
+  - Median age at first marriage: US Census Bureau (2024) — 30.2 (men),
+    28.6 (women); the grid uses the 29.4 midpoint.
+  - Mean age at first birth: CDC/NCHS (2023) — 27.5.
+  - Average actual retirement age: Gallup (2023) — 62.
+  - Life expectancy at birth: CDC/NCHS (2023) — 78.4.
+
+Usage examples:
+  life 1985-03-14
+  life 1985-03-14 --mode months
+  life 1985-03-14 --mode years --lifespan 100
+  life --reference
+  life 1985-03-14 --as-of 2030-01-01 --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import date
+from typing import IO, Any, Mapping, NamedTuple
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+_UNITS_PER_YEAR = {"weeks": 52, "months": 12, "years": 1}
+_COLS = {"weeks": 52, "months": 12, "years": 10}
+
+_ELAPSED = "█"
+_REMAINING = "░"
+_MILESTONE = "◆"
+
+_RESET = "\033[0m"
+_COLORS = {
+    "cyan": "\033[36m",
+    "blue": "\033[34m",
+    "yellow": "\033[33m",
+    "green": "\033[32m",
+    "magenta": "\033[35m",
+    "dim": "\033[90m",
+}
+
+
+class LifeGrid(NamedTuple):
+    mode: str
+    birthdate: date
+    as_of: date
+    lifespan: int
+    total_units: int
+    elapsed_units: int
+    remaining_units: int
+    cols: int
+
+
+class Phase(NamedTuple):
+    label: str
+    start_year: float
+    end_year: float
+    color: str
+    glyph: str
+
+
+_PHASES: tuple[Phase, ...] = (
+    Phase("Childhood and K-12 school", 0.0, 18.0, "cyan", "▁"),
+    Phase("Higher education / early adulthood", 18.0, 22.0, "blue", "▃"),
+    Phase("Working years", 22.0, 62.0, "yellow", "▅"),
+    Phase("Retirement", 62.0, 78.4, "green", "▇"),
+    Phase("Beyond US life expectancy", 78.4, float("inf"), "dim", "░"),
+)
+
+_MILESTONES: tuple[tuple[float, str], ...] = (
+    (27.5, "mean age at first birth (NCHS 2023)"),
+    (29.4, "median age at first marriage (Census 2024)"),
+    (62.0, "average actual retirement age (Gallup 2023)"),
+)
+
+
+def units_elapsed(birth: date, as_of: date, mode: str) -> int:
+    """Return whole time units elapsed between two dates for a display mode.
+
+    The month and year comparisons use a literal day-of-month test rather than
+    end-of-month clamping, so a birthdate on the 29th-31st advances only once
+    the same day number is reached in a later month.
+
+    Args:
+        birth: Birthdate.
+        as_of: Date to measure to.
+        mode: One of "weeks", "months", or "years".
+
+    Returns:
+        Count of completed units, never negative.
+
+    Raises:
+        ValueError: If mode is unknown or as_of precedes birth.
+    """
+    if mode not in _UNITS_PER_YEAR:
+        raise ValueError(f"unknown mode: {mode!r}")
+    if as_of < birth:
+        raise ValueError(
+            f"birthdate {birth.isoformat()} is after as-of date {as_of.isoformat()}"
+        )
+
+    if mode == "weeks":
+        return (as_of - birth).days // 7
+
+    if mode == "months":
+        months = (as_of.year - birth.year) * 12 + (as_of.month - birth.month)
+        if as_of.day < birth.day:
+            months -= 1
+        return months
+
+    years = as_of.year - birth.year
+    if (as_of.month, as_of.day) < (birth.month, birth.day):
+        years -= 1
+    return years
+
+
+def compute_grid(
+    birth: date, as_of: date, mode: str = "weeks", lifespan: int = 90
+) -> LifeGrid:
+    """Compute grid dimensions and elapsed/remaining counts for a life.
+
+    Args:
+        birth: Birthdate.
+        as_of: Date the grid is current as of.
+        mode: One of "weeks", "months", or "years".
+        lifespan: Nominal lifespan in years spanned by the grid.
+
+    Returns:
+        LifeGrid with totals; elapsed is clamped to the grid capacity so a
+        life longer than the nominal lifespan renders as fully elapsed.
+
+    Raises:
+        ValueError: If mode is unknown, lifespan is not positive, or as_of
+            precedes birth.
+    """
+    if mode not in _UNITS_PER_YEAR:
+        raise ValueError(f"unknown mode: {mode!r}")
+    if lifespan <= 0:
+        raise ValueError(f"lifespan must be positive, got {lifespan}")
+
+    total = lifespan * _UNITS_PER_YEAR[mode]
+    elapsed = min(units_elapsed(birth, as_of, mode), total)
+
+    return LifeGrid(
+        mode=mode,
+        birthdate=birth,
+        as_of=as_of,
+        lifespan=lifespan,
+        total_units=total,
+        elapsed_units=elapsed,
+        remaining_units=total - elapsed,
+        cols=_COLS[mode],
+    )
+
+
+def grid_rows(total: int, elapsed: int, cols: int) -> list[str]:
+    """Return glyph rows for a grid, without any ANSI escapes.
+
+    Args:
+        total: Total cells in the grid.
+        elapsed: Leading cells to mark as elapsed.
+        cols: Cells per row.
+
+    Returns:
+        List of glyph strings, one per row; the last row may be short.
+    """
+    return [
+        "".join(
+            _ELAPSED if i < elapsed else _REMAINING
+            for i in range(start, min(start + cols, total))
+        )
+        for start in range(0, total, cols)
+    ]
+
+
+def _phase_for_age(age: float) -> Phase:
+    """Return the life phase containing a given age in years."""
+    for phase in _PHASES[:-1]:
+        if phase.start_year <= age < phase.end_year:
+            return phase
+    return _PHASES[-1]
+
+
+def reference_rows(mode: str = "weeks", lifespan: int = 90) -> list[str]:
+    """Return glyph rows for the typical-American reference grid.
+
+    Each cell carries its life-phase glyph; cells containing a milestone age
+    are overlaid with the milestone glyph.
+
+    Args:
+        mode: One of "weeks", "months", or "years".
+        lifespan: Nominal lifespan in years spanned by the grid.
+
+    Returns:
+        List of glyph strings, one per row.
+
+    Raises:
+        ValueError: If mode is unknown or lifespan is not positive.
+    """
+    if mode not in _UNITS_PER_YEAR:
+        raise ValueError(f"unknown mode: {mode!r}")
+    if lifespan <= 0:
+        raise ValueError(f"lifespan must be positive, got {lifespan}")
+
+    per_year = _UNITS_PER_YEAR[mode]
+    total = lifespan * per_year
+    cells = [_phase_for_age(i / per_year).glyph for i in range(total)]
+
+    for age, _ in _MILESTONES:
+        index = int(age * per_year)
+        if index < total:
+            cells[index] = _MILESTONE
+
+    cols = _COLS[mode]
+    return ["".join(cells[start : start + cols]) for start in range(0, total, cols)]
+
+
+def milestone_units(mode: str = "weeks") -> list[tuple[str, int]]:
+    """Return each milestone label paired with its unit index for a mode."""
+    per_year = _UNITS_PER_YEAR[mode]
+    return [(label, int(age * per_year)) for age, label in _MILESTONES]
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Life in weeks: an ANSI grid of a human life, elapsed vs remaining.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  life 1985-03-14
+  life 1985-03-14 --mode months
+  life 1985-03-14 --mode years --lifespan 100
+  life --reference
+  life 1985-03-14 --as-of 2030-01-01 --format json
+""",
+    )
+    parser.add_argument(
+        "birthdate",
+        metavar="BIRTHDATE",
+        nargs="?",
+        help="birthdate in ISO format (YYYY-MM-DD); required unless --reference is used",
+    )
+    parser.add_argument(
+        "--mode",
+        "-m",
+        choices=["weeks", "months", "years"],
+        default="weeks",
+        help="grid granularity: one cell per unit (default: weeks)",
+    )
+    parser.add_argument(
+        "--lifespan",
+        "-l",
+        type=int,
+        default=90,
+        metavar="YEARS",
+        help="nominal lifespan spanned by the grid, 1-150 (default: 90)",
+    )
+    parser.add_argument(
+        "--as-of",
+        metavar="DATE",
+        help="ISO date to measure elapsed time to (default: today)",
+    )
+    parser.add_argument(
+        "--reference",
+        "-r",
+        action="store_true",
+        help="render the typical-American reference grid instead of a personal one",
+    )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="disable ANSI color; glyphs alone distinguish the cells",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        choices=["table", "json"],
+        default="table",
+        help="output format: table (default) or json",
+    )
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Return an error message for invalid argument combinations, else None."""
+    if args.birthdate is None and not args.reference:
+        return "BIRTHDATE is required unless --reference is used"
+    if not 1 <= args.lifespan <= 150:
+        return f"lifespan must be between 1 and 150, got {args.lifespan}"
+    return None
+
+
+def _parse_date(raw: str) -> date:
+    """Parse an ISO date string, raising ValueError with a uniform message."""
+    try:
+        return date.fromisoformat(raw)
+    except ValueError as exc:
+        raise ValueError(f"invalid date: {raw!r} (expected YYYY-MM-DD)") from exc
+
+
+def _use_color(
+    args: argparse.Namespace,
+    env: Mapping[str, str] | None = None,
+    stream: IO[str] | None = None,
+) -> bool:
+    """Return whether ANSI color should be emitted.
+
+    Color is suppressed by --no-color, by a non-empty NO_COLOR environment
+    variable, or when the output stream is not a terminal.
+    """
+    if args.no_color:
+        return False
+    env = os.environ if env is None else env
+    if env.get("NO_COLOR"):
+        return False
+    stream = sys.stdout if stream is None else stream
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _paint(text: str, color: str, use_color: bool) -> str:
+    """Wrap text in an ANSI color when coloring is enabled."""
+    if not use_color:
+        return text
+    return f"{_COLORS[color]}{text}{_RESET}"
+
+
+_GLYPH_COLORS = {phase.glyph: phase.color for phase in _PHASES} | {
+    _ELAPSED: "cyan",
+    _REMAINING: "dim",
+    _MILESTONE: "magenta",
+}
+
+
+def _paint_row(row: str, use_color: bool) -> str:
+    """Color a glyph row by grouping runs of identical glyphs."""
+    if not use_color:
+        return row
+
+    painted: list[str] = []
+    run_start = 0
+    for i in range(1, len(row) + 1):
+        if i == len(row) or row[i] != row[run_start]:
+            glyph = row[run_start]
+            painted.append(_paint(row[run_start:i], _GLYPH_COLORS[glyph], True))
+            run_start = i
+    return "".join(painted)
+
+
+def _row_label(mode: str, row_index: int) -> str:
+    """Return the left-margin age label for a grid row."""
+    age = row_index * 10 if mode == "years" else row_index
+    return f"{age:>3} │ "
+
+
+def _render_grid(rows: list[str], mode: str, use_color: bool) -> list[str]:
+    """Return labelled, optionally colored grid lines."""
+    return [
+        _row_label(mode, i) + _paint_row(row, use_color) for i, row in enumerate(rows)
+    ]
+
+
+def _pct(part: int, whole: int) -> float:
+    """Return part as a percentage of whole."""
+    return part / whole * 100.0
+
+
+def format_grid(grid: LifeGrid, use_color: bool = False) -> str:
+    """Return the rendered personal life grid with legend and summary."""
+    unit = grid.mode
+    lines = [
+        f"Your Life in {unit.capitalize()}",
+        "=" * 40,
+        f"Birthdate:  {grid.birthdate.isoformat()}",
+        f"As of:      {grid.as_of.isoformat()}",
+        f"Lifespan:   {grid.lifespan} years ({grid.total_units:,} {unit})",
+        "",
+    ]
+    lines.extend(
+        _render_grid(
+            grid_rows(grid.total_units, grid.elapsed_units, grid.cols),
+            grid.mode,
+            use_color,
+        )
+    )
+    lines.extend(
+        [
+            "",
+            f"{_paint(_ELAPSED, 'cyan', use_color)} lived    {_paint(_REMAINING, 'dim', use_color)} remaining",
+            "",
+            f"Lived:      {grid.elapsed_units:,} {unit} ({_pct(grid.elapsed_units, grid.total_units):.1f}%)",
+            f"Remaining:  {grid.remaining_units:,} {unit} ({_pct(grid.remaining_units, grid.total_units):.1f}%)",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def format_reference(
+    mode: str = "weeks", lifespan: int = 90, use_color: bool = False
+) -> str:
+    """Return the rendered typical-American reference grid with legend."""
+    total = lifespan * _UNITS_PER_YEAR[mode]
+    lines = [
+        "The Life of a Typical American",
+        "=" * 40,
+        f"Lifespan:   {lifespan} years ({total:,} {mode})",
+        "Phase boundaries are approximate US averages; see module docstring",
+        "for sources (Census, NCHS, Gallup).",
+        "",
+    ]
+    lines.extend(_render_grid(reference_rows(mode, lifespan), mode, use_color))
+    lines.append("")
+
+    for phase in _PHASES:
+        end = "onward" if phase.end_year == float("inf") else f"{phase.end_year:g}"
+        lines.append(
+            f"{_paint(phase.glyph, phase.color, use_color)} {phase.label} ({phase.start_year:g}-{end})"
+        )
+
+    lines.append("")
+    for label, index in milestone_units(mode):
+        lines.append(
+            f"{_paint(_MILESTONE, 'magenta', use_color)} {label} — {mode[:-1]} {index:,}"
+        )
+
+    return "\n".join(lines)
+
+
+def format_json(grid: LifeGrid) -> str:
+    """Return the personal grid summary as JSON."""
+    return json.dumps(
+        {
+            "mode": grid.mode,
+            "birthdate": grid.birthdate.isoformat(),
+            "as_of": grid.as_of.isoformat(),
+            "lifespan_years": grid.lifespan,
+            "total_units": grid.total_units,
+            "elapsed_units": grid.elapsed_units,
+            "remaining_units": grid.remaining_units,
+            "percent_lived": round(_pct(grid.elapsed_units, grid.total_units), 4),
+            "cols": grid.cols,
+        },
+        indent=2,
+    )
+
+
+def format_reference_json(mode: str = "weeks", lifespan: int = 90) -> str:
+    """Return the reference grid's phases and milestones as JSON."""
+    per_year = _UNITS_PER_YEAR[mode]
+    phases: list[dict[str, Any]] = []
+    for phase in _PHASES:
+        end_year = min(phase.end_year, float(lifespan))
+        phases.append(
+            {
+                "label": phase.label,
+                "start_year": phase.start_year,
+                "end_year": end_year,
+                "units": max(
+                    0, int(end_year * per_year) - int(phase.start_year * per_year)
+                ),
+            }
+        )
+
+    return json.dumps(
+        {
+            "mode": mode,
+            "lifespan_years": lifespan,
+            "total_units": lifespan * per_year,
+            "phases": phases,
+            "milestones": [
+                {"label": label, "unit_index": index}
+                for label, index in milestone_units(mode)
+            ],
+        },
+        indent=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error is not None:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    use_color = _use_color(args)
+
+    if args.reference:
+        if args.format == "json":
+            print(format_reference_json(args.mode, args.lifespan))
+        else:
+            print(format_reference(args.mode, args.lifespan, use_color))
+        return 0
+
+    try:
+        as_of = _parse_date(args.as_of) if args.as_of else date.today()
+        birth = _parse_date(args.birthdate)
+        grid = compute_grid(birth, as_of, args.mode, args.lifespan)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(format_json(grid))
+    else:
+        print(format_grid(grid, use_color))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/life_in_weeks.py
+++ b/src/utils/life_in_weeks.py
@@ -5,6 +5,10 @@ Inspired by Wait But Why's "Your Life in Weeks" (2014), this renders an ANSI
 grid where each cell is one week, month, or year of a nominal 90-year lifespan,
 color-coded to distinguish elapsed units from remaining ones.
 
+Cells use discrete shape glyphs rather than solid blocks, and are separated
+into groups (quarters for weeks and months) with a blank line between decades,
+so individual units stay countable instead of merging into a bar.
+
 The --reference view renders "The Life of a Typical American": the same grid
 shaded by life phase, with milestone markers. Phase boundaries and milestone
 ages are approximate US averages drawn from public sources:
@@ -20,6 +24,7 @@ Usage examples:
   life 1985-03-14 --mode months
   life 1985-03-14 --mode years --lifespan 100
   life --reference
+  life 1985-03-14 --group 4
   life 1985-03-14 --as-of 2030-01-01 --format json
 """
 
@@ -39,9 +44,16 @@ from typing import IO, Any, Mapping, NamedTuple
 _UNITS_PER_YEAR = {"weeks": 52, "months": 12, "years": 1}
 _COLS = {"weeks": 52, "months": 12, "years": 10}
 
-_ELAPSED = "█"
-_REMAINING = "░"
-_MILESTONE = "◆"
+# Cells per visual group, so a run of identical glyphs still reads as discrete
+# units: quarters for weeks and months, half-decades for years.
+_GROUP_DEFAULTS = {"weeks": 13, "months": 3, "years": 5}
+
+# Grids taller than this get a blank line between decades.
+_DECADE_BREAK_MIN = 20
+
+_ELAPSED = "■"
+_REMAINING = "□"
+_MILESTONE = "★"
 
 _RESET = "\033[0m"
 _COLORS = {
@@ -74,11 +86,11 @@ class Phase(NamedTuple):
 
 
 _PHASES: tuple[Phase, ...] = (
-    Phase("Childhood and K-12 school", 0.0, 18.0, "cyan", "▁"),
-    Phase("Higher education / early adulthood", 18.0, 22.0, "blue", "▃"),
-    Phase("Working years", 22.0, 62.0, "yellow", "▅"),
-    Phase("Retirement", 62.0, 78.4, "green", "▇"),
-    Phase("Beyond US life expectancy", 78.4, float("inf"), "dim", "░"),
+    Phase("Childhood and K-12 school", 0.0, 18.0, "cyan", "●"),
+    Phase("Higher education / early adulthood", 18.0, 22.0, "blue", "▲"),
+    Phase("Working years", 22.0, 62.0, "yellow", "■"),
+    Phase("Retirement", 62.0, 78.4, "green", "◆"),
+    Phase("Beyond US life expectancy", 78.4, float("inf"), "dim", "○"),
 )
 
 _MILESTONES: tuple[tuple[float, str], ...] = (
@@ -250,6 +262,7 @@ Examples:
   life 1985-03-14 --mode months
   life 1985-03-14 --mode years --lifespan 100
   life --reference
+  life 1985-03-14 --group 4
   life 1985-03-14 --as-of 2030-01-01 --format json
 """,
     )
@@ -286,6 +299,13 @@ Examples:
         help="render the typical-American reference grid instead of a personal one",
     )
     parser.add_argument(
+        "--group",
+        "-g",
+        type=int,
+        metavar="CELLS",
+        help="cells per visual group, 0 to disable (default: 13 weeks, 3 months, 5 years)",
+    )
+    parser.add_argument(
         "--no-color",
         action="store_true",
         help="disable ANSI color; glyphs alone distinguish the cells",
@@ -311,6 +331,8 @@ def validate(args: argparse.Namespace) -> str | None:
         return "BIRTHDATE is required unless --reference is used"
     if not 1 <= args.lifespan <= 150:
         return f"lifespan must be between 1 and 150, got {args.lifespan}"
+    if args.group is not None and args.group < 0:
+        return f"group must be 0 or greater, got {args.group}"
     return None
 
 
@@ -353,14 +375,15 @@ def _paint(text: str, color: str, use_color: bool) -> str:
     return f"{_COLORS[color]}{text}{_RESET}"
 
 
-_GLYPH_COLORS = {phase.glyph: phase.color for phase in _PHASES} | {
-    _ELAPSED: "cyan",
-    _REMAINING: "dim",
-    _MILESTONE: "magenta",
+# The personal and reference grids share the ■ glyph with different meanings,
+# so each carries its own glyph-to-color map rather than one merged lookup.
+_LIFE_COLORS = {_ELAPSED: "cyan", _REMAINING: "dim"}
+_PHASE_COLORS = {phase.glyph: phase.color for phase in _PHASES} | {
+    _MILESTONE: "magenta"
 }
 
 
-def _paint_row(row: str, use_color: bool) -> str:
+def _paint_row(row: str, colors: Mapping[str, str], use_color: bool) -> str:
     """Color a glyph row by grouping runs of identical glyphs."""
     if not use_color:
         return row
@@ -370,9 +393,23 @@ def _paint_row(row: str, use_color: bool) -> str:
     for i in range(1, len(row) + 1):
         if i == len(row) or row[i] != row[run_start]:
             glyph = row[run_start]
-            painted.append(_paint(row[run_start:i], _GLYPH_COLORS[glyph], True))
+            painted.append(_paint(row[run_start:i], colors[glyph], True))
             run_start = i
     return "".join(painted)
+
+
+def _render_row(
+    row: str, colors: Mapping[str, str], use_color: bool, group: int
+) -> str:
+    """Color a glyph row, separating every `group` cells with a space.
+
+    Grouping keeps runs of identical glyphs from merging into a solid bar, so
+    individual cells stay countable. A group of 0 or less disables separators.
+    """
+    if group <= 0:
+        return _paint_row(row, colors, use_color)
+    segments = [row[i : i + group] for i in range(0, len(row), group)]
+    return " ".join(_paint_row(segment, colors, use_color) for segment in segments)
 
 
 def _row_label(mode: str, row_index: int) -> str:
@@ -381,11 +418,29 @@ def _row_label(mode: str, row_index: int) -> str:
     return f"{age:>3} │ "
 
 
-def _render_grid(rows: list[str], mode: str, use_color: bool) -> list[str]:
-    """Return labelled, optionally colored grid lines."""
-    return [
-        _row_label(mode, i) + _paint_row(row, use_color) for i, row in enumerate(rows)
-    ]
+def _render_grid(
+    rows: list[str],
+    mode: str,
+    colors: Mapping[str, str],
+    use_color: bool,
+    group: int,
+) -> list[str]:
+    """Return labelled, optionally colored grid lines.
+
+    Grids taller than _DECADE_BREAK_MIN rows are split by a blank line every
+    decade, so a 90-row grid reads as nine blocks rather than one wall.
+    """
+    lines: list[str] = []
+    for i, row in enumerate(rows):
+        if i and i % 10 == 0 and len(rows) > _DECADE_BREAK_MIN:
+            lines.append("")
+        lines.append(_row_label(mode, i) + _render_row(row, colors, use_color, group))
+    return lines
+
+
+def resolve_group(mode: str, group: int | None) -> int:
+    """Return the cell-group size for a mode, falling back to its default."""
+    return _GROUP_DEFAULTS[mode] if group is None else group
 
 
 def _pct(part: int, whole: int) -> float:
@@ -393,7 +448,9 @@ def _pct(part: int, whole: int) -> float:
     return part / whole * 100.0
 
 
-def format_grid(grid: LifeGrid, use_color: bool = False) -> str:
+def format_grid(
+    grid: LifeGrid, use_color: bool = False, group: int | None = None
+) -> str:
     """Return the rendered personal life grid with legend and summary."""
     unit = grid.mode
     lines = [
@@ -408,7 +465,9 @@ def format_grid(grid: LifeGrid, use_color: bool = False) -> str:
         _render_grid(
             grid_rows(grid.total_units, grid.elapsed_units, grid.cols),
             grid.mode,
+            _LIFE_COLORS,
             use_color,
+            resolve_group(grid.mode, group),
         )
     )
     lines.extend(
@@ -424,7 +483,10 @@ def format_grid(grid: LifeGrid, use_color: bool = False) -> str:
 
 
 def format_reference(
-    mode: str = "weeks", lifespan: int = 90, use_color: bool = False
+    mode: str = "weeks",
+    lifespan: int = 90,
+    use_color: bool = False,
+    group: int | None = None,
 ) -> str:
     """Return the rendered typical-American reference grid with legend."""
     total = lifespan * _UNITS_PER_YEAR[mode]
@@ -436,7 +498,15 @@ def format_reference(
         "for sources (Census, NCHS, Gallup).",
         "",
     ]
-    lines.extend(_render_grid(reference_rows(mode, lifespan), mode, use_color))
+    lines.extend(
+        _render_grid(
+            reference_rows(mode, lifespan),
+            mode,
+            _PHASE_COLORS,
+            use_color,
+            resolve_group(mode, group),
+        )
+    )
     lines.append("")
 
     for phase in _PHASES:
@@ -523,7 +593,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.format == "json":
             print(format_reference_json(args.mode, args.lifespan))
         else:
-            print(format_reference(args.mode, args.lifespan, use_color))
+            print(format_reference(args.mode, args.lifespan, use_color, args.group))
         return 0
 
     try:
@@ -537,7 +607,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.format == "json":
         print(format_json(grid))
     else:
-        print(format_grid(grid, use_color))
+        print(format_grid(grid, use_color, args.group))
 
     return 0
 

--- a/tests/test_life_in_weeks.py
+++ b/tests/test_life_in_weeks.py
@@ -1,0 +1,434 @@
+"""Tests for the life-in-weeks grid visualizer utility."""
+
+import argparse
+import json
+from datetime import date
+
+import pytest
+
+from src.utils.life_in_weeks import (
+    _ELAPSED,
+    _MILESTONE,
+    _PHASES,
+    _REMAINING,
+    _paint,
+    _paint_row,
+    _parse_date,
+    _phase_for_age,
+    _row_label,
+    _use_color,
+    compute_grid,
+    format_grid,
+    format_json,
+    format_reference,
+    format_reference_json,
+    grid_rows,
+    main,
+    milestone_units,
+    reference_rows,
+    units_elapsed,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# units_elapsed
+# ---------------------------------------------------------------------------
+
+
+def test_units_elapsed_weeks_counts_whole_weeks():
+    assert units_elapsed(date(2020, 1, 1), date(2020, 1, 22), "weeks") == 3
+    assert units_elapsed(date(2020, 1, 1), date(2020, 1, 7), "weeks") == 0
+
+
+def test_units_elapsed_months_counts_whole_months():
+    assert units_elapsed(date(2020, 1, 15), date(2021, 1, 15), "months") == 12
+    assert units_elapsed(date(2020, 1, 15), date(2020, 3, 14), "months") == 1
+
+
+def test_units_elapsed_months_day_of_month_not_yet_reached():
+    assert units_elapsed(date(2020, 1, 31), date(2020, 2, 28), "months") == 0
+
+
+def test_units_elapsed_years_counts_whole_years():
+    assert units_elapsed(date(1985, 3, 14), date(2026, 3, 14), "years") == 41
+    assert units_elapsed(date(1985, 3, 14), date(2026, 3, 13), "years") == 40
+
+
+def test_units_elapsed_leap_day_birthdate_in_non_leap_year():
+    assert units_elapsed(date(2000, 2, 29), date(2001, 2, 28), "years") == 0
+    assert units_elapsed(date(2000, 2, 29), date(2001, 3, 1), "years") == 1
+
+
+def test_units_elapsed_same_day_is_zero():
+    assert units_elapsed(date(2020, 6, 1), date(2020, 6, 1), "weeks") == 0
+
+
+def test_units_elapsed_unknown_mode_raises():
+    with pytest.raises(ValueError, match="unknown mode"):
+        units_elapsed(date(2020, 1, 1), date(2020, 2, 1), "decades")
+
+
+def test_units_elapsed_as_of_before_birth_raises():
+    with pytest.raises(ValueError, match="is after as-of date"):
+        units_elapsed(date(2030, 1, 1), date(2026, 8, 7), "weeks")
+
+
+# ---------------------------------------------------------------------------
+# compute_grid
+# ---------------------------------------------------------------------------
+
+
+def test_compute_grid_weeks_defaults():
+    grid = compute_grid(date(1985, 3, 14), date(2026, 8, 7))
+    assert grid.mode == "weeks"
+    assert grid.total_units == 4680
+    assert grid.cols == 52
+    assert grid.elapsed_units + grid.remaining_units == grid.total_units
+
+
+def test_compute_grid_months_and_years_totals():
+    months = compute_grid(date(1985, 3, 14), date(2026, 8, 7), "months")
+    years = compute_grid(date(1985, 3, 14), date(2026, 8, 7), "years")
+    assert (months.total_units, months.cols) == (1080, 12)
+    assert (years.total_units, years.cols) == (90, 10)
+    assert years.elapsed_units == 41
+
+
+def test_compute_grid_custom_lifespan():
+    grid = compute_grid(date(1985, 3, 14), date(2026, 8, 7), "years", lifespan=100)
+    assert grid.total_units == 100
+    assert grid.remaining_units == 59
+
+
+def test_compute_grid_clamps_elapsed_at_grid_capacity():
+    # 52 weeks/year understates a real 90-year span by ~15 weeks; the clamp
+    # keeps elapsed from exceeding the grid.
+    grid = compute_grid(date(1900, 1, 1), date(2026, 8, 7))
+    assert grid.elapsed_units == grid.total_units == 4680
+    assert grid.remaining_units == 0
+
+
+def test_compute_grid_life_exactly_at_lifespan_is_full():
+    grid = compute_grid(date(1936, 8, 7), date(2026, 8, 7), "years")
+    assert grid.elapsed_units == 90
+    assert grid.remaining_units == 0
+
+
+def test_compute_grid_unknown_mode_raises():
+    with pytest.raises(ValueError, match="unknown mode"):
+        compute_grid(date(1985, 3, 14), date(2026, 8, 7), "decades")
+
+
+def test_compute_grid_non_positive_lifespan_raises():
+    with pytest.raises(ValueError, match="lifespan must be positive"):
+        compute_grid(date(1985, 3, 14), date(2026, 8, 7), "weeks", lifespan=0)
+
+
+# ---------------------------------------------------------------------------
+# grid_rows
+# ---------------------------------------------------------------------------
+
+
+def test_grid_rows_marks_leading_cells_as_elapsed():
+    rows = grid_rows(total=8, elapsed=3, cols=4)
+    assert rows == [_ELAPSED * 3 + _REMAINING, _REMAINING * 4]
+
+
+def test_grid_rows_final_row_may_be_short():
+    rows = grid_rows(total=7, elapsed=0, cols=4)
+    assert [len(row) for row in rows] == [4, 3]
+
+
+def test_grid_rows_all_elapsed():
+    assert grid_rows(total=4, elapsed=4, cols=4) == [_ELAPSED * 4]
+
+
+# ---------------------------------------------------------------------------
+# Reference grid
+# ---------------------------------------------------------------------------
+
+
+def test_phase_for_age_boundaries_are_half_open():
+    assert _phase_for_age(0.0).label.startswith("Childhood")
+    assert _phase_for_age(17.99).label.startswith("Childhood")
+    assert _phase_for_age(18.0).label.startswith("Higher education")
+    assert _phase_for_age(22.0).label == "Working years"
+    assert _phase_for_age(62.0).label == "Retirement"
+    assert _phase_for_age(80.0).label.startswith("Beyond")
+
+
+def test_reference_rows_shape_matches_mode():
+    rows = reference_rows("weeks", 90)
+    assert len(rows) == 90
+    assert all(len(row) == 52 for row in rows)
+
+
+def test_reference_rows_overlay_milestone_glyphs():
+    rows = reference_rows("years", 90)
+    assert "".join(rows).count(_MILESTONE) == 3
+
+
+def test_reference_rows_skips_milestones_beyond_lifespan():
+    rows = reference_rows("years", 10)
+    assert _MILESTONE not in "".join(rows)
+
+
+def test_reference_rows_uses_every_phase_glyph():
+    grid = "".join(reference_rows("weeks", 90))
+    for phase in _PHASES:
+        assert phase.glyph in grid
+
+
+def test_reference_rows_unknown_mode_raises():
+    with pytest.raises(ValueError, match="unknown mode"):
+        reference_rows("decades", 90)
+
+
+def test_reference_rows_non_positive_lifespan_raises():
+    with pytest.raises(ValueError, match="lifespan must be positive"):
+        reference_rows("weeks", 0)
+
+
+def test_milestone_units_scales_with_mode():
+    assert milestone_units("years")[2] == (
+        "average actual retirement age (Gallup 2023)",
+        62,
+    )
+    assert milestone_units("weeks")[2][1] == 62 * 52
+
+
+# ---------------------------------------------------------------------------
+# Validation and color detection
+# ---------------------------------------------------------------------------
+
+
+def _ns(**overrides) -> argparse.Namespace:
+    defaults = {
+        "birthdate": "1985-03-14",
+        "mode": "weeks",
+        "lifespan": 90,
+        "as_of": "2026-08-07",
+        "reference": False,
+        "no_color": False,
+        "format": "table",
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_validate_accepts_normal_arguments():
+    assert validate(_ns()) is None
+
+
+def test_validate_requires_birthdate_without_reference():
+    assert (
+        validate(_ns(birthdate=None))
+        == "BIRTHDATE is required unless --reference is used"
+    )
+
+
+def test_validate_allows_missing_birthdate_with_reference():
+    assert validate(_ns(birthdate=None, reference=True)) is None
+
+
+def test_validate_rejects_out_of_range_lifespan():
+    assert validate(_ns(lifespan=0)) == "lifespan must be between 1 and 150, got 0"
+    assert validate(_ns(lifespan=151)) == "lifespan must be between 1 and 150, got 151"
+
+
+def test_parse_date_accepts_iso():
+    assert _parse_date("2026-08-07") == date(2026, 8, 7)
+
+
+def test_parse_date_rejects_garbage():
+    with pytest.raises(ValueError, match="invalid date"):
+        _parse_date("07/08/2026")
+
+
+class _Stream:
+    def __init__(self, tty: bool):
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+def test_use_color_true_for_tty_without_no_color():
+    assert _use_color(_ns(), env={}, stream=_Stream(True)) is True
+
+
+def test_use_color_false_for_non_tty():
+    assert _use_color(_ns(), env={}, stream=_Stream(False)) is False
+
+
+def test_use_color_false_when_flag_set():
+    assert _use_color(_ns(no_color=True), env={}, stream=_Stream(True)) is False
+
+
+def test_use_color_false_when_no_color_env_set():
+    assert _use_color(_ns(), env={"NO_COLOR": "1"}, stream=_Stream(True)) is False
+
+
+def test_use_color_false_when_stream_lacks_isatty():
+    assert _use_color(_ns(), env={}, stream=object()) is False
+
+
+def test_use_color_reads_process_environment_by_default(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert _use_color(_ns(), stream=_Stream(True)) is False
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def test_paint_is_a_noop_without_color():
+    assert _paint(_ELAPSED, "cyan", False) == _ELAPSED
+    assert "\033[36m" in _paint(_ELAPSED, "cyan", True)
+
+
+def test_paint_row_groups_runs_of_identical_glyphs():
+    row = _ELAPSED * 2 + _REMAINING * 2
+    painted = _paint_row(row, True)
+    assert painted.count("\033[0m") == 2
+    assert _paint_row(row, False) == row
+
+
+def test_row_label_uses_decades_for_years_mode():
+    assert _row_label("years", 3) == " 30 │ "
+    assert _row_label("weeks", 3) == "  3 │ "
+
+
+def test_format_grid_contains_header_legend_and_summary():
+    grid = compute_grid(date(1985, 3, 14), date(2026, 8, 7), "years")
+    out = format_grid(grid)
+    assert "Your Life in Years" in out
+    assert "Birthdate:  1985-03-14" in out
+    assert "Lived:      41 years (45.6%)" in out
+    assert "Remaining:  49 years (54.4%)" in out
+    assert "\033[" not in out
+
+
+def test_format_grid_emits_ansi_when_colored():
+    grid = compute_grid(date(1985, 3, 14), date(2026, 8, 7), "years")
+    assert "\033[" in format_grid(grid, use_color=True)
+
+
+def test_format_grid_row_count_matches_grid():
+    grid = compute_grid(date(1985, 3, 14), date(2026, 8, 7))
+    body = [line for line in format_grid(grid).splitlines() if "│" in line]
+    assert len(body) == 90
+
+
+def test_format_reference_lists_every_phase_and_milestone():
+    out = format_reference("years", 90)
+    assert "The Life of a Typical American" in out
+    for phase in _PHASES:
+        assert phase.label in out
+    assert out.count("— year ") == 3
+    assert "(78.4-onward)" in out
+    assert "\033[" not in out
+
+
+def test_format_reference_emits_ansi_when_colored():
+    assert "\033[" in format_reference("years", 90, use_color=True)
+
+
+def test_format_json_round_trips():
+    grid = compute_grid(date(1985, 3, 14), date(2026, 8, 7))
+    data = json.loads(format_json(grid))
+    assert data["mode"] == "weeks"
+    assert data["birthdate"] == "1985-03-14"
+    assert data["elapsed_units"] + data["remaining_units"] == data["total_units"]
+    assert data["percent_lived"] == pytest.approx(
+        data["elapsed_units"] / data["total_units"] * 100, abs=5e-5
+    )
+
+
+def test_format_reference_json_reports_phase_unit_counts():
+    data = json.loads(format_reference_json("years", 90))
+    assert data["total_units"] == 90
+    assert sum(phase["units"] for phase in data["phases"]) == 90
+    assert len(data["milestones"]) == 3
+
+
+def test_format_reference_json_zeroes_phases_beyond_lifespan():
+    data = json.loads(format_reference_json("years", 10))
+    beyond = [phase for phase in data["phases"] if phase["start_year"] >= 10]
+    assert beyond and all(phase["units"] == 0 for phase in beyond)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def test_main_renders_personal_grid(capsys):
+    rc = main(["1985-03-14", "--mode", "years", "--as-of", "2026-08-07"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Your Life in Years" in out
+    assert "\033[" not in out
+
+
+def test_main_json_output(capsys):
+    rc = main(["1985-03-14", "--as-of", "2026-08-07", "--format", "json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["total_units"] == 4680
+
+
+def test_main_reference_needs_no_birthdate(capsys):
+    rc = main(["--reference", "--mode", "years"])
+    assert rc == 0
+    assert "The Life of a Typical American" in capsys.readouterr().out
+
+
+def test_main_reference_json_output(capsys):
+    rc = main(["--reference", "--mode", "years", "--format", "json"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["lifespan_years"] == 90
+
+
+def test_main_defaults_as_of_to_today(capsys):
+    rc = main(["1985-03-14", "--mode", "years", "--format", "json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["as_of"] == date.today().isoformat()
+
+
+def test_main_no_color_flag_suppresses_ansi(capsys):
+    rc = main(["1985-03-14", "--mode", "years", "--as-of", "2026-08-07", "--no-color"])
+    assert rc == 0
+    assert "\033[" not in capsys.readouterr().out
+
+
+def test_main_missing_birthdate_returns_2(capsys):
+    rc = main([])
+    assert rc == 2
+    assert "Error" in capsys.readouterr().err
+
+
+def test_main_invalid_lifespan_returns_2(capsys):
+    rc = main(["1985-03-14", "--lifespan", "0"])
+    assert rc == 2
+    assert "lifespan must be between 1 and 150" in capsys.readouterr().err
+
+
+def test_main_future_birthdate_returns_2(capsys):
+    rc = main(["2030-01-01", "--as-of", "2026-08-07"])
+    assert rc == 2
+    assert "is after as-of date" in capsys.readouterr().err
+
+
+def test_main_malformed_date_returns_2(capsys):
+    rc = main(["not-a-date", "--as-of", "2026-08-07"])
+    assert rc == 2
+    assert "invalid date" in capsys.readouterr().err
+
+
+def test_main_malformed_as_of_returns_2(capsys):
+    rc = main(["1985-03-14", "--as-of", "yesterday"])
+    assert rc == 2
+    assert "invalid date" in capsys.readouterr().err

--- a/tests/test_life_in_weeks.py
+++ b/tests/test_life_in_weeks.py
@@ -8,13 +8,16 @@ import pytest
 
 from src.utils.life_in_weeks import (
     _ELAPSED,
+    _LIFE_COLORS,
     _MILESTONE,
+    _PHASE_COLORS,
     _PHASES,
     _REMAINING,
     _paint,
     _paint_row,
     _parse_date,
     _phase_for_age,
+    _render_row,
     _row_label,
     _use_color,
     compute_grid,
@@ -26,6 +29,7 @@ from src.utils.life_in_weeks import (
     main,
     milestone_units,
     reference_rows,
+    resolve_group,
     units_elapsed,
     validate,
 )
@@ -208,6 +212,7 @@ def _ns(**overrides) -> argparse.Namespace:
         "mode": "weeks",
         "lifespan": 90,
         "as_of": "2026-08-07",
+        "group": None,
         "reference": False,
         "no_color": False,
         "format": "table",
@@ -290,9 +295,46 @@ def test_paint_is_a_noop_without_color():
 
 def test_paint_row_groups_runs_of_identical_glyphs():
     row = _ELAPSED * 2 + _REMAINING * 2
-    painted = _paint_row(row, True)
+    painted = _paint_row(row, _LIFE_COLORS, True)
     assert painted.count("\033[0m") == 2
-    assert _paint_row(row, False) == row
+    assert _paint_row(row, _LIFE_COLORS, False) == row
+
+
+def test_render_row_separates_cells_into_groups():
+    row = _ELAPSED * 6
+    assert _render_row(row, _LIFE_COLORS, False, 2) == "■■ ■■ ■■"
+    assert _render_row(row, _LIFE_COLORS, False, 1) == "■ ■ ■ ■ ■ ■"
+
+
+def test_render_row_group_of_zero_disables_separators():
+    row = _ELAPSED * 6
+    assert _render_row(row, _LIFE_COLORS, False, 0) == row
+    assert _render_row(row, _LIFE_COLORS, False, -1) == row
+
+
+def test_render_row_final_group_may_be_short():
+    assert _render_row(_ELAPSED * 5, _LIFE_COLORS, False, 2) == "■■ ■■ ■"
+
+
+def test_render_row_colors_each_group_independently():
+    painted = _render_row(_ELAPSED * 4, _LIFE_COLORS, True, 2)
+    assert painted.count("\033[0m") == 2
+    assert " " in painted
+
+
+def test_resolve_group_falls_back_to_mode_default():
+    assert resolve_group("weeks", None) == 13
+    assert resolve_group("months", None) == 3
+    assert resolve_group("years", None) == 5
+    assert resolve_group("weeks", 4) == 4
+    assert resolve_group("weeks", 0) == 0
+
+
+def test_life_and_phase_colors_disambiguate_the_shared_square_glyph():
+    # ■ means "lived" in the personal grid and "working years" in the
+    # reference grid; the two maps must not collide.
+    assert _LIFE_COLORS[_ELAPSED] == "cyan"
+    assert _PHASE_COLORS[_ELAPSED] == "yellow"
 
 
 def test_row_label_uses_decades_for_years_mode():
@@ -319,6 +361,39 @@ def test_format_grid_row_count_matches_grid():
     grid = compute_grid(date(1985, 3, 14), date(2026, 8, 7))
     body = [line for line in format_grid(grid).splitlines() if "│" in line]
     assert len(body) == 90
+
+
+def test_format_grid_groups_weeks_into_quarters_by_default():
+    grid = compute_grid(date(1985, 3, 14), date(2026, 8, 7))
+    row = next(line for line in format_grid(grid).splitlines() if "│" in line)
+    cells = row.split("│ ")[1]
+    # 52 weeks in four groups of 13, separated by three spaces.
+    assert [len(group) for group in cells.split(" ")] == [13, 13, 13, 13]
+    # Grid plus label stays inside an 80-column terminal.
+    assert len(row) == 61
+
+
+def test_format_grid_breaks_tall_grids_every_decade():
+    grid = compute_grid(date(1985, 3, 14), date(2026, 8, 7))
+    lines = format_grid(grid).splitlines()
+    # Grid body sits between the 6-line header and the 5-line legend/summary.
+    body = lines[6:-5]
+    # 90 rows in nine decade blocks separated by eight blank lines.
+    assert sum(1 for line in body if not line) == 8
+    assert body[10] == ""
+
+
+def test_format_grid_short_grids_are_not_broken():
+    grid = compute_grid(date(1985, 3, 14), date(2026, 8, 7), "years")
+    rows = [line for line in format_grid(grid).splitlines() if "│" in line]
+    assert len(rows) == 9
+    assert "\n\n" not in "\n".join(rows)
+
+
+def test_format_grid_group_zero_renders_an_unbroken_row():
+    grid = compute_grid(date(1985, 3, 14), date(2026, 8, 7))
+    row = next(line for line in format_grid(grid, group=0).splitlines() if "│" in line)
+    assert " " not in row.split("│ ")[1]
 
 
 def test_format_reference_lists_every_phase_and_milestone():
@@ -396,6 +471,21 @@ def test_main_defaults_as_of_to_today(capsys):
     assert rc == 0
     data = json.loads(capsys.readouterr().out)
     assert data["as_of"] == date.today().isoformat()
+
+
+def test_main_group_flag_changes_cell_separation(capsys):
+    rc = main(
+        ["1985-03-14", "--mode", "years", "--as-of", "2026-08-07", "--group", "2"]
+    )
+    assert rc == 0
+    row = next(line for line in capsys.readouterr().out.splitlines() if "│" in line)
+    assert row.split("│ ")[1] == "■■ ■■ ■■ ■■ ■■"
+
+
+def test_main_negative_group_returns_2(capsys):
+    rc = main(["1985-03-14", "--group", "-2"])
+    assert rc == 2
+    assert "group must be 0 or greater" in capsys.readouterr().err
 
 
 def test_main_no_color_flag_suppresses_ansi(capsys):


### PR DESCRIPTION
Adds a `life` CLI tool that renders a human life as an ANSI grid — one cell per week, month, or year of a nominal 90-year lifespan — color-coded elapsed vs remaining from a birthdate.

## Design notes

**Modes.** The issue listed `weeks` / `months` / `decades`; a decades grid is only 9 cells, so `decades` was replaced with `years` (10×9), which is one of the three grids the original article actually shows.

**Reference grid.** The Wait But Why article publishes no numeric table, and its typical-American chart is sourced from Gallup (retirement age), Pew (marriage age), BabyCenter (first birth), and Census — i.e. it is a life-milestone chart, not a time-use chart. `--reference` is therefore built from cited US milestone constants, with sources and years in the module docstring, rather than invented percentages.

**Determinism.** Core functions take an injected `as_of` date; `date.today()` appears once, at the CLI boundary. `--as-of` is both a test-stability mechanism and a documented what-if feature.

**Legibility.** Cells are discrete shape glyphs (`■` lived, `□` remaining; `●▲■◆○` per life phase, `★` milestones) grouped into quarters with a blank line between decades, so runs stay countable instead of merging into a bar. `--group` overrides the group size.

**Color.** Glyph generation is separate from colorization, so `--no-color`, `NO_COLOR`, and non-tty output are escape-free and still readable. Nothing else in `src/` implemented `NO_COLOR`, so this establishes the convention rather than following one.

## Verification

- 1291 tests pass; `src/utils/life_in_weeks.py` at 100% coverage
- ruff format + check clean; mypy clean on the new module
- Weeks grid renders at 61 columns, inside an 80-column terminal

## Notes

- `CHANGELOG.md` and the version bump are deferred to the release flow, matching how v0.21.0 was assembled.
- `life BIRTHDATE --reference` currently ignores the birthdate and prints only the reference grid. The issue asked for a dedicated comparison view, which is what this builds; printing both grids or erroring is a follow-up decision.
- The milestone-overlay work marked "Deferred" in the issue is not included.

Closes #46