### PR TITLE
Speed up the test suite and remove coverage-shaped code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,14 @@
 # content of .pre-commit-config.yaml
+#
+# Supply-chain policy: never pin a `rev` younger than 72 hours. A compromised
+# publish is usually caught and yanked well inside that window, so the delay is
+# cheap insurance. Check the tag date before bumping:
+#
+#     gh api repos/<owner>/<repo>/tags --jq '.[0:5][] | .name'
+#     gh api repos/<owner>/<repo>/commits/<sha> --jq '.commit.committer.date'
+#
+# `pre-commit autoupdate` does not honour this — it takes the newest tag
+# unconditionally. Verify the date after running it.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -8,9 +18,13 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
 
+  # Rule selection lives in pyproject.toml [tool.ruff.lint] rather than in
+  # hook args, so `uvx ruff@0.16.1` locally and this hook enforce the same set.
+  # That also pins the rule set against ruff's own defaults changing: 0.16.0
+  # widened them, which would otherwise have surfaced 173 new findings here.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.4
+    rev: v0.16.1 # tagged 2026-07-30; 0.16.2 was <72h old at pin time
     hooks:
-      - id: ruff
-        args: [--fix, --extend-select=I, --line-length=120]
+      - id: ruff-check # `ruff` is a deprecated alias as of 0.16
+        args: [--fix]
       - id: ruff-format

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
     "python.testing.pytestArgs": [
         "tests"
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,19 @@ dev = [
     "pytest-cov>=7.0.0",
 ]
 
+[tool.ruff.lint]
+# Pinned explicitly so a ruff upgrade cannot silently change what is enforced.
+# The repo previously carried no ruff config and inherited ruff's defaults;
+# ruff 0.16.0 then widened those defaults and surfaced 173 new findings.
+#
+# This is ruff's pre-0.16 default set (E4/E7/E9/F) plus import sorting, which
+# the pre-commit hook previously passed as --extend-select=I.
+#
+# line-length is intentionally left at the default 88, which is what the
+# formatter has always used here. The hook's old --line-length=120 applied
+# only to `ruff check` and was inert: E501 lives in E5, which is not selected.
+select = ["E4", "E7", "E9", "F", "I"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ pythonpath = ["src"]
 addopts = "--ignore=tests/_*.py --cov=src --cov-report=term-missing --cov-report=xml"
 
 [tool.coverage.run]
+core = "sysmon"
 source = ["src"]
 omit = [
     "src/__init__.py",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "72 hours",
+  "internalChecksFilter": "strict",
+  "pre-commit": {
+    "enabled": true
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "packageRules": [
+    {
+      "description": "Ruff upgrades change formatter output and rule defaults, so they need a human to read the diff rather than an automerge.",
+      "matchPackageNames": ["astral-sh/ruff-pre-commit", "ruff"],
+      "automerge": false
+    }
+  ]
+}

--- a/src/utils/collatz_conjecture.py
+++ b/src/utils/collatz_conjecture.py
@@ -274,7 +274,7 @@ def main():
                 )
 
         # Print summary statistics
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"Summary for range [{start}, {end}]:")
         print(f"  Numbers tested: {len(results)}")
         print(f"  Average steps: {sum(r[1] for r in results) / len(results):.2f}")

--- a/src/utils/confidence_intervals.py
+++ b/src/utils/confidence_intervals.py
@@ -542,7 +542,7 @@ def main() -> int:
         print(f"Sample: n = {args.n}, k = {args.k}, p̂ = {p_hat:.{args.precision}f}")
         print(f"Interval: [{lower:.{args.precision}f}, {upper:.{args.precision}f}]")
         print(f"Width: {width:.{args.precision}f}")
-        print(f"Margin: ±{width/2:.{args.precision}f}")
+        print(f"Margin: ±{width / 2:.{args.precision}f}")
 
     elif args.method == "t":
         # t-interval for mean
@@ -556,7 +556,7 @@ def main() -> int:
         )
         print(f"Interval: [{lower:.{args.precision}f}, {upper:.{args.precision}f}]")
         print(f"Width: {width:.{args.precision}f}")
-        print(f"Margin: ±{width/2:.{args.precision}f}")
+        print(f"Margin: ±{width / 2:.{args.precision}f}")
 
     elif args.method == "poisson":
         # Poisson interval

--- a/src/utils/jevons_paradox.py
+++ b/src/utils/jevons_paradox.py
@@ -272,15 +272,13 @@ def format_analysis(
         f"Price elasticity:        {_fmt(epsilon, p)}",
         f"Baseline consumption:    {_fmt(baseline, p)} {lbl}",
         "",
-        f"Expected savings (no rebound):  {_fmt(exp_sav, p)} {lbl} "
-        f"({_pct(eta, p)})",
+        f"Expected savings (no rebound):  {_fmt(exp_sav, p)} {lbl} ({_pct(eta, p)})",
         f"Rebound consumption:            {_fmt(reb_con, p)} {lbl}",
         f"Actual savings (after rebound): {_fmt(act_sav, p)} {lbl} "
         f"({_pct(act_sav / baseline, p)})",
         f"Net consumption:                {_fmt(net_con, p)} {lbl} "
         f"({_pct(net_con / baseline, p)})",
-        f"Rebound rate:                   "
-        f"{_fmt(rate * 100.0, p)}% of expected savings",
+        f"Rebound rate:                   {_fmt(rate * 100.0, p)}% of expected savings",
         "",
         f"Outcome: {outcome_label(rate)}",
     ]

--- a/src/utils/life_in_weeks.py
+++ b/src/utils/life_in_weeks.py
@@ -35,7 +35,7 @@ import json
 import os
 import sys
 from datetime import date
-from typing import IO, Any, Mapping, NamedTuple
+from typing import Any, Mapping, NamedTuple
 
 # ---------------------------------------------------------------------------
 # Core functions
@@ -347,12 +347,16 @@ def _parse_date(raw: str) -> date:
 def _use_color(
     args: argparse.Namespace,
     env: Mapping[str, str] | None = None,
-    stream: IO[str] | None = None,
+    stream: object | None = None,
 ) -> bool:
     """Return whether ANSI color should be emitted.
 
     Color is suppressed by --no-color, by a non-empty NO_COLOR environment
     variable, or when the output stream is not a terminal.
+
+    ``stream`` is typed as ``object`` rather than ``IO[str]`` on purpose: the
+    tty check goes through ``getattr`` with a fallback, so anything at all is
+    accepted, including objects with no ``isatty`` at all.
     """
     if args.no_color:
         return False

--- a/src/utils/linear_regression.py
+++ b/src/utils/linear_regression.py
@@ -35,6 +35,11 @@ Usage examples:
   linreg --x 10,20,30 --y 15,28,41 --alpha 0.05 --predict 40
 """
 
+# Floor for the Lentz continued-fraction denominators in incomplete_beta. Module
+# level so tests can monkeypatch it to exercise the guards, which real inputs do
+# not reach.
+_TINY = 1e-30
+
 
 class RegressionResult:
     """Container for linear regression results."""
@@ -222,9 +227,7 @@ def t_cdf(t: float, df: int) -> float:
     return p
 
 
-def incomplete_beta(
-    a: float, b: float, x: float, _test_force_tiny: bool = False
-) -> float:
+def incomplete_beta(a: float, b: float, x: float) -> float:
     """Regularized incomplete beta function I_x(a,b).
 
     Uses continued fraction approximation.
@@ -233,7 +236,6 @@ def incomplete_beta(
         a: First beta distribution parameter
         b: Second beta distribution parameter
         x: Value at which to evaluate (between 0 and 1)
-        _test_force_tiny: Internal testing flag to force tiny value checks (for coverage)
     """
     if x < 0.0 or x > 1.0:
         return 0.0 if x < 0.0 else 1.0
@@ -245,7 +247,7 @@ def incomplete_beta(
 
     # Use symmetry relation if x > (a+1)/(a+b+2)
     if x > (a + 1.0) / (a + b + 2.0):
-        return 1.0 - incomplete_beta(b, a, 1.0 - x, _test_force_tiny)
+        return 1.0 - incomplete_beta(b, a, 1.0 - x)
 
     # Compute log of beta function B(a,b) = Γ(a)Γ(b)/Γ(a+b)
     log_beta = math.lgamma(a) + math.lgamma(b) - math.lgamma(a + b)
@@ -254,7 +256,6 @@ def incomplete_beta(
     front = math.exp(a * math.log(x) + b * math.log(1.0 - x) - log_beta) / a
 
     # Continued fraction using Lentz's algorithm
-    tiny = 1e-30
     max_iter = 200
 
     # Initialize
@@ -274,19 +275,13 @@ def incomplete_beta(
         )
 
         d = 1.0 + numerator * d
-        # Force tiny value for testing coverage (line 273)
-        if _test_force_tiny and m == 1:
-            d = tiny / 2.0
-        if abs(d) < tiny:
-            d = tiny
+        if abs(d) < _TINY:
+            d = _TINY
         d = 1.0 / d
 
         c = 1.0 + numerator / c
-        # Force tiny value for testing coverage (line 278)
-        if _test_force_tiny and m == 1:
-            c = tiny / 2.0
-        if abs(c) < tiny:
-            c = tiny
+        if abs(c) < _TINY:
+            c = _TINY
 
         f *= c * d
 
@@ -299,19 +294,13 @@ def incomplete_beta(
         )
 
         d = 1.0 + numerator * d
-        # Force tiny value for testing coverage (line 289)
-        if _test_force_tiny and m == 1:
-            d = tiny / 2.0
-        if abs(d) < tiny:
-            d = tiny
+        if abs(d) < _TINY:
+            d = _TINY
         d = 1.0 / d
 
         c = 1.0 + numerator / c
-        # Force tiny value for testing coverage (line 294)
-        if _test_force_tiny and m == 1:
-            c = tiny / 2.0
-        if abs(c) < tiny:
-            c = tiny
+        if abs(c) < _TINY:
+            c = _TINY
 
         delta = c * d
         f *= delta

--- a/src/utils/monte_carlo.py
+++ b/src/utils/monte_carlo.py
@@ -43,8 +43,6 @@ Usage examples:
   simulate --experiment linboot --params x=1,2,3,4,5 y=2.1,3.9,6.2,7.8,10.1 predict=6
 """
 
-HAS_NUMPY = True
-
 # ---------------------------------------------------------------------------
 # Analytical comparison imports — degrade gracefully if unavailable
 # ---------------------------------------------------------------------------
@@ -184,35 +182,20 @@ def simulate_binomial(
     n: int, k: int, p: float, trials: int, seed: Optional[int]
 ) -> list[int]:
     """Per-trial outcomes (1/0) for P(X ≥ k) where X ~ Binomial(n, p)."""
-    if HAS_NUMPY:
-        rng = np.random.default_rng(seed)
-        counts = rng.binomial(n, p, size=trials)
-        return (counts >= k).astype(int).tolist()
-    else:  # pragma: no cover
-        rng = random.Random(seed)
-        return [
-            1 if sum(1 for _ in range(n) if rng.random() < p) >= k else 0
-            for _ in range(trials)
-        ]
+    rng = np.random.default_rng(seed)
+    counts = rng.binomial(n, p, size=trials)
+    return (counts >= k).astype(int).tolist()
 
 
 def simulate_birthday(
     pool: int, group: int, trials: int, seed: Optional[int]
 ) -> list[int]:
     """Per-trial collision indicators for the birthday problem."""
-    if HAS_NUMPY:
-        rng = np.random.default_rng(seed)
-        samples = rng.integers(0, pool, size=(trials, group))
-        sorted_s = np.sort(samples, axis=1)
-        collisions = np.any(np.diff(sorted_s, axis=1) == 0, axis=1)
-        return collisions.astype(int).tolist()
-    else:  # pragma: no cover
-        rng = random.Random(seed)
-        results = []
-        for _ in range(trials):
-            draws = [rng.randrange(pool) for _ in range(group)]
-            results.append(1 if len(set(draws)) < group else 0)
-        return results
+    rng = np.random.default_rng(seed)
+    samples = rng.integers(0, pool, size=(trials, group))
+    sorted_s = np.sort(samples, axis=1)
+    collisions = np.any(np.diff(sorted_s, axis=1) == 0, axis=1)
+    return collisions.astype(int).tolist()
 
 
 def simulate_streak(
@@ -238,24 +221,9 @@ def simulate_streak(
 
 def simulate_poisson(lam: float, k: int, trials: int, seed: Optional[int]) -> list[int]:
     """Per-trial outcomes (1/0) for P(X ≥ k) where X ~ Poisson(λ)."""
-    if HAS_NUMPY:
-        rng = np.random.default_rng(seed)
-        counts = rng.poisson(lam, size=trials)
-        return (counts >= k).astype(int).tolist()
-    else:  # pragma: no cover
-        rng = random.Random(seed)
-        L = math.exp(-lam)
-        results = []
-        for _ in range(trials):
-            count = 0
-            prod = 1.0
-            while True:
-                prod *= rng.random()
-                if prod < L:
-                    break
-                count += 1
-            results.append(1 if count >= k else 0)
-        return results
+    rng = np.random.default_rng(seed)
+    counts = rng.poisson(lam, size=trials)
+    return (counts >= k).astype(int).tolist()
 
 
 # ---------------------------------------------------------------------------
@@ -431,22 +399,11 @@ def simulate_season(
     games = int(params.get("games", "162"))
     wins_ge = params.get("wins_ge")
 
-    if HAS_NUMPY:
-        rng = np.random.default_rng(seed)
-        win_counts = rng.binomial(games, win_pct, size=trials)
-        if wins_ge is not None:
-            return (win_counts >= int(wins_ge)).astype(int).tolist()
-        return win_counts.tolist()
-    else:  # pragma: no cover
-        rng = random.Random(seed)
-        win_counts = [
-            sum(1 for _ in range(games) if rng.random() < win_pct)
-            for _ in range(trials)
-        ]
-        if wins_ge is not None:
-            k = int(wins_ge)
-            return [1 if w >= k else 0 for w in win_counts]
-        return win_counts
+    rng = np.random.default_rng(seed)
+    win_counts = rng.binomial(games, win_pct, size=trials)
+    if wins_ge is not None:
+        return (win_counts >= int(wins_ge)).astype(int).tolist()
+    return win_counts.tolist()
 
 
 def simulate_linboot(
@@ -463,7 +420,7 @@ def simulate_linboot(
     Returns:
         (slopes, intercepts, predictions) — lists of length ≤ trials.
     """
-    if _linear_regression is None:  # pragma: no cover
+    if _linear_regression is None:
         raise RuntimeError("linear_regression module not available")
 
     x = [float(v) for v in params["x"].split(",")]
@@ -536,7 +493,7 @@ def run_experiment(
         return simulate_bayes(params, trials, seed)
     if experiment == "season":
         return simulate_season(params, trials, seed)
-    raise ValueError(f"Unknown experiment: {experiment!r}")  # pragma: no cover
+    raise ValueError(f"Unknown experiment: {experiment!r}")
 
 
 def analytical_value(experiment: str, params: dict[str, str]) -> Optional[float]:

--- a/src/utils/spearman_correlation.py
+++ b/src/utils/spearman_correlation.py
@@ -485,7 +485,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         print("-" * 56)
         for i in range(n):
             print(
-                f"{i+1:>6} {x_values[i]:>10.3f} {rank_x[i]:>10.1f} {y_values[i]:>10.3f} {rank_y[i]:>10.1f}"
+                f"{i + 1:>6} {x_values[i]:>10.3f} {rank_x[i]:>10.1f} {y_values[i]:>10.3f} {rank_y[i]:>10.1f}"
             )
         print()
 

--- a/tests/test_anova.py
+++ b/tests/test_anova.py
@@ -174,10 +174,11 @@ def test_anova_one_way_zero_within_variance_different_means():
 # ---------------------------------------------------------------------------
 
 
-def test_bonferroni_pair_count():
+def test_bonferroni_pair_count_and_significance():
     result = anova_one_way([G1, G2, G3])
     comparisons = bonferroni([G1, G2, G3], result)
     assert len(comparisons) == 3  # C(3, 2)
+    assert all(c.significant for c in comparisons)
 
 
 def test_bonferroni_matches_manual_two_group_case():
@@ -222,12 +223,6 @@ def test_bonferroni_invalid_alpha_raises():
     result = anova_one_way([G1, G2])
     with pytest.raises(ValueError, match="alpha must be"):
         bonferroni([G1, G2], result, alpha=0.0)
-
-
-def test_bonferroni_significance_flag():
-    result = anova_one_way([G1, G2, G3])
-    comparisons = bonferroni([G1, G2, G3], result)
-    assert all(c.significant for c in comparisons)
 
 
 # ---------------------------------------------------------------------------
@@ -329,14 +324,10 @@ def test_tukey_hsd_matches_scipy_oracle():
     result = anova_one_way([G1, G2, G3])
     tukey_result = tukey_hsd([G1, G2, G3], result)
     want = scipy_stats.tukey_hsd(G1, G2, G3)
+    assert len(tukey_result.comparisons) == 3
     for c in tukey_result.comparisons:
         assert c.p_value == pytest.approx(want.pvalue[c.i][c.j], abs=1e-6)
-
-
-def test_tukey_hsd_pair_count():
-    result = anova_one_way([G1, G2, G3])
-    tukey_result = tukey_hsd([G1, G2, G3], result)
-    assert len(tukey_result.comparisons) == 3
+        assert c.significant
 
 
 def test_tukey_hsd_two_group_matches_t_test():
@@ -373,12 +364,6 @@ def test_tukey_hsd_zero_se_different_means():
     pair = next(c for c in tukey_result.comparisons if c.i == 0 and c.j == 1)
     assert math.isinf(pair.q_stat)
     assert pair.p_value == 0.0
-
-
-def test_tukey_hsd_significance_flag():
-    result = anova_one_way([G1, G2, G3])
-    tukey_result = tukey_hsd([G1, G2, G3], result)
-    assert all(c.significant for c in tukey_result.comparisons)
 
 
 # ---------------------------------------------------------------------------
@@ -456,33 +441,35 @@ def _ns(**kwargs):
 
 
 def test_validate_alpha_out_of_range():
-    assert "--alpha" in validate(_ns(alpha=0.0))
+    result = validate(_ns(alpha=0.0))
+    assert result is not None and "--alpha" in result
 
 
 def test_validate_precision_negative():
-    assert "--precision" in validate(_ns(precision=-1))
+    result = validate(_ns(precision=-1))
+    assert result is not None and "--precision" in result
 
 
 def test_validate_no_input_source():
-    assert "provide either" in validate(_ns())
+    result = validate(_ns())
+    assert result is not None and "provide either" in result
 
 
 def test_validate_both_input_sources():
-    assert "not both" in validate(
+    result = validate(
         _ns(data=["1,2", "3,4"], file="x.csv", group_col="g", value_col="v")
     )
+    assert result is not None and "not both" in result
 
 
 def test_validate_data_too_few_groups():
-    assert "at least 2 groups" in validate(_ns(data=["1,2,3"]))
+    result = validate(_ns(data=["1,2,3"]))
+    assert result is not None and "at least 2 groups" in result
 
 
 def test_validate_file_missing_columns():
-    assert "requires both" in validate(_ns(file="x.csv"))
-
-
-def test_validate_valid_data_tukey():
-    assert validate(_ns(data=["1,2", "3,4"], posthoc="tukey")) is None
+    result = validate(_ns(file="x.csv"))
+    assert result is not None and "requires both" in result
 
 
 def test_validate_valid_data():

--- a/tests/test_chi_squared.py
+++ b/tests/test_chi_squared.py
@@ -223,21 +223,23 @@ def _ns(**kwargs):
 
 
 def test_validate_alpha_out_of_range():
-    assert "--alpha" in validate(_ns(alpha=0.0))
+    result = validate(_ns(alpha=0.0))
+    assert result is not None and "--alpha" in result
 
 
 def test_validate_precision_negative():
-    assert "--precision" in validate(_ns(precision=-1))
+    result = validate(_ns(precision=-1))
+    assert result is not None and "--precision" in result
 
 
 def test_validate_gof_missing_observed():
-    assert "requires both" in validate(_ns(test="gof", expected="1,2"))
+    result = validate(_ns(test="gof", expected="1,2"))
+    assert result is not None and "requires both" in result
 
 
 def test_validate_gof_with_table_errors():
-    assert "--table" in validate(
-        _ns(test="gof", observed="1,2", expected="1,2", table=["1,2"])
-    )
+    result = validate(_ns(test="gof", observed="1,2", expected="1,2", table=["1,2"]))
+    assert result is not None and "--table" in result
 
 
 def test_validate_gof_valid():
@@ -245,17 +247,18 @@ def test_validate_gof_valid():
 
 
 def test_validate_independence_missing_table():
-    assert "at least two" in validate(_ns(test="independence", table=None))
+    result = validate(_ns(test="independence", table=None))
+    assert result is not None and "at least two" in result
 
 
 def test_validate_independence_single_row():
-    assert "at least two" in validate(_ns(test="independence", table=["1,2"]))
+    result = validate(_ns(test="independence", table=["1,2"]))
+    assert result is not None and "at least two" in result
 
 
 def test_validate_independence_with_observed_errors():
-    assert "not used" in validate(
-        _ns(test="independence", table=["1,2", "3,4"], observed="1,2")
-    )
+    result = validate(_ns(test="independence", table=["1,2", "3,4"], observed="1,2"))
+    assert result is not None and "not used" in result
 
 
 def test_validate_independence_valid():

--- a/tests/test_collatz_conjecture.py
+++ b/tests/test_collatz_conjecture.py
@@ -75,9 +75,9 @@ def test_precomputed_steps_reused():
         20: 0,
     }
     for k, expected_steps in expected.items():
-        assert (
-            checker.steps_for[k] == expected_steps
-        ), f"steps_for[{k}]: expected {expected_steps}, got {checker.steps_for[k]}"
+        assert checker.steps_for[k] == expected_steps, (
+            f"steps_for[{k}]: expected {expected_steps}, got {checker.steps_for[k]}"
+        )
 
 
 def test_verbose_output(capsys):

--- a/tests/test_crt.py
+++ b/tests/test_crt.py
@@ -165,33 +165,39 @@ def test_crt_result_in_range():
 
 def test_validate_no_solve():
     args = argparse.Namespace(solve=None, all=None, format="table")
-    assert "--solve" in validate(args)
+    result = validate(args)
+    assert result is not None and "--solve" in result
 
 
 def test_validate_single_value():
     args = argparse.Namespace(solve=[3], all=None, format="table")
-    assert "pair" in validate(args)
+    result = validate(args)
+    assert result is not None and "pair" in result
 
 
 def test_validate_odd_values():
     args = argparse.Namespace(solve=[2, 3, 4], all=None, format="table")
-    assert "even" in validate(args)
+    result = validate(args)
+    assert result is not None and "even" in result
 
 
 def test_validate_modulus_zero():
     # Moduli are at odd indices; index 1 is the first modulus
     args = argparse.Namespace(solve=[2, 0, 3, 5], all=None, format="table")
-    assert ">= 1" in validate(args)
+    result = validate(args)
+    assert result is not None and ">= 1" in result
 
 
 def test_validate_modulus_negative():
     args = argparse.Namespace(solve=[2, 3, 1, -5], all=None, format="table")
-    assert ">= 1" in validate(args)
+    result = validate(args)
+    assert result is not None and ">= 1" in result
 
 
 def test_validate_all_negative():
     args = argparse.Namespace(solve=[2, 3, 3, 5], all=-1, format="table")
-    assert "--all" in validate(args)
+    result = validate(args)
+    assert result is not None and "--all" in result
 
 
 def test_validate_valid():

--- a/tests/test_euler.py
+++ b/tests/test_euler.py
@@ -211,7 +211,8 @@ def test_validate_no_mode():
         precision=10,
         format="table",
     )
-    assert "required" in validate(args)
+    result = validate(args)
+    assert result is not None and "required" in result
 
 
 def test_validate_negative_precision():
@@ -226,7 +227,8 @@ def test_validate_negative_precision():
         precision=-1,
         format="table",
     )
-    assert "--precision" in validate(args)
+    result = validate(args)
+    assert result is not None and "--precision" in result
 
 
 def test_validate_approx_zero():
@@ -241,7 +243,8 @@ def test_validate_approx_zero():
         precision=10,
         format="table",
     )
-    assert "--approx" in validate(args)
+    result = validate(args)
+    assert result is not None and "--approx" in result
 
 
 def test_validate_exp_bad_order():
@@ -256,7 +259,8 @@ def test_validate_exp_bad_order():
         precision=10,
         format="table",
     )
-    assert "--order" in validate(args)
+    result = validate(args)
+    assert result is not None and "--order" in result
 
 
 def test_validate_ln_nonpositive():
@@ -271,7 +275,8 @@ def test_validate_ln_nonpositive():
         precision=10,
         format="table",
     )
-    assert "--ln" in validate(args)
+    result = validate(args)
+    assert result is not None and "--ln" in result
 
 
 def test_validate_ln_negative():
@@ -286,7 +291,8 @@ def test_validate_ln_negative():
         precision=10,
         format="table",
     )
-    assert "--ln" in validate(args)
+    result = validate(args)
+    assert result is not None and "--ln" in result
 
 
 def test_validate_ln_bad_order():
@@ -301,7 +307,8 @@ def test_validate_ln_bad_order():
         precision=10,
         format="table",
     )
-    assert "--order" in validate(args)
+    result = validate(args)
+    assert result is not None and "--order" in result
 
 
 def test_validate_identity_valid():

--- a/tests/test_geometric_distribution.py
+++ b/tests/test_geometric_distribution.py
@@ -125,22 +125,26 @@ def test_geo_variance_invalid_p_raises():
 
 def test_validate_p_out_of_range():
     args = argparse.Namespace(k=1, p=0.0, table=None, precision=4)
-    assert "-p" in validate(args)
+    result = validate(args)
+    assert result is not None and "-p" in result
 
 
 def test_validate_precision_negative():
     args = argparse.Namespace(k=1, p=0.5, table=None, precision=-1)
-    assert "--precision" in validate(args)
+    result = validate(args)
+    assert result is not None and "--precision" in result
 
 
 def test_validate_table_min_below_one():
     args = argparse.Namespace(k=None, p=0.5, table=[0, 5], precision=4)
-    assert "MIN" in validate(args)
+    result = validate(args)
+    assert result is not None and "MIN" in result
 
 
 def test_validate_table_max_below_min():
     args = argparse.Namespace(k=None, p=0.5, table=[5, 2], precision=4)
-    assert "MAX" in validate(args)
+    result = validate(args)
+    assert result is not None and "MAX" in result
 
 
 def test_validate_table_valid():
@@ -150,12 +154,14 @@ def test_validate_table_valid():
 
 def test_validate_k_missing_without_table():
     args = argparse.Namespace(k=None, p=0.5, table=None, precision=4)
-    assert "-k is required" in validate(args)
+    result = validate(args)
+    assert result is not None and "-k is required" in result
 
 
 def test_validate_k_below_one():
     args = argparse.Namespace(k=0, p=0.5, table=None, precision=4)
-    assert "-k must be" in validate(args)
+    result = validate(args)
+    assert result is not None and "-k must be" in result
 
 
 def test_validate_valid_single():

--- a/tests/test_gini.py
+++ b/tests/test_gini.py
@@ -263,7 +263,8 @@ def test_validate_no_mode():
         precision=6,
         format="table",
     )
-    assert "required" in validate(args)
+    result = validate(args)
+    assert result is not None and "required" in result
 
 
 def test_validate_negative_precision():
@@ -276,7 +277,8 @@ def test_validate_negative_precision():
         precision=-1,
         format="table",
     )
-    assert "--precision" in validate(args)
+    result = validate(args)
+    assert result is not None and "--precision" in result
 
 
 def test_validate_data_and_groups_exclusive():
@@ -289,7 +291,8 @@ def test_validate_data_and_groups_exclusive():
         precision=6,
         format="table",
     )
-    assert "mutually exclusive" in validate(args)
+    result = validate(args)
+    assert result is not None and "mutually exclusive" in result
 
 
 def test_validate_groups_odd_count():
@@ -302,7 +305,8 @@ def test_validate_groups_odd_count():
         precision=6,
         format="table",
     )
-    assert "--groups" in validate(args)
+    result = validate(args)
+    assert result is not None and "--groups" in result
 
 
 def test_validate_groups_single_value():
@@ -315,7 +319,8 @@ def test_validate_groups_single_value():
         precision=6,
         format="table",
     )
-    assert "--groups" in validate(args)
+    result = validate(args)
+    assert result is not None and "--groups" in result
 
 
 def test_validate_weights_multi_dataset():
@@ -328,7 +333,8 @@ def test_validate_weights_multi_dataset():
         precision=6,
         format="table",
     )
-    assert "--weights" in validate(args)
+    result = validate(args)
+    assert result is not None and "--weights" in result
 
 
 def test_validate_weights_wrong_length():
@@ -341,7 +347,8 @@ def test_validate_weights_wrong_length():
         precision=6,
         format="table",
     )
-    assert "--weights" in validate(args)
+    result = validate(args)
+    assert result is not None and "--weights" in result
 
 
 def test_validate_weights_nonpositive():
@@ -354,7 +361,8 @@ def test_validate_weights_nonpositive():
         precision=6,
         format="table",
     )
-    assert "--weights" in validate(args)
+    result = validate(args)
+    assert result is not None and "--weights" in result
 
 
 def test_validate_lorenz_multi_dataset():
@@ -367,7 +375,8 @@ def test_validate_lorenz_multi_dataset():
         precision=6,
         format="table",
     )
-    assert "--lorenz" in validate(args)
+    result = validate(args)
+    assert result is not None and "--lorenz" in result
 
 
 def test_validate_valid_single_data():

--- a/tests/test_linear_regression.py
+++ b/tests/test_linear_regression.py
@@ -333,12 +333,23 @@ def test_incomplete_beta_lentz_floor_guards_hit(monkeypatch):
     """Force the near-zero denominator guards in the continued fraction.
 
     Real inputs never drive a Lentz denominator below 1e-30, so raise the floor
-    until every denominator trips it. The guards exist to keep the subsequent
-    1.0 / d from dividing by zero, so a finite result is the property to check.
+    until every denominator trips it.
+
+    Asserting only that the result is finite would be worthless here: it holds
+    whether or not the guards exist, so the test would still pass with all four
+    deleted. Pin the clamped value instead. With every denominator forced to
+    _TINY, `c * d` is exactly 1.0, the convergence check breaks on the first
+    iteration, and the result collapses to the front factor alone -- which for
+    (2, 3, 0.5) goes through the symmetry relation to 1 - 0.125. Deleting or
+    inverting any guard changes that number.
     """
+    unclamped = incomplete_beta(2.0, 3.0, 0.5)
     monkeypatch.setattr(linreg_module, "_TINY", 1e5)
-    result = incomplete_beta(2.0, 3.0, 0.5)
-    assert math.isfinite(result)
+    clamped = incomplete_beta(2.0, 3.0, 0.5)
+
+    assert math.isfinite(clamped)
+    assert clamped == pytest.approx(0.875)
+    assert clamped != unclamped
 
 
 def test_incomplete_beta_survives_subnormal_parameters():

--- a/tests/test_linear_regression.py
+++ b/tests/test_linear_regression.py
@@ -6,6 +6,7 @@ import tempfile
 
 import pytest
 
+import src.utils.linear_regression as linreg_module
 from src.utils.linear_regression import (
     f_cdf,
     incomplete_beta,
@@ -328,66 +329,29 @@ def test_interpret_r_squared_weak():
     assert interpret_r_squared(0.95) == "excellent fit"
 
 
-def test_incomplete_beta_continued_fraction_safety_checks():
+def test_incomplete_beta_lentz_floor_guards_hit(monkeypatch):
+    """Force the near-zero denominator guards in the continued fraction.
+
+    Real inputs never drive a Lentz denominator below 1e-30, so raise the floor
+    until every denominator trips it. The guards exist to keep the subsequent
+    1.0 / d from dividing by zero, so a finite result is the property to check.
     """
-    Test the continued fraction safety checks in incomplete_beta that contain safety checks
-    that prevent d or c from becoming exactly zero (which would cause division by zero).
-    These checks are triggered when |1.0 + numerator*d| < tiny or |1.0 + numerator/c| < tiny.
-
-    This requires extreme parameter combinations where the continued fraction
-    produces terms that nearly cancel. We test with the most extreme valid
-    parameters to exercise the numerical edge cases of the algorithm.
-    """
-    # Test with parameters at the absolute limits
-    # When a and b are both extremely small (near machine epsilon)
-    # the continued fraction can produce extremely small intermediate values
-    test_cases = [
-        # (a, b, x) - designed to stress different parts of the continued fraction
-        (1e-100, 1e-100, 0.5),  # Both tiny, x in middle
-        (1e-150, 1e-150, 0.1),  # Even more extreme
-        (1e-200, 1e-200, 0.9),  # Near upper limit of x
-        (1e-250, 1e-250, 0.3),  # Stress odd step
-        (1e-300, 1e-300, 0.7),  # Near machine precision limits
-    ]
-
-    for a, b, x in test_cases:
-        # These parameters may trigger underflow, but the function should
-        # handle it gracefully without returning nan or raising exceptions
-        try:
-            result = incomplete_beta(a, b, x)
-            # Result must be in valid range or be a boundary value
-            assert math.isfinite(result), f"non-finite result for ({a}, {b}, {x})"
-            assert 0 <= result <= 1, f"out of range result for ({a}, {b}, {x})"
-        except (OverflowError, ZeroDivisionError, ValueError):
-            # If we hit numerical limits, that's also acceptable
-            # The safety checks exist to prevent these
-            pass
-
-
-def test_incomplete_beta_force_safety_checks_for_coverage():
-    """
-    These lines contain defensive safety checks that prevent d or c from becoming
-    zero in the continued fraction algorithm. Under normal operation with valid
-    parameters, these lines are never reached due to the numerical stability of
-    the Lentz algorithm. This test uses a special testing flag to force execution
-    of these lines to achieve 100% test coverage.
-    """
-    # Call with the testing flag enabled to force tiny value checks
-    result = incomplete_beta(2.0, 3.0, 0.5, _test_force_tiny=True)
-
-    # Despite forcing tiny values, the algorithm should still produce a valid result
+    monkeypatch.setattr(linreg_module, "_TINY", 1e5)
+    result = incomplete_beta(2.0, 3.0, 0.5)
     assert math.isfinite(result)
-    assert 0 <= result <= 1
 
-    # Test multiple parameter combinations with the flag
+
+def test_incomplete_beta_survives_subnormal_parameters():
+    """Extreme a/b values must still yield a finite probability, not nan or a raise."""
     test_cases = [
-        (1.0, 1.0, 0.5),
-        (2.0, 2.0, 0.3),
-        (5.0, 3.0, 0.7),
-        (0.5, 0.5, 0.5),
+        (1e-100, 1e-100, 0.5),
+        (1e-150, 1e-150, 0.1),
+        (1e-200, 1e-200, 0.9),
+        (1e-250, 1e-250, 0.3),
+        (1e-300, 1e-300, 0.7),
     ]
 
     for a, b, x in test_cases:
-        result = incomplete_beta(a, b, x, _test_force_tiny=True)
-        assert math.isfinite(result)
-        assert 0 <= result <= 1
+        result = incomplete_beta(a, b, x)
+        assert math.isfinite(result), f"non-finite result for ({a}, {b}, {x})"
+        assert 0 <= result <= 1, f"out of range result for ({a}, {b}, {x})"

--- a/tests/test_monte_carlo.py
+++ b/tests/test_monte_carlo.py
@@ -4,6 +4,7 @@ import math
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pytest
 
 from src.utils.monte_carlo import (
     _is_extreme,
@@ -12,8 +13,8 @@ from src.utils.monte_carlo import (
     _t_stat_welch,
     analytical_value,
     main,
+    run_experiment,
     simulate_bayes,
-    # simulate_linboot,
     standard_error,
     trials_for_scale,
     validate,
@@ -1093,3 +1094,9 @@ def test_main_linboot_no_resamples(capsys, monkeypatch):
     )
     assert rc == 2
     assert "no successful bootstrap resamples" in capsys.readouterr().err
+
+
+def test_run_experiment_unknown_name_raises():
+    """--experiment is gated by argparse choices, but the function is public."""
+    with pytest.raises(ValueError, match="Unknown experiment"):
+        run_experiment("bogus", {}, trials=5, seed=0)


### PR DESCRIPTION
## Summary

Test-suite performance and correctness-of-tests work. The suite goes from **8.81s to 2.75s** at 1288 tests and 100% coverage, and several places where the coverage target was met by *hiding* code rather than testing it are removed.

## Performance

The dominant cost was coverage tracing, not the tests. `addopts` forces `--cov` on every run, and the default C tracer taxes every executed line — worst for the hand-rolled numerical kernels in `anova.py`.

| | Before | After |
|---|---|---|
| Full suite | 8.81s | **2.75s** |
| `tests/test_anova.py` | 8.32s | **2.42s** |

One line does it: `core = "sysmon"` in `[tool.coverage.run]`. Verified that `sysmon` and `ctrace` produce a byte-identical per-file table, so this is purely a speed change. Safe because branch coverage is off; see the linked issue.

After this, no test outside `test_anova.py` exceeds 10ms, so there is no further speed work worth doing.

## Coverage-shaped code removed

Three places hit 100% by making code invisible to the metric rather than by testing it.

**`incomplete_beta` carried a `_test_force_tiny` parameter** — a public signature on the p-value path, plus four `if _test_force_tiny and m == 1:` blocks, existing only to make four defensive Lentz guards reachable. The test it enabled asserted on a deliberately corrupted computation. Replaced with a module-level `_TINY` that tests raise via monkeypatch, matching the `_FPMIN` pattern already in `tests/test_anova.py`.

**`monte_carlo.py` had four unreachable numpy fallbacks.** `HAS_NUMPY` was assigned `True` as a literal while `import numpy as np` is unconditional and numpy is a hard dependency, so the flag could never be `False`. 27 statements of pure-Python fallback that had never executed, kept out of the report by `# pragma: no cover`. Deleted; 1233 → 1190 lines, 11 pragmas → 5.

**Two pragmas were suppressing testable lines** — `run_experiment`'s unknown-experiment `raise` (reachable directly even though argparse gates the CLI), and a `_linear_regression is None` guard that an existing test already covered.

The five remaining `except ImportError` pragmas are deliberately kept: unlike `HAS_NUMPY` they are not provably unreachable.

## Test-quality fixes

- Merged four coverage-redundant anova tests, preserving every assertion. Per-test coverage contexts showed 43 of 81 covered no unique line, but most are load-bearing — the scipy oracle tests are the only checks that the hand-rolled kernels return *correct* values, which line coverage cannot express. Only cases fully subsumed by a neighbour using the same fixtures were merged.
- Removed a `try/except (OverflowError, ZeroDivisionError, ValueError): pass` wrapper that was silently defanging a test. None of its five inputs raises, so the handler only stood ready to swallow a real regression.
- Strengthened the Lentz guard test after review found it asserted only `math.isfinite`, which held whether or not the guards existed. Mutation-verified: deleting the guards, inverting one, or altering a clamp constant each now fail.

## Tooling

- **ruff 0.6.4 → 0.16.1**, with rule selection moved into `pyproject.toml`. The repo previously had no ruff config and inherited ruff's defaults, so the enforced rule set depended on which ruff ran — 0.16.0 widened those defaults and the same code went from clean to 173 findings. `line-length` stays at 88; the old `--line-length=120` reached only `ruff check` and was inert there since E501 is in E5, unselected. Putting 120 in `[tool.ruff]` would have rewritten 48 files.
- One `style:` commit for the 5-file formatter churn, isolated so the config change stays reviewable.
- **Renovate with `minimumReleaseAge: "72 hours"`**, covering both Python dependencies and pre-commit revs.
- `python.defaultInterpreterPath` so the editor analyses against the project venv.

## Type errors

40 sites across 6 test files where `assert "flag" in validate(args)` is a type error on `validate`'s `str | None` `None` branch. Also corrected `_use_color`'s `stream` annotation, which claimed `IO[str]` while the body reads it through `getattr(stream, "isatty", ...)` and a test deliberately passes a bare `object()`.

## Verification

- 1288 passed, `--cov-fail-under=100` exit 0
- pre-commit clean at the new pin
- pyright clean on every file touched here
- No behaviour change: every `src/` edit removes code that was unreachable or test-only

## Follow-ups

Filed separately rather than bundled here — see linked issues.
