### PR TITLE
feat: add breakeven, entropy, weibull, and discount CLI tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+- Break-even analysis tool (`breakeven`) — cost-volume-profit analysis reporting break-even units and revenue, contribution margin and margin ratio, target-profit volume, and margin of safety (#14)
+  - `--sweep MIN MAX STEP` appends a profit/loss table across a unit range; `--chart` renders that column as a text bar chart with losses left of the break-even axis and profits right of it, so the crossing is visible without a plotting dependency
+  - `--format` supports `table`, `json`, and `csv`
+- Information entropy tool (`entropy`) — Shannon entropy, KL divergence, cross-entropy, mutual information, and conditional entropy in bits, nats, or hartleys (#32)
+  - Input vectors are normalized to sum to 1, so raw counts are accepted alongside probabilities
+  - The entropy report names the maximum entropy for that number of outcomes and the resulting efficiency; the divergence report adds the reverse KL, since D(P‖Q) is asymmetric, and reports it as infinite rather than failing when the reverse direction is undefined
+- Weibull distribution tool (`weibull`) — PDF, CDF, survival, hazard, quantile, mean, median, and variance for Weibull(k, λ) (#34)
+  - Names the failure mode implied by the shape parameter: infant mortality (k<1), constant hazard (k=1), or wear-out (k>1)
+  - The hazard rate uses the closed form rather than f(x)/S(x), so it stays finite in the far tail where that ratio would divide zero by zero; moments go through `math.lgamma` so large parameters do not overflow
+- Discount rate tool (`discount`) — real and nominal rates via the Fisher equation, discount factors, present value of a lump sum, and nominal and inflation-adjusted NPV (#42)
+  - Supplying either `--nominal` or `--real` (the latter with `--inflation`) derives the other
+  - Reports the discounted payback period, interpolated within the period where cumulative discounted cash flow crosses zero
+
+---
+
 ## [0.22.0] — 2026-08-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Hypothesis Testing & p-values** | Perform statistical hypothesis tests: z-tests and binomial exact tests (proportions), t-tests (means), and chi-squared goodness-of-fit tests; includes alpha sensitivity analysis |
 | **T-Test** | Perform one-sample, two-sample (Welch's), and paired t-tests; compute t-statistics, degrees of freedom, p-values, confidence intervals, and Cohen's d effect size; accepts raw data or summary statistics (mean, std, n); supports one-sided and two-sided alternatives |
 | **Time Series Forecasting** | Forecast future values with prediction intervals using simple, double (Holt's), or Holt-Winters exponential smoothing; supports backtesting and multiple output formats |
-| **Collatz Conjecture** | Evaluate the Collatz conjecture (3n+1 problem) for positive integers up to n; track which numbers reach 1 and report the largest consecutive verified sequence |
+| **Collatz Conjecture** | Evaluate the Collatz conjecture _(3n+1 problem)_ for positive integers up to n; track which numbers reach 1 and report the largest consecutive verified sequence |
 | **Jevons' Paradox** | Quantify the rebound effect and backfire condition for resource efficiency improvements; compute expected savings, rebound consumption, actual savings, and net consumption change given an efficiency gain and price elasticity of demand; support sweeps over efficiency or elasticity ranges |
 | **Sigmoid Function** | Evaluate σ(x) = 1/(1+e^(−x)), its derivative, and the inverse logit; range tables and Unicode sparkline |
 | **Euler's Number** | Explore e via limit convergence, Taylor series for e^x and ln(x), Euler's identity, and the Euler-Mascheroni constant |
@@ -1656,11 +1656,14 @@ breakeven --fixed 50000 --price 25 --variable 10 --sweep 0 8000 500 --chart
 <details>
 <summary><strong><code>entropy</code></strong> — Information Entropy</summary>
 
-Computes the core information-theoretic measures: Shannon entropy, KL divergence, cross-entropy, mutual information, and conditional entropy. Pure Python via `math.log`, reported in bits (base 2), nats (base e), or hartleys (base 10). Input vectors are normalized to sum to 1, so raw counts work as well as probabilities. The entropy report also names the maximum entropy for that number of outcomes and the resulting efficiency; the divergence report includes the reverse KL, since D(P‖Q) is not symmetric.
+Computes the core information-theoretic measures: Shannon entropy, Kullback-Leibler (KL) divergence, cross-entropy, mutual information, and conditional entropy. Pure Python via `math.log`, reported in bits (base 2), nats (base e), or hartleys (base 10). Input vectors are normalized to sum to 1, so raw counts work as well as probabilities. The entropy report also names the maximum entropy for that number of outcomes and the resulting efficiency; the divergence report includes the reverse KL, since D(P‖Q) is not symmetric.
 
 ```bash
 # Shannon entropy of a fair six-sided die (2.585 bits)
 entropy --probs 0.167,0.167,0.167,0.167,0.167,0.167
+
+# Shannon entropy of an odd-favored die
+entropy --probs 1,4,2,5,2,3
 
 # Raw counts work too — normalized internally
 entropy --probs "42 17 8 3"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Chi-Square Tests** | Goodness-of-fit and independence (contingency table) chi-square tests via the exact regularised incomplete gamma function; per-cell contributions for residual diagnostics |
 | **One-Way ANOVA** | Test whether the means of three or more independent groups are equal; F-statistic via the regularised incomplete beta function, with Tukey HSD or Bonferroni-corrected pairwise post-hoc comparisons |
 | **Life in Weeks** | Render a human life as an ANSI grid of weeks, months, or years, color-coded elapsed vs remaining from a birthdate; discrete shape glyphs with quarter and decade grouping keep individual cells countable, and a "Life of a Typical American" reference grid shades each life phase with milestone markers |
-| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, `chisq`, `anova`, and `life` commands |
+| **Break-Even Analysis** | Cost-volume-profit analysis: break-even units and revenue, contribution margin and ratio, margin of safety, and the volume needed to hit a target profit; optional profit/loss sweep across a unit range with a text bar chart |
+| **Information Entropy** | Shannon entropy, KL divergence, cross-entropy, mutual information, and conditional entropy in bits, nats, or hartleys; accepts raw counts as well as probabilities |
+| **Weibull Distribution** | PDF, CDF, survival, hazard rate, quantiles, mean, median, and variance for Weibull(k, λ), with the shape parameter's failure mode named (infant mortality, constant hazard, or wear-out) |
+| **Discount Rates & NPV** | Real and nominal discount rates via the Fisher equation, discount factors, present value of a lump sum, and nominal and inflation-adjusted NPV with discounted payback period |
+| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, `chisq`, `anova`, `life`, `breakeven`, `entropy`, `weibull`, and `discount` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
 
@@ -99,6 +103,10 @@ pip install -e .
 | `chisq` | Chi-square goodness-of-fit and independence tests with per-cell contributions |
 | `anova` | One-way ANOVA F-test with optional Tukey HSD or Bonferroni-corrected pairwise post-hoc comparisons |
 | `life` | ANSI grid of a human life in weeks, months, or years, elapsed vs remaining, with a typical-American reference grid |
+| `breakeven` | Break-even units and revenue, contribution margin, margin of safety, target-profit volume, and profit/loss sweep |
+| `entropy` | Shannon entropy, KL divergence, cross-entropy, mutual information, and conditional entropy in bits, nats, or hartleys |
+| `weibull` | PDF, CDF, survival, hazard, quantiles, and moments for the Weibull(k, λ) reliability distribution |
+| `discount` | Real and nominal discount rates (Fisher), discount factors, present value, and inflation-adjusted NPV |
 | `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
 
 ---
@@ -1609,6 +1617,151 @@ life 1985-03-14 --as-of 2030-01-01 --format json
 ---
 
 <details>
+<summary><strong><code>breakeven</code></strong> — Break-Even Analysis</summary>
+
+Answers the foundational viability question: at what unit volume does revenue cover total cost? Reports break-even units and revenue, contribution margin and margin ratio, the volume needed to reach a target profit, and the margin of safety at an actual or projected volume. `--sweep` adds a profit/loss table across a unit range, and `--chart` renders that table as a text bar chart with losses left of the break-even axis and profits right of it — no plotting library required.
+
+```bash
+# Basic break-even: fixed costs 50,000, price 25, variable cost 10 per unit
+breakeven --fixed 50000 --price 25 --variable 10
+
+# How many units to hit a 20,000 profit?
+breakeven --fixed 50000 --price 25 --variable 10 --target-profit 20000
+
+# Margin of safety at a projected 5,000 units
+breakeven --fixed 50000 --price 25 --variable 10 --actual-units 5000
+
+# Profit/loss table from 0 to 8,000 units in steps of 500, with a chart
+breakeven --fixed 50000 --price 25 --variable 10 --sweep 0 8000 500 --chart
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| | `--fixed F` | Total fixed costs (required) |
+| | `--price F` | Selling price per unit (required) |
+| | `--variable F` | Variable cost per unit (required) |
+| | `--target-profit F` | Also report the unit volume needed for this profit |
+| | `--actual-units F` | Actual or projected volume, for the margin of safety |
+| | `--sweep MIN MAX STEP` | Append a profit/loss table across a unit range |
+| | `--chart` | Render the sweep profit column as a text bar chart (needs `--sweep`) |
+| | `--format {table,json,csv}` | Output format (default: table) |
+| `-P` | `--precision` | Decimal places for output (default: 2) |
+
+</details>
+
+---
+
+<details>
+<summary><strong><code>entropy</code></strong> — Information Entropy</summary>
+
+Computes the core information-theoretic measures: Shannon entropy, KL divergence, cross-entropy, mutual information, and conditional entropy. Pure Python via `math.log`, reported in bits (base 2), nats (base e), or hartleys (base 10). Input vectors are normalized to sum to 1, so raw counts work as well as probabilities. The entropy report also names the maximum entropy for that number of outcomes and the resulting efficiency; the divergence report includes the reverse KL, since D(P‖Q) is not symmetric.
+
+```bash
+# Shannon entropy of a fair six-sided die (2.585 bits)
+entropy --probs 0.167,0.167,0.167,0.167,0.167,0.167
+
+# Raw counts work too — normalized internally
+entropy --probs "42 17 8 3"
+
+# KL divergence between a biased coin (0.7/0.3) and a fair coin
+entropy --measure kl --probs-p 0.7,0.3 --probs-q 0.5,0.5
+
+# Cross-entropy loss of a prediction, in nats
+entropy --measure cross --probs-p 1,0 --probs-q 0.9,0.1 --base e
+
+# Mutual information from a 2x2 joint distribution
+entropy --measure mi --joint 0.25,0.25 --joint 0.25,0.25
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| | `--probs VALUES` | Distribution for the `entropy` measure (comma or space separated) |
+| | `--measure {entropy,kl,cross,mi,conditional}` | Quantity to compute (default: entropy) |
+| | `--base {2,e,10}` | Logarithm base: 2=bits, e=nats, 10=hartleys (default: 2) |
+| | `--probs-p VALUES` | Distribution P for the `kl` and `cross` measures |
+| | `--probs-q VALUES` | Distribution Q for the `kl` and `cross` measures |
+| | `--joint ROW` | One row of the joint table for `mi` and `conditional`; repeat per row |
+| | `--format {table,json}` | Output format (default: table) |
+| `-P` | `--precision` | Decimal places for output (default: 4) |
+
+</details>
+
+---
+
+<details>
+<summary><strong><code>weibull</code></strong> — Weibull Distribution</summary>
+
+The standard model for component lifetimes and failure analysis. The shape parameter `k` sets the failure mode, which the report names outright: `k < 1` is a decreasing hazard (infant mortality), `k = 1` is the constant-hazard exponential case, and `k > 1` is an increasing hazard (wear-out). The hazard rate is computed in closed form rather than as `f(x)/S(x)`, so it stays finite far out in the tail where that ratio would divide zero by zero. Moments use `math.lgamma`, so large parameters do not overflow.
+
+```bash
+# Survival probability at t=500 hours, shape=2, scale=1000
+weibull -x 500 -k 2 --lambda 1000 --survival
+
+# 5th percentile of failure time — when have 5% of units failed?
+weibull --quantile 0.05 -k 1.5 --lambda 800
+
+# Range table from 0 to 2000 in steps of 200
+weibull -k 2.5 --lambda 1200 --table 0 2000 200
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| `-x` | | Evaluation point (required unless `--quantile` or `--table` is used) |
+| `-k` | `--shape F` | Shape parameter k; <1 infant mortality, 1 constant, >1 wear-out (required) |
+| | `--lambda F` / `--scale F` | Scale parameter λ, the characteristic life (required) |
+| | `--quantile F` | Report the x at this cumulative probability |
+| | `--survival` | Lead the point report with S(x) = 1 − F(x) |
+| | `--table MIN MAX STEP` | Print a table over x = MIN..MAX |
+| | `--format {table,json}` | Output format (default: table) |
+| `-P` | `--precision` | Decimal places for output (default: 4) |
+
+</details>
+
+---
+
+<details>
+<summary><strong><code>discount</code></strong> — Discount Rate & NPV</summary>
+
+Relates nominal rates, real rates, and inflation through the Fisher equation — `real = (1 + nominal) / (1 + inflation) − 1` — and applies the result to lump sums and cash-flow series. Give either `--nominal` or `--real` (the latter with `--inflation`) and the other is derived. Cash flows start at period 0, so an up-front investment is the negative first element. The real NPV assumes the cash flows are stated in today's purchasing power and discounts them at the real rate; the discounted payback period interpolates within the period where cumulative cash flow crosses zero.
+
+```bash
+# Real rate and discount factor from a nominal rate and inflation
+discount --nominal 0.08 --inflation 0.03
+
+# Nominal rate implied by a real rate and inflation
+discount --real 0.05 --inflation 0.03
+
+# Present value of a 10,000 lump sum received in 5 periods
+discount --nominal 0.08 --fv 10000 --periods 5
+
+# Nominal and inflation-adjusted NPV of a project
+discount --nominal 0.08 --inflation 0.03 --cashflows -1000 300 400 500
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| | `--nominal F` | Nominal discount rate per period, e.g. `0.08` for 8% |
+| | `--real F` | Real discount rate per period (requires `--inflation`) |
+| | `--inflation F` | Inflation rate per period, e.g. `0.03` for 3% |
+| | `--fv F` | Future value of a lump sum to discount |
+| | `--periods F` | Periods for the lump sum and discount factor (default: 1) |
+| | `--cashflows F [F ...]` | Cash flow series starting at period 0, for NPV |
+| | `--format {table,json}` | Output format (default: table) |
+| `-P` | `--precision` | Decimal places for output (default: 4) |
+
+</details>
+
+---
+
+<details>
 <summary><strong><code>simulate</code></strong> — Monte Carlo Probability Simulator</summary>
 
 Runs repeated random experiments to estimate probabilities empirically, with optional confidence intervals and analytical comparison against `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, and `linboot`.
@@ -1711,6 +1864,10 @@ simulate --experiment linboot --params x=1,2,3,4,5 y=2.1,3.9,6.2,7.8,10.1 predic
 | Chi-Square | `src.utils.chi_squared` | `chisq_gof`, `chisq_independence`, `chi2_cdf`, `regularized_gamma_p` |
 | ANOVA | `src.utils.anova` | `anova_one_way`, `tukey_hsd`, `bonferroni`, `f_cdf`, `studentized_range_cdf` |
 | Life in Weeks | `src.utils.life_in_weeks` | `compute_grid`, `units_elapsed`, `grid_rows`, `reference_rows`, `milestone_units` |
+| Break-Even | `src.utils.break_even` | `breakeven_units`, `breakeven_revenue`, `contribution_margin`, `margin_of_safety`, `target_profit_units`, `sweep_rows` |
+| Entropy | `src.utils.information_entropy` | `shannon_entropy`, `kl_divergence`, `cross_entropy`, `mutual_information`, `conditional_entropy`, `joint_entropy` |
+| Weibull | `src.utils.weibull_distribution` | `weibull_pdf`, `weibull_cdf`, `weibull_survival`, `weibull_hazard`, `weibull_quantile`, `weibull_mean` |
+| Discount Rate | `src.utils.discount_rate` | `real_rate`, `nominal_rate`, `discount_factor`, `present_value`, `npv`, `real_npv`, `payback_period` |
 | Monte Carlo | `src.utils.monte_carlo` | `simulate_binomial`, `simulate_birthday`, `simulate_streak`, `simulate_poisson`, `simulate_power`, `simulate_permutation`, `simulate_bayes`, `simulate_season`, `simulate_linboot` |
 
 ---
@@ -2690,6 +2847,123 @@ print(reference_rows("years", 90)[2])  # ▲▲■■■■■★■★
 
 # Milestone ages converted to unit indices
 print(milestone_units("weeks")[0])  # ('mean age at first birth (NCHS 2023)', 1430)
+```
+
+</details>
+
+<details>
+<summary><strong>Break-Even Analysis</strong></summary>
+
+```python
+from src.utils.break_even import (
+    breakeven_units,
+    contribution_margin,
+    margin_of_safety,
+    target_profit_units,
+)
+
+# Units needed to cover 50,000 of fixed cost at a 15 per-unit margin
+units = breakeven_units(50_000, price=25, variable=10)
+
+# Per-unit contribution toward fixed costs
+margin = contribution_margin(25, 10)
+
+# Volume required to earn a 20,000 profit
+target = target_profit_units(50_000, 25, 10, profit=20_000)
+
+# Fraction volume may fall before the business hits break-even
+safety = margin_of_safety(actual_units=5_000, be_units=units)
+```
+
+</details>
+
+<details>
+<summary><strong>Information Entropy</strong></summary>
+
+```python
+from src.utils.information_entropy import (
+    conditional_entropy,
+    cross_entropy,
+    kl_divergence,
+    mutual_information,
+    shannon_entropy,
+)
+
+# Entropy of a fair six-sided die, in bits (2.585)
+h = shannon_entropy([1] * 6)
+
+# Raw counts are normalized internally
+h_counts = shannon_entropy([42, 17, 8, 3])
+
+# Extra bits from coding a biased coin with a fair-coin code
+kl = kl_divergence([0.7, 0.3], [0.5, 0.5])
+
+# Cross-entropy loss, in nats
+import math
+loss = cross_entropy([1, 0], [0.9, 0.1], base=math.e)
+
+# Shared information and residual uncertainty in a joint distribution
+mi = mutual_information([[0.4, 0.2], [0.1, 0.3]])
+h_y_given_x = conditional_entropy([[0.4, 0.2], [0.1, 0.3]])
+```
+
+</details>
+
+<details>
+<summary><strong>Weibull Distribution</strong></summary>
+
+```python
+from src.utils.weibull_distribution import (
+    failure_mode,
+    weibull_hazard,
+    weibull_mean,
+    weibull_quantile,
+    weibull_survival,
+)
+
+# P(component survives past 500 hours) for Weibull(k=2, lambda=1000)
+s = weibull_survival(500, 2, 1000)
+
+# Instantaneous failure rate of a unit that reached 500 hours
+h = weibull_hazard(500, 2, 1000)
+
+# Time by which 5% of units have failed
+t05 = weibull_quantile(0.05, 1.5, 800)
+
+# Mean time to failure, and what the shape parameter implies
+mttf = weibull_mean(2, 1000)
+mode = failure_mode(2)  # 'wear-out (increasing hazard)'
+```
+
+</details>
+
+<details>
+<summary><strong>Discount Rate & NPV</strong></summary>
+
+```python
+from src.utils.discount_rate import (
+    discount_factor,
+    npv,
+    payback_period,
+    present_value,
+    real_npv,
+    real_rate,
+)
+
+# Fisher-equation real rate from an 8% nominal rate and 3% inflation
+r = real_rate(0.08, 0.03)
+
+# Present-value factor and the PV of a future lump sum
+factor = discount_factor(0.08, periods=5)
+pv = present_value(10_000, 0.08, periods=5)
+
+# NPV of a project, nominal and in today's purchasing power
+flows = [-1000, 300, 400, 500]
+value = npv(0.08, flows)
+value_real = real_npv(0.08, 0.03, flows)
+
+# Period at which discounted cumulative cash flow turns positive
+payback = payback_period(flows, 0.08)
 ```
 
 </details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ geometric = "src.utils.geometric_distribution:main"
 chisq = "src.utils.chi_squared:main"
 anova = "src.utils.anova:main"
 life = "src.utils.life_in_weeks:main"
+breakeven = "src.utils.break_even:main"
+entropy = "src.utils.information_entropy:main"
+weibull = "src.utils.weibull_distribution:main"
+discount = "src.utils.discount_rate:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/utils/break_even.py
+++ b/src/utils/break_even.py
@@ -1,0 +1,627 @@
+#!/usr/bin/env python3
+"""Command-line utility for break-even (cost-volume-profit) analysis.
+
+Answers the core viability question: at what unit volume does revenue cover
+total cost?  Pure Python — no external dependencies.  The optional ``--chart``
+flag renders a text bar chart rather than pulling in a plotting library.
+
+Usage examples:
+  breakeven --fixed 50000 --price 25 --variable 10
+  breakeven --fixed 50000 --price 25 --variable 10 --target-profit 20000
+  breakeven --fixed 50000 --price 25 --variable 10 --sweep 0 8000 500 --chart
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def contribution_margin(price: float, variable: float) -> float:
+    """Contribution margin per unit.
+
+    Args:
+        price: Selling price per unit; must be > 0.
+        variable: Variable cost per unit; must be >= 0.
+
+    Returns:
+        price - variable, the cash each unit contributes toward fixed costs.
+
+    Raises:
+        ValueError: If ``price`` <= 0 or ``variable`` < 0.
+    """
+    _validate_price_variable(price, variable)
+    return price - variable
+
+
+def contribution_margin_ratio(price: float, variable: float) -> float:
+    """Contribution margin as a fraction of the selling price.
+
+    Args:
+        price: Selling price per unit; must be > 0.
+        variable: Variable cost per unit; must be >= 0.
+
+    Returns:
+        (price - variable) / price, in (-inf, 1].
+
+    Raises:
+        ValueError: If ``price`` <= 0 or ``variable`` < 0.
+    """
+    _validate_price_variable(price, variable)
+    return (price - variable) / price
+
+
+def breakeven_units(fixed: float, price: float, variable: float) -> float:
+    """Unit volume at which total revenue equals total cost.
+
+    Args:
+        fixed: Total fixed costs; must be >= 0.
+        price: Selling price per unit; must be > 0.
+        variable: Variable cost per unit; must be >= 0 and < ``price``.
+
+    Returns:
+        fixed / (price - variable).
+
+    Raises:
+        ValueError: If an input is out of range, or if ``price`` <= ``variable``
+            (no contribution margin means the break-even point never arrives).
+    """
+    _validate_fixed(fixed)
+    margin = contribution_margin(price, variable)
+    if margin <= 0:
+        raise ValueError(
+            f"price must exceed variable cost, got price={price}, variable={variable}"
+        )
+    return fixed / margin
+
+
+def breakeven_revenue(fixed: float, margin_ratio: float) -> float:
+    """Sales revenue at which total revenue equals total cost.
+
+    Args:
+        fixed: Total fixed costs; must be >= 0.
+        margin_ratio: Contribution margin ratio, in (0, 1].
+
+    Returns:
+        fixed / margin_ratio.
+
+    Raises:
+        ValueError: If ``fixed`` < 0 or ``margin_ratio`` is not in (0, 1].
+    """
+    _validate_fixed(fixed)
+    if not (0 < margin_ratio <= 1):
+        raise ValueError(f"margin_ratio must be in (0, 1], got {margin_ratio}")
+    return fixed / margin_ratio
+
+
+def margin_of_safety(actual_units: float, be_units: float) -> float:
+    """Fraction by which actual volume may fall before hitting break-even.
+
+    Args:
+        actual_units: Actual or projected unit volume; must be > 0.
+        be_units: Break-even unit volume; must be >= 0.
+
+    Returns:
+        (actual_units - be_units) / actual_units.  Negative when actual volume
+        is already below break-even.
+
+    Raises:
+        ValueError: If ``actual_units`` <= 0 or ``be_units`` < 0.
+    """
+    if actual_units <= 0:
+        raise ValueError(f"actual_units must be > 0, got {actual_units}")
+    if be_units < 0:
+        raise ValueError(f"be_units must be >= 0, got {be_units}")
+    return (actual_units - be_units) / actual_units
+
+
+def target_profit_units(
+    fixed: float, price: float, variable: float, profit: float
+) -> float:
+    """Unit volume required to reach a target operating profit.
+
+    Args:
+        fixed: Total fixed costs; must be >= 0.
+        price: Selling price per unit; must be > 0.
+        variable: Variable cost per unit; must be >= 0 and < ``price``.
+        profit: Target profit; may be negative to model an acceptable loss.
+
+    Returns:
+        (fixed + profit) / (price - variable).
+
+    Raises:
+        ValueError: If an input is out of range, or if ``price`` <= ``variable``.
+    """
+    _validate_fixed(fixed)
+    margin = contribution_margin(price, variable)
+    if margin <= 0:
+        raise ValueError(
+            f"price must exceed variable cost, got price={price}, variable={variable}"
+        )
+    return (fixed + profit) / margin
+
+
+def profit_at(units: float, fixed: float, price: float, variable: float) -> float:
+    """Operating profit at a given unit volume.
+
+    Args:
+        units: Unit volume; must be >= 0.
+        fixed: Total fixed costs; must be >= 0.
+        price: Selling price per unit; must be > 0.
+        variable: Variable cost per unit; must be >= 0.
+
+    Returns:
+        units * (price - variable) - fixed.
+
+    Raises:
+        ValueError: If an input is out of range.
+    """
+    if units < 0:
+        raise ValueError(f"units must be >= 0, got {units}")
+    _validate_fixed(fixed)
+    return units * contribution_margin(price, variable) - fixed
+
+
+def sweep_rows(
+    min_units: float,
+    max_units: float,
+    step: float,
+    fixed: float,
+    price: float,
+    variable: float,
+) -> list[tuple[float, float, float, float]]:
+    """Build a profit/loss table across a unit range.
+
+    Args:
+        min_units: First unit volume in the table; must be >= 0.
+        max_units: Last unit volume in the table; must be >= ``min_units``.
+        step: Increment between rows; must be > 0.
+        fixed: Total fixed costs; must be >= 0.
+        price: Selling price per unit; must be > 0.
+        variable: Variable cost per unit; must be >= 0.
+
+    Returns:
+        List of (units, revenue, total_cost, profit) tuples.
+
+    Raises:
+        ValueError: If the range or step is invalid, or a cost input is invalid.
+    """
+    if step <= 0:
+        raise ValueError(f"step must be > 0, got {step}")
+    if min_units < 0:
+        raise ValueError(f"min_units must be >= 0, got {min_units}")
+    if max_units < min_units:
+        raise ValueError(
+            f"max_units must be >= min_units, got min={min_units}, max={max_units}"
+        )
+    _validate_fixed(fixed)
+    _validate_price_variable(price, variable)
+
+    rows: list[tuple[float, float, float, float]] = []
+    # Step through with an integer counter so float accumulation cannot drift.
+    count = int((max_units - min_units) / step) + 1
+    for i in range(count):
+        units = min_units + i * step
+        revenue = units * price
+        cost = fixed + units * variable
+        rows.append((units, revenue, cost, revenue - cost))
+    return rows
+
+
+def _validate_fixed(fixed: float) -> None:
+    """Raise if total fixed costs are negative."""
+    if fixed < 0:
+        raise ValueError(f"fixed must be >= 0, got {fixed}")
+
+
+def _validate_price_variable(price: float, variable: float) -> None:
+    """Raise if the per-unit price or variable cost is out of range."""
+    if price <= 0:
+        raise ValueError(f"price must be > 0, got {price}")
+    if variable < 0:
+        raise ValueError(f"variable must be >= 0, got {variable}")
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and return the argument parser namespace.
+
+    Args:
+        argv: Argument list (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        Parsed :class:`argparse.Namespace`.
+    """
+    parser = argparse.ArgumentParser(
+        description="Break-even (cost-volume-profit) analysis calculator.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  breakeven --fixed 50000 --price 25 --variable 10
+  breakeven --fixed 50000 --price 25 --variable 10 --target-profit 20000
+  breakeven --fixed 50000 --price 25 --variable 10 --actual-units 5000
+  breakeven --fixed 50000 --price 25 --variable 10 --sweep 0 8000 500 --chart
+""",
+    )
+    parser.add_argument(
+        "--fixed",
+        type=float,
+        required=True,
+        metavar="F",
+        help="total fixed costs",
+    )
+    parser.add_argument(
+        "--price",
+        type=float,
+        required=True,
+        metavar="F",
+        help="selling price per unit",
+    )
+    parser.add_argument(
+        "--variable",
+        type=float,
+        required=True,
+        metavar="F",
+        help="variable cost per unit",
+    )
+    parser.add_argument(
+        "--target-profit",
+        type=float,
+        default=None,
+        metavar="F",
+        help="also report the unit volume needed for this profit",
+    )
+    parser.add_argument(
+        "--actual-units",
+        type=float,
+        default=None,
+        metavar="F",
+        help="actual or projected volume, for the margin of safety",
+    )
+    parser.add_argument(
+        "--sweep",
+        type=float,
+        nargs=3,
+        default=None,
+        metavar=("MIN", "MAX", "STEP"),
+        help="append a profit/loss table across a unit range",
+    )
+    parser.add_argument(
+        "--chart",
+        action="store_true",
+        help="render a text bar chart of the sweep profit column (needs --sweep)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json", "csv"],
+        default="table",
+        help="output format (default: table)",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=2,
+        metavar="PREC",
+        help="decimal places for output (default: 2)",
+    )
+    return parser.parse_args(argv)
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Return an error message string, or ``None`` if arguments are valid.
+
+    Args:
+        args: Parsed argument namespace from :func:`parse_args`.
+
+    Returns:
+        Error description string, or ``None`` when validation passes.
+    """
+    if args.fixed < 0:
+        return f"--fixed must be >= 0, got {args.fixed}"
+    if args.price <= 0:
+        return f"--price must be > 0, got {args.price}"
+    if args.variable < 0:
+        return f"--variable must be >= 0, got {args.variable}"
+    if args.price <= args.variable:
+        return (
+            "--price must exceed --variable; with no contribution margin there "
+            "is no break-even volume"
+        )
+    if args.precision < 0:
+        return "--precision must be non-negative"
+    if args.actual_units is not None and args.actual_units <= 0:
+        return f"--actual-units must be > 0, got {args.actual_units}"
+
+    if args.sweep is not None:
+        min_units, max_units, step = args.sweep
+        if min_units < 0:
+            return f"--sweep MIN must be >= 0, got {min_units}"
+        if max_units < min_units:
+            return f"--sweep MAX must be >= MIN, got MIN={min_units}, MAX={max_units}"
+        if step <= 0:
+            return f"--sweep STEP must be > 0, got {step}"
+    elif args.chart:
+        return "--chart requires --sweep"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(value: float, precision: int) -> str:
+    """Format a float to the requested number of decimal places."""
+    return f"{value:.{precision}f}"
+
+
+def _pct(value: float, precision: int) -> str:
+    """Format a fraction as a percentage string."""
+    return f"{value * 100:.{precision}f}%"
+
+
+def build_result(args: argparse.Namespace) -> dict[str, Any]:
+    """Compute every requested figure into a single result mapping.
+
+    Args:
+        args: Validated argument namespace from :func:`parse_args`.
+
+    Returns:
+        Mapping of input echoes, core results, and any optional sections
+        (``target_profit``, ``margin_of_safety``, ``sweep``).
+
+    Raises:
+        ValueError: If a core computation rejects its inputs.
+    """
+    margin = contribution_margin(args.price, args.variable)
+    ratio = contribution_margin_ratio(args.price, args.variable)
+    be_units = breakeven_units(args.fixed, args.price, args.variable)
+
+    result: dict[str, Any] = {
+        "fixed": args.fixed,
+        "price": args.price,
+        "variable": args.variable,
+        "contribution_margin": margin,
+        "contribution_margin_ratio": ratio,
+        "breakeven_units": be_units,
+        "breakeven_revenue": breakeven_revenue(args.fixed, ratio),
+    }
+
+    if args.target_profit is not None:
+        units = target_profit_units(
+            args.fixed, args.price, args.variable, args.target_profit
+        )
+        result["target_profit"] = {
+            "profit": args.target_profit,
+            "units": units,
+            "revenue": units * args.price,
+        }
+
+    if args.actual_units is not None:
+        result["margin_of_safety"] = {
+            "actual_units": args.actual_units,
+            "units": args.actual_units - be_units,
+            "ratio": margin_of_safety(args.actual_units, be_units),
+            "profit": profit_at(
+                args.actual_units, args.fixed, args.price, args.variable
+            ),
+        }
+
+    if args.sweep is not None:
+        min_units, max_units, step = args.sweep
+        result["sweep"] = sweep_rows(
+            min_units, max_units, step, args.fixed, args.price, args.variable
+        )
+
+    return result
+
+
+def format_chart(rows: list[tuple[float, float, float, float]], width: int = 40) -> str:
+    """Render the sweep profit column as a text bar chart.
+
+    Losses extend left of a zero axis and profits extend right, so the
+    break-even crossing is visible as the point where the bars flip sides.
+
+    Args:
+        rows: Sweep rows from :func:`sweep_rows`.
+        width: Maximum bar length in characters for the largest magnitude.
+
+    Returns:
+        Multi-line string ready to print; empty string when ``rows`` is empty.
+    """
+    if not rows:
+        return ""
+    peak = max(abs(row[3]) for row in rows)
+    lines = ["", "  Profit / loss chart  (| = break-even axis)", ""]
+    for units, _revenue, _cost, profit in rows:
+        # Scale each bar against the largest absolute profit or loss in the set.
+        bars = 0 if peak == 0 else round(abs(profit) / peak * width)
+        if profit < 0:
+            left, right = "#" * bars, ""
+        else:
+            left, right = "", "#" * bars
+        lines.append(f"  {units:>10,.0f}  {left:>{width}}|{right}")
+    return "\n".join(lines)
+
+
+def format_table(result: dict[str, Any], precision: int, chart: bool) -> str:
+    """Format the result mapping as an aligned text report.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+        precision: Decimal places for all floating-point output.
+        chart: If True, append a text bar chart of the sweep profit column.
+
+    Returns:
+        Multi-line string ready to print.
+    """
+    lines = [
+        "Break-even analysis",
+        "",
+        f"  Fixed costs:               {_fmt(float(result['fixed']), precision):>14}",
+        f"  Price per unit:            {_fmt(float(result['price']), precision):>14}",
+        f"  Variable cost per unit:    {_fmt(float(result['variable']), precision):>14}",
+        "",
+        "  Contribution margin:       "
+        f"{_fmt(float(result['contribution_margin']), precision):>14}",
+        "  Contribution margin ratio: "
+        f"{_pct(float(result['contribution_margin_ratio']), precision):>14}",
+        "",
+        "  Break-even units:          "
+        f"{_fmt(float(result['breakeven_units']), precision):>14}",
+        "  Break-even revenue:        "
+        f"{_fmt(float(result['breakeven_revenue']), precision):>14}",
+    ]
+
+    target = result.get("target_profit")
+    if isinstance(target, dict):
+        lines += [
+            "",
+            f"  Target profit:             {_fmt(target['profit'], precision):>14}",
+            f"  Units required:            {_fmt(target['units'], precision):>14}",
+            f"  Revenue required:          {_fmt(target['revenue'], precision):>14}",
+        ]
+
+    mos = result.get("margin_of_safety")
+    if isinstance(mos, dict):
+        lines += [
+            "",
+            f"  Actual units:              {_fmt(mos['actual_units'], precision):>14}",
+            f"  Profit at actual units:    {_fmt(mos['profit'], precision):>14}",
+            f"  Margin of safety (units):  {_fmt(mos['units'], precision):>14}",
+            f"  Margin of safety:          {_pct(mos['ratio'], precision):>14}",
+        ]
+
+    rows = result.get("sweep")
+    if isinstance(rows, list):
+        lines += [
+            "",
+            f"  {'units':>10}  {'revenue':>14}  {'cost':>14}  {'profit':>14}",
+        ]
+        for units, revenue, cost, profit in rows:
+            lines.append(
+                f"  {_fmt(units, precision):>10}  {_fmt(revenue, precision):>14}  "
+                f"{_fmt(cost, precision):>14}  {_fmt(profit, precision):>14}"
+            )
+        if chart:
+            lines.append(format_chart(rows))
+
+    return "\n".join(lines)
+
+
+def format_csv(result: dict[str, Any], precision: int) -> str:
+    """Format the result mapping as CSV.
+
+    Scalar figures are emitted as ``key,value`` rows; a sweep table, when
+    present, follows as its own header plus one row per unit volume.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+        precision: Decimal places for all floating-point output.
+
+    Returns:
+        Multi-line CSV string ready to print.
+    """
+    lines = ["metric,value"]
+    for key in (
+        "fixed",
+        "price",
+        "variable",
+        "contribution_margin",
+        "contribution_margin_ratio",
+        "breakeven_units",
+        "breakeven_revenue",
+    ):
+        lines.append(f"{key},{_fmt(float(result[key]), precision)}")
+
+    target = result.get("target_profit")
+    if isinstance(target, dict):
+        lines.append(f"target_profit,{_fmt(target['profit'], precision)}")
+        lines.append(f"target_profit_units,{_fmt(target['units'], precision)}")
+        lines.append(f"target_profit_revenue,{_fmt(target['revenue'], precision)}")
+
+    mos = result.get("margin_of_safety")
+    if isinstance(mos, dict):
+        lines.append(f"actual_units,{_fmt(mos['actual_units'], precision)}")
+        lines.append(f"profit_at_actual_units,{_fmt(mos['profit'], precision)}")
+        lines.append(f"margin_of_safety_units,{_fmt(mos['units'], precision)}")
+        lines.append(f"margin_of_safety_ratio,{_fmt(mos['ratio'], precision)}")
+
+    rows = result.get("sweep")
+    if isinstance(rows, list):
+        lines += ["", "units,revenue,cost,profit"]
+        for units, revenue, cost, profit in rows:
+            lines.append(
+                f"{_fmt(units, precision)},{_fmt(revenue, precision)},"
+                f"{_fmt(cost, precision)},{_fmt(profit, precision)}"
+            )
+    return "\n".join(lines)
+
+
+def format_json(result: dict[str, Any]) -> str:
+    """Format the result mapping as JSON.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+
+    Returns:
+        JSON string.
+    """
+    data = dict(result)
+    rows = data.get("sweep")
+    if isinstance(rows, list):
+        data["sweep"] = [
+            {"units": u, "revenue": r, "cost": c, "profit": p} for u, r, c, p in rows
+        ]
+    return json.dumps(data, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the break-even analysis CLI.
+
+    Args:
+        argv: Argument list override for testing (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        0 on success, 2 on input or computation error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        result = build_result(args)
+        if args.format == "json":
+            print(format_json(result))
+        elif args.format == "csv":
+            print(format_csv(result, args.precision))
+        else:
+            print(format_table(result, args.precision, args.chart))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/discount_rate.py
+++ b/src/utils/discount_rate.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Command-line utility for discount rates and present value.
+
+Relates nominal rates, real rates, and inflation through the Fisher equation,
+and applies the result to lump sums and cash-flow series.  Pure Python via
+``math`` — no external dependencies.
+
+    real_rate = (1 + nominal) / (1 + inflation) - 1
+
+Usage examples:
+  discount --nominal 0.08 --inflation 0.03
+  discount --nominal 0.08 --fv 10000 --periods 5
+  discount --nominal 0.08 --inflation 0.03 --cashflows -1000 300 400 500
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def real_rate(nominal: float, inflation: float) -> float:
+    """Real discount rate implied by a nominal rate and inflation.
+
+    Args:
+        nominal: Nominal (money) rate per period, e.g. 0.08 for 8%; must be > -1.
+        inflation: Inflation rate per period, e.g. 0.03 for 3%; must be > -1.
+
+    Returns:
+        (1 + nominal) / (1 + inflation) - 1, the Fisher-equation real rate.
+
+    Raises:
+        ValueError: If ``nominal`` or ``inflation`` is <= -1.
+    """
+    _validate_rate(nominal, "nominal")
+    _validate_rate(inflation, "inflation")
+    return (1 + nominal) / (1 + inflation) - 1
+
+
+def nominal_rate(real: float, inflation: float) -> float:
+    """Nominal discount rate implied by a real rate and inflation.
+
+    Args:
+        real: Real (purchasing-power) rate per period; must be > -1.
+        inflation: Inflation rate per period; must be > -1.
+
+    Returns:
+        (1 + real) * (1 + inflation) - 1.
+
+    Raises:
+        ValueError: If ``real`` or ``inflation`` is <= -1.
+    """
+    _validate_rate(real, "real")
+    _validate_rate(inflation, "inflation")
+    return (1 + real) * (1 + inflation) - 1
+
+
+def discount_factor(rate: float, periods: float) -> float:
+    """Present-value factor for one amount ``periods`` periods out.
+
+    Args:
+        rate: Discount rate per period; must be > -1.
+        periods: Number of periods; must be >= 0.
+
+    Returns:
+        1 / (1 + rate)^periods.
+
+    Raises:
+        ValueError: If ``rate`` <= -1 or ``periods`` < 0.
+    """
+    _validate_rate(rate, "rate")
+    if periods < 0:
+        raise ValueError(f"periods must be >= 0, got {periods}")
+    return 1 / (1 + rate) ** periods
+
+
+def present_value(fv: float, rate: float, periods: float) -> float:
+    """Present value of a future lump sum.
+
+    Args:
+        fv: Future value of the lump sum.
+        rate: Discount rate per period; must be > -1.
+        periods: Number of periods until the amount is received; must be >= 0.
+
+    Returns:
+        fv / (1 + rate)^periods.
+
+    Raises:
+        ValueError: If ``rate`` <= -1 or ``periods`` < 0.
+    """
+    return fv * discount_factor(rate, periods)
+
+
+def npv(rate: float, cash_flows: Sequence[float]) -> float:
+    """Net present value of a cash-flow series.
+
+    The first cash flow is treated as occurring at period 0 (undiscounted), so
+    an up-front investment is entered as a negative first element.
+
+    Args:
+        rate: Discount rate per period; must be > -1.
+        cash_flows: Cash flows in period order; must be non-empty.
+
+    Returns:
+        sum over t of cash_flows[t] / (1 + rate)^t.
+
+    Raises:
+        ValueError: If ``rate`` <= -1 or ``cash_flows`` is empty.
+    """
+    _validate_rate(rate, "rate")
+    if not cash_flows:
+        raise ValueError("cash_flows must have at least one value")
+    return sum(cf / (1 + rate) ** t for t, cf in enumerate(cash_flows))
+
+
+def real_npv(nominal: float, inflation: float, cash_flows: Sequence[float]) -> float:
+    """Inflation-adjusted NPV of cash flows stated in today's purchasing power.
+
+    Constant-dollar (real) cash flows must be discounted at the real rate; the
+    real rate is derived from ``nominal`` and ``inflation`` via the Fisher
+    equation.
+
+    Args:
+        nominal: Nominal discount rate per period; must be > -1.
+        inflation: Inflation rate per period; must be > -1.
+        cash_flows: Real cash flows in period order; must be non-empty.
+
+    Returns:
+        NPV of ``cash_flows`` discounted at ``real_rate(nominal, inflation)``.
+
+    Raises:
+        ValueError: If a rate is <= -1 or ``cash_flows`` is empty.
+    """
+    return npv(real_rate(nominal, inflation), cash_flows)
+
+
+def payback_period(cash_flows: Sequence[float], rate: float) -> float | None:
+    """First period at which the discounted cumulative cash flow turns positive.
+
+    Args:
+        cash_flows: Cash flows in period order; must be non-empty.
+        rate: Discount rate per period; must be > -1.
+
+    Returns:
+        The fractional period at which cumulative discounted cash flow crosses
+        zero, interpolating within the crossing period, or ``None`` if it never
+        does.
+
+    Raises:
+        ValueError: If ``rate`` <= -1 or ``cash_flows`` is empty.
+    """
+    _validate_rate(rate, "rate")
+    if not cash_flows:
+        raise ValueError("cash_flows must have at least one value")
+    cumulative = 0.0
+    for t, cf in enumerate(cash_flows):
+        discounted = cf / (1 + rate) ** t
+        previous = cumulative
+        cumulative += discounted
+        if cumulative >= 0 > previous:
+            # Interpolate inside the crossing period rather than rounding up.
+            return t - 1 + (-previous / discounted)
+        if t == 0 and cumulative >= 0:
+            return 0.0
+    return None
+
+
+def _validate_rate(rate: float, name: str) -> None:
+    """Raise if a per-period rate is at or below -100%."""
+    if rate <= -1:
+        raise ValueError(f"{name} must be > -1, got {rate}")
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and return the argument parser namespace.
+
+    Args:
+        argv: Argument list (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        Parsed :class:`argparse.Namespace`.
+    """
+    parser = argparse.ArgumentParser(
+        description="Discount rate, present value, and inflation-adjusted NPV.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  discount --nominal 0.08 --inflation 0.03
+  discount --real 0.05 --inflation 0.03
+  discount --nominal 0.08 --fv 10000 --periods 5
+  discount --nominal 0.08 --inflation 0.03 --cashflows -1000 300 400 500
+""",
+    )
+    parser.add_argument(
+        "--nominal",
+        type=float,
+        default=None,
+        metavar="F",
+        help="nominal discount rate per period, e.g. 0.08 for 8%%",
+    )
+    parser.add_argument(
+        "--real",
+        type=float,
+        default=None,
+        metavar="F",
+        help="real discount rate per period (requires --inflation)",
+    )
+    parser.add_argument(
+        "--inflation",
+        type=float,
+        default=None,
+        metavar="F",
+        help="inflation rate per period, e.g. 0.03 for 3%%",
+    )
+    parser.add_argument(
+        "--fv",
+        type=float,
+        default=None,
+        metavar="F",
+        help="future value of a lump sum to discount (requires --periods)",
+    )
+    parser.add_argument(
+        "--periods",
+        type=float,
+        default=1.0,
+        metavar="F",
+        help="number of periods for the lump sum and discount factor (default: 1)",
+    )
+    parser.add_argument(
+        "--cashflows",
+        type=float,
+        nargs="+",
+        default=None,
+        metavar="F",
+        help="cash flow series starting at period 0, for NPV",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="output format (default: table)",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=4,
+        metavar="PREC",
+        help="decimal places for output (default: 4)",
+    )
+    return parser.parse_args(argv)
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Return an error message string, or ``None`` if arguments are valid.
+
+    Args:
+        args: Parsed argument namespace from :func:`parse_args`.
+
+    Returns:
+        Error description string, or ``None`` when validation passes.
+    """
+    if args.nominal is None and args.real is None:
+        return "one of --nominal or --real is required"
+    if args.nominal is None and args.inflation is None:
+        return "--real requires --inflation to derive the nominal rate"
+    if args.nominal is not None and args.nominal <= -1:
+        return f"--nominal must be > -1, got {args.nominal}"
+    if args.real is not None and args.real <= -1:
+        return f"--real must be > -1, got {args.real}"
+    if args.inflation is not None and args.inflation <= -1:
+        return f"--inflation must be > -1, got {args.inflation}"
+    if args.periods < 0:
+        return f"--periods must be >= 0, got {args.periods}"
+    if args.precision < 0:
+        return "--precision must be non-negative"
+    if args.cashflows is not None and not args.cashflows:
+        return "--cashflows must list at least one value"
+    return None
+
+
+def resolve_rates(args: argparse.Namespace) -> tuple[float, float | None, float | None]:
+    """Reconcile whichever of the nominal, real, and inflation rates were given.
+
+    Args:
+        args: Validated argument namespace from :func:`parse_args`.
+
+    Returns:
+        Tuple of (nominal, real, inflation).  ``real`` is ``None`` when no
+        inflation rate was supplied and none was given directly.
+
+    Raises:
+        ValueError: If a supplied rate is <= -1.
+    """
+    inflation = args.inflation
+    if args.nominal is not None:
+        nominal = args.nominal
+        real = real_rate(nominal, inflation) if inflation is not None else None
+        # An explicit --real alongside --nominal is informational only; the
+        # Fisher-derived value is what the report uses.
+    else:
+        # validate() guarantees inflation is present on this branch.
+        nominal = nominal_rate(args.real, inflation)
+        real = args.real
+    return nominal, real, inflation
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(value: float, precision: int) -> str:
+    """Format a float to the requested number of decimal places."""
+    return f"{value:,.{precision}f}"
+
+
+def _pct(value: float, precision: int) -> str:
+    """Format a per-period rate as a percentage string."""
+    return f"{value * 100:.{precision}f}%"
+
+
+def build_result(args: argparse.Namespace) -> dict[str, Any]:
+    """Compute every requested figure into a single result mapping.
+
+    Args:
+        args: Validated argument namespace from :func:`parse_args`.
+
+    Returns:
+        Mapping of the reconciled rates plus any ``lump_sum`` and ``npv``
+        sections that the flags asked for.
+
+    Raises:
+        ValueError: If a core computation rejects its inputs.
+    """
+    nominal, real, inflation = resolve_rates(args)
+    result: dict[str, Any] = {
+        "nominal_rate": nominal,
+        "inflation": inflation,
+        "real_rate": real,
+        "periods": args.periods,
+        "discount_factor_nominal": discount_factor(nominal, args.periods),
+        "discount_factor_real": (
+            discount_factor(real, args.periods) if real is not None else None
+        ),
+    }
+
+    if args.fv is not None:
+        result["lump_sum"] = {
+            "future_value": args.fv,
+            "present_value_nominal": present_value(args.fv, nominal, args.periods),
+            "present_value_real": (
+                present_value(args.fv, real, args.periods) if real is not None else None
+            ),
+        }
+
+    if args.cashflows is not None:
+        nominal_npv = npv(nominal, args.cashflows)
+        result["npv"] = {
+            "cash_flows": list(args.cashflows),
+            "nominal": nominal_npv,
+            "real": (
+                real_npv(nominal, inflation, args.cashflows)
+                if inflation is not None
+                else None
+            ),
+            "payback_period": payback_period(args.cashflows, nominal),
+        }
+    return result
+
+
+def format_table(result: dict[str, Any], precision: int) -> str:
+    """Format the result mapping as an aligned text report.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+        precision: Decimal places for all floating-point output.
+
+    Returns:
+        Multi-line string ready to print.
+    """
+    periods = float(result["periods"])
+    lines = [
+        "Discount rate analysis",
+        "",
+        f"  {'Nominal rate:':<32} {_pct(float(result['nominal_rate']), precision):>14}",
+    ]
+    if result["inflation"] is not None:
+        lines.append(
+            f"  {'Inflation:':<32} {_pct(float(result['inflation']), precision):>14}"
+        )
+        lines.append(
+            f"  {'Real rate (Fisher):':<32} "
+            f"{_pct(float(result['real_rate']), precision):>14}"
+        )
+    lines += [
+        "",
+        f"  {'Periods:':<32} {periods:>14g}",
+        f"  {'Discount factor (nominal):':<32} "
+        f"{_fmt(float(result['discount_factor_nominal']), precision):>14}",
+    ]
+    if result["discount_factor_real"] is not None:
+        lines.append(
+            f"  {'Discount factor (real):':<32} "
+            f"{_fmt(float(result['discount_factor_real']), precision):>14}"
+        )
+
+    lump = result.get("lump_sum")
+    if isinstance(lump, dict):
+        lines += [
+            "",
+            f"  {'Future value:':<32} {_fmt(lump['future_value'], precision):>14}",
+            f"  {'Present value (nominal):':<32} "
+            f"{_fmt(lump['present_value_nominal'], precision):>14}",
+        ]
+        if lump["present_value_real"] is not None:
+            lines.append(
+                f"  {'Present value (real):':<32} "
+                f"{_fmt(lump['present_value_real'], precision):>14}"
+            )
+
+    series = result.get("npv")
+    if isinstance(series, dict):
+        lines += [
+            "",
+            f"  {'Cash flows:':<32} {len(series['cash_flows']):>14}",
+            f"  {'NPV (nominal):':<32} {_fmt(series['nominal'], precision):>14}",
+        ]
+        if series["real"] is not None:
+            lines.append(f"  {'NPV (real):':<32} {_fmt(series['real'], precision):>14}")
+        payback = series["payback_period"]
+        payback_text = "never" if payback is None else _fmt(payback, precision)
+        lines.append(f"  {'Discounted payback (periods):':<32} {payback_text:>14}")
+        lines += [
+            "",
+            "  Note: real NPV assumes the cash flows are stated in today's",
+            "  purchasing power and discounts them at the real rate.",
+        ]
+    return "\n".join(lines)
+
+
+def format_json(result: dict[str, Any]) -> str:
+    """Format the result mapping as JSON.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+
+    Returns:
+        JSON string.
+    """
+    return json.dumps(result, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the discount rate CLI.
+
+    Args:
+        argv: Argument list override for testing (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        0 on success, 2 on input or computation error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        result = build_result(args)
+        if args.format == "json":
+            print(format_json(result))
+        else:
+            print(format_table(result, args.precision))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/information_entropy.py
+++ b/src/utils/information_entropy.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+"""Command-line utility for information-theoretic measures.
+
+Computes Shannon entropy, KL divergence, cross-entropy, mutual information,
+and conditional entropy.  Pure Python via ``math.log`` — no external
+dependencies.  Results are reported in bits (base 2), nats (base e), or
+hartleys (base 10).
+
+Input vectors are normalized to sum to 1, so raw counts are accepted
+alongside probabilities.
+
+Usage examples:
+  entropy --probs 0.167,0.167,0.167,0.167,0.167,0.167
+  entropy --measure kl --probs-p 0.7,0.3 --probs-q 0.5,0.5
+  entropy --measure mi --joint 0.25,0.25 --joint 0.25,0.25
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections.abc import Sequence
+from typing import Any
+
+# Display names for the supported logarithm bases.
+UNIT_NAMES: dict[str, str] = {"2": "bits", "e": "nats", "10": "hartleys"}
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def normalize(values: Sequence[float]) -> list[float]:
+    """Scale non-negative weights into a probability distribution.
+
+    Args:
+        values: Non-negative weights or probabilities; must be non-empty and
+            sum to a positive total.
+
+    Returns:
+        The values divided by their sum, so the result sums to 1.
+
+    Raises:
+        ValueError: If ``values`` is empty, contains a negative entry, or sums
+            to zero.
+    """
+    if not values:
+        raise ValueError("distribution must have at least one outcome")
+    for value in values:
+        if value < 0:
+            raise ValueError(f"probabilities must be >= 0, got {value}")
+    total = math.fsum(values)
+    if total <= 0:
+        raise ValueError("probabilities must sum to a positive total")
+    return [value / total for value in values]
+
+
+def shannon_entropy(probs: Sequence[float], base: float = 2.0) -> float:
+    """Shannon entropy H(X) of a discrete distribution.
+
+    Args:
+        probs: Non-negative weights or probabilities; normalized internally.
+        base: Logarithm base; must be > 1.
+
+    Returns:
+        H(X) = -sum p_i * log_base(p_i), with the 0 * log 0 = 0 convention.
+
+    Raises:
+        ValueError: If ``probs`` is not a valid distribution or ``base`` <= 1.
+    """
+    _validate_base(base)
+    p = normalize(probs)
+    # Zero-probability outcomes contribute nothing (0 log 0 -> 0 by convention).
+    return -math.fsum(pi * math.log(pi, base) for pi in p if pi > 0)
+
+
+def max_entropy(outcomes: int, base: float = 2.0) -> float:
+    """Entropy of the uniform distribution over ``outcomes`` outcomes.
+
+    Args:
+        outcomes: Number of outcomes; must be >= 1.
+        base: Logarithm base; must be > 1.
+
+    Returns:
+        log_base(outcomes) — the largest entropy any distribution of this size
+        can reach.
+
+    Raises:
+        ValueError: If ``outcomes`` < 1 or ``base`` <= 1.
+    """
+    _validate_base(base)
+    if outcomes < 1:
+        raise ValueError(f"outcomes must be >= 1, got {outcomes}")
+    return math.log(outcomes, base)
+
+
+def kl_divergence(p: Sequence[float], q: Sequence[float], base: float = 2.0) -> float:
+    """Kullback-Leibler divergence D(P || Q).
+
+    Args:
+        p: Reference distribution, normalized internally.
+        q: Comparison distribution, normalized internally; must be the same
+            length as ``p``.
+        base: Logarithm base; must be > 1.
+
+    Returns:
+        D(P||Q) = sum p_i * log_base(p_i / q_i) — the extra information cost of
+        coding samples from P using a code built for Q.
+
+    Raises:
+        ValueError: If the vectors differ in length, either is not a valid
+            distribution, ``base`` <= 1, or some ``q_i`` is 0 where ``p_i`` > 0
+            (the divergence is then infinite).
+    """
+    _validate_base(base)
+    _validate_same_length(p, q)
+    pn, qn = normalize(p), normalize(q)
+    total = 0.0
+    for pi, qi in zip(pn, qn):
+        if pi == 0:
+            continue
+        if qi == 0:
+            raise ValueError(
+                "KL divergence is infinite: q assigns zero probability to an "
+                "outcome p gives positive probability"
+            )
+        total += pi * math.log(pi / qi, base)
+    return total
+
+
+def cross_entropy(p: Sequence[float], q: Sequence[float], base: float = 2.0) -> float:
+    """Cross-entropy H(P, Q).
+
+    Args:
+        p: True distribution, normalized internally.
+        q: Predicted distribution, normalized internally; must be the same
+            length as ``p``.
+        base: Logarithm base; must be > 1.
+
+    Returns:
+        H(P, Q) = -sum p_i * log_base(q_i) = H(P) + D(P||Q).
+
+    Raises:
+        ValueError: If the vectors differ in length, either is not a valid
+            distribution, ``base`` <= 1, or some ``q_i`` is 0 where ``p_i`` > 0.
+    """
+    _validate_base(base)
+    _validate_same_length(p, q)
+    pn, qn = normalize(p), normalize(q)
+    total = 0.0
+    for pi, qi in zip(pn, qn):
+        if pi == 0:
+            continue
+        if qi == 0:
+            raise ValueError(
+                "cross-entropy is infinite: q assigns zero probability to an "
+                "outcome p gives positive probability"
+            )
+        total -= pi * math.log(qi, base)
+    return total
+
+
+def normalize_joint(joint: Sequence[Sequence[float]]) -> list[list[float]]:
+    """Scale a joint weight table into a joint probability distribution.
+
+    Args:
+        joint: Rectangular table of non-negative weights, one row per X outcome
+            and one column per Y outcome.
+
+    Returns:
+        The table divided by its grand total, so all cells sum to 1.
+
+    Raises:
+        ValueError: If the table is empty, ragged, has a negative cell, or sums
+            to zero.
+    """
+    if not joint:
+        raise ValueError("joint distribution must have at least one row")
+    width = len(joint[0])
+    if width == 0:
+        raise ValueError("joint distribution rows must have at least one column")
+    for row in joint:
+        if len(row) != width:
+            raise ValueError(
+                f"joint rows must all have the same length, got {width} and {len(row)}"
+            )
+    flat = normalize([cell for row in joint for cell in row])
+    return [flat[i * width : (i + 1) * width] for i in range(len(joint))]
+
+
+def marginals(
+    joint: Sequence[Sequence[float]],
+) -> tuple[list[float], list[float]]:
+    """Row and column marginal distributions of a joint table.
+
+    Args:
+        joint: Rectangular table of non-negative weights.
+
+    Returns:
+        Tuple of (P(X), P(Y)) — the row sums and the column sums of the
+        normalized joint table.
+
+    Raises:
+        ValueError: If the joint table is invalid.
+    """
+    table = normalize_joint(joint)
+    px = [math.fsum(row) for row in table]
+    py = [math.fsum(row[j] for row in table) for j in range(len(table[0]))]
+    return px, py
+
+
+def joint_entropy(joint: Sequence[Sequence[float]], base: float = 2.0) -> float:
+    """Joint entropy H(X, Y) of a joint distribution table.
+
+    Args:
+        joint: Rectangular table of non-negative weights.
+        base: Logarithm base; must be > 1.
+
+    Returns:
+        H(X, Y), the entropy of the flattened joint distribution.
+
+    Raises:
+        ValueError: If the joint table is invalid or ``base`` <= 1.
+    """
+    table = normalize_joint(joint)
+    return shannon_entropy([cell for row in table for cell in row], base)
+
+
+def mutual_information(joint: Sequence[Sequence[float]], base: float = 2.0) -> float:
+    """Mutual information I(X; Y) of a joint distribution table.
+
+    Args:
+        joint: Rectangular table of non-negative weights.
+        base: Logarithm base; must be > 1.
+
+    Returns:
+        I(X; Y) = H(X) + H(Y) - H(X, Y) — the information the two variables
+        share.  Zero exactly when X and Y are independent.
+
+    Raises:
+        ValueError: If the joint table is invalid or ``base`` <= 1.
+    """
+    px, py = marginals(joint)
+    value = (
+        shannon_entropy(px, base)
+        + shannon_entropy(py, base)
+        - joint_entropy(joint, base)
+    )
+    # Floating-point cancellation can push an independent table slightly below
+    # zero; mutual information is non-negative by definition.
+    return max(0.0, value)
+
+
+def conditional_entropy(joint: Sequence[Sequence[float]], base: float = 2.0) -> float:
+    """Conditional entropy H(Y | X) of a joint distribution table.
+
+    Args:
+        joint: Rectangular table of non-negative weights, rows indexing X.
+        base: Logarithm base; must be > 1.
+
+    Returns:
+        H(Y | X) = H(X, Y) - H(X) — the uncertainty left in Y once X is known.
+
+    Raises:
+        ValueError: If the joint table is invalid or ``base`` <= 1.
+    """
+    px, _py = marginals(joint)
+    return max(0.0, joint_entropy(joint, base) - shannon_entropy(px, base))
+
+
+def _kl_or_none(p: Sequence[float], q: Sequence[float], base: float) -> float | None:
+    """Return D(P||Q), or ``None`` when the divergence is infinite.
+
+    Args:
+        p: Reference distribution.
+        q: Comparison distribution.
+        base: Logarithm base.
+
+    Returns:
+        The divergence, or ``None`` if ``q`` puts zero mass where ``p`` does not.
+    """
+    try:
+        return kl_divergence(p, q, base)
+    except ValueError as exc:
+        if "infinite" in str(exc):
+            return None
+        raise
+
+
+def _validate_base(base: float) -> None:
+    """Raise if the logarithm base is not usable for an entropy measure."""
+    if base <= 1:
+        raise ValueError(f"base must be > 1, got {base}")
+
+
+def _validate_same_length(p: Sequence[float], q: Sequence[float]) -> None:
+    """Raise if two distributions do not have matching support sizes."""
+    if len(p) != len(q):
+        raise ValueError(
+            f"p and q must have the same length, got {len(p)} and {len(q)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_values(text: str) -> list[float]:
+    """Parse a comma- or whitespace-separated list of numbers.
+
+    Args:
+        text: Raw string such as ``"0.7,0.3"`` or ``"3 1 1"``.
+
+    Returns:
+        List of parsed floats.
+
+    Raises:
+        ValueError: If ``text`` holds no values or an entry is not numeric.
+    """
+    tokens = [token for token in text.replace(",", " ").split() if token]
+    if not tokens:
+        raise ValueError("no numeric values found")
+    try:
+        return [float(token) for token in tokens]
+    except ValueError:
+        raise ValueError(f"could not parse '{text}' as a list of numbers") from None
+
+
+def base_value(base: str) -> float:
+    """Convert a ``--base`` choice into a numeric logarithm base.
+
+    Args:
+        base: One of ``"2"``, ``"e"``, or ``"10"``.
+
+    Returns:
+        The numeric base.
+
+    Raises:
+        ValueError: If ``base`` is not a supported choice.
+    """
+    if base == "e":
+        return math.e
+    if base in ("2", "10"):
+        return float(base)
+    raise ValueError(f"base must be one of 2, e, 10, got {base}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and return the argument parser namespace.
+
+    Args:
+        argv: Argument list (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        Parsed :class:`argparse.Namespace`.
+    """
+    parser = argparse.ArgumentParser(
+        description="Information entropy and divergence calculator.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  entropy --probs 0.167,0.167,0.167,0.167,0.167,0.167
+  entropy --measure kl --probs-p 0.7,0.3 --probs-q 0.5,0.5
+  entropy --measure cross --probs-p 1,0 --probs-q 0.9,0.1 --base e
+  entropy --measure mi --joint 0.25,0.25 --joint 0.25,0.25
+""",
+    )
+    parser.add_argument(
+        "--probs",
+        type=str,
+        default=None,
+        metavar="VALUES",
+        help="distribution for the entropy measure (comma or space separated)",
+    )
+    parser.add_argument(
+        "--measure",
+        choices=["entropy", "kl", "cross", "mi", "conditional"],
+        default="entropy",
+        help="quantity to compute (default: entropy)",
+    )
+    parser.add_argument(
+        "--base",
+        choices=["2", "e", "10"],
+        default="2",
+        help="logarithm base: 2=bits, e=nats, 10=hartleys (default: 2)",
+    )
+    parser.add_argument(
+        "--probs-p",
+        type=str,
+        default=None,
+        metavar="VALUES",
+        help="distribution P for the kl and cross measures",
+    )
+    parser.add_argument(
+        "--probs-q",
+        type=str,
+        default=None,
+        metavar="VALUES",
+        help="distribution Q for the kl and cross measures",
+    )
+    parser.add_argument(
+        "--joint",
+        type=str,
+        action="append",
+        default=None,
+        metavar="ROW",
+        help="one row of the joint table for mi and conditional; repeat per row",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="output format (default: table)",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=4,
+        metavar="PREC",
+        help="decimal places for output (default: 4)",
+    )
+    return parser.parse_args(argv)
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Return an error message string, or ``None`` if arguments are valid.
+
+    Args:
+        args: Parsed argument namespace from :func:`parse_args`.
+
+    Returns:
+        Error description string, or ``None`` when validation passes.
+    """
+    if args.precision < 0:
+        return "--precision must be non-negative"
+
+    if args.measure == "entropy":
+        if args.probs is None:
+            return "--probs is required for --measure entropy"
+    elif args.measure in ("kl", "cross"):
+        if args.probs_p is None or args.probs_q is None:
+            return f"--probs-p and --probs-q are required for --measure {args.measure}"
+    elif args.joint is None:
+        return f"--joint is required for --measure {args.measure}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(value: float, precision: int) -> str:
+    """Format a float to the requested number of decimal places."""
+    return f"{value:.{precision}f}"
+
+
+def build_result(args: argparse.Namespace) -> dict[str, Any]:
+    """Compute the requested measure into a result mapping.
+
+    Args:
+        args: Validated argument namespace from :func:`parse_args`.
+
+    Returns:
+        Mapping with the measure name, unit, and every figure the report shows.
+
+    Raises:
+        ValueError: If an input vector or the joint table is invalid.
+    """
+    base = base_value(args.base)
+    unit = UNIT_NAMES[args.base]
+    result: dict[str, Any] = {
+        "measure": args.measure,
+        "base": args.base,
+        "unit": unit,
+    }
+
+    if args.measure == "entropy":
+        probs = normalize(parse_values(args.probs))
+        maximum = max_entropy(len(probs), base)
+        value = shannon_entropy(probs, base)
+        result.update(
+            {
+                "outcomes": len(probs),
+                "entropy": value,
+                "max_entropy": maximum,
+                # Efficiency is undefined for a single outcome (max entropy 0).
+                "efficiency": value / maximum if maximum > 0 else 1.0,
+            }
+        )
+    elif args.measure in ("kl", "cross"):
+        p = normalize(parse_values(args.probs_p))
+        q = normalize(parse_values(args.probs_q))
+        result.update(
+            {
+                "entropy_p": shannon_entropy(p, base),
+                "kl_divergence": kl_divergence(p, q, base),
+                "cross_entropy": cross_entropy(p, q, base),
+                # Reverse KL is supplementary, so an infinite value is reported
+                # rather than failing the run the user actually asked for.
+                "kl_reverse": _kl_or_none(q, p, base),
+            }
+        )
+    else:
+        joint = [parse_values(row) for row in args.joint]
+        px, py = marginals(joint)
+        result.update(
+            {
+                "entropy_x": shannon_entropy(px, base),
+                "entropy_y": shannon_entropy(py, base),
+                "joint_entropy": joint_entropy(joint, base),
+                "mutual_information": mutual_information(joint, base),
+                "conditional_entropy_y_given_x": conditional_entropy(joint, base),
+                "conditional_entropy_x_given_y": conditional_entropy(
+                    [list(col) for col in zip(*normalize_joint(joint))], base
+                ),
+            }
+        )
+    return result
+
+
+def format_table(result: dict[str, Any], precision: int) -> str:
+    """Format the result mapping as an aligned text report.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+        precision: Decimal places for all floating-point output.
+
+    Returns:
+        Multi-line string ready to print.
+    """
+    unit = str(result["unit"])
+    measure = str(result["measure"])
+
+    def line(label: str, key: str) -> str:
+        """Render one labelled value row in the report's unit."""
+        value = result[key]
+        if value is None:
+            return f"  {label:<26} {'infinite':>12}"
+        return f"  {label:<26} {_fmt(float(value), precision):>12} {unit}"
+
+    if measure == "entropy":
+        lines = [
+            f"Shannon entropy  (base {result['base']}, {unit})",
+            "",
+            f"  {'Outcomes:':<26} {int(result['outcomes']):>12}",
+            line("Entropy H(X):", "entropy"),
+            line("Maximum (uniform):", "max_entropy"),
+            f"  {'Efficiency:':<26} "
+            f"{_fmt(float(result['efficiency']) * 100, precision):>12} %",
+        ]
+    elif measure in ("kl", "cross"):
+        title = "KL divergence" if measure == "kl" else "Cross-entropy"
+        lines = [
+            f"{title}  (base {result['base']}, {unit})",
+            "",
+            line("Entropy H(P):", "entropy_p"),
+            line("KL divergence D(P||Q):", "kl_divergence"),
+            line("Cross-entropy H(P,Q):", "cross_entropy"),
+            line("Reverse KL D(Q||P):", "kl_reverse"),
+            "",
+            "  Note: KL is asymmetric — D(P||Q) is the extra cost of coding",
+            "  samples from P with a code built for Q.",
+        ]
+    else:
+        title = "Mutual information" if measure == "mi" else "Conditional entropy"
+        lines = [
+            f"{title}  (base {result['base']}, {unit})",
+            "",
+            line("Entropy H(X):", "entropy_x"),
+            line("Entropy H(Y):", "entropy_y"),
+            line("Joint entropy H(X,Y):", "joint_entropy"),
+            line("Mutual information I(X;Y):", "mutual_information"),
+            line("Conditional H(Y|X):", "conditional_entropy_y_given_x"),
+            line("Conditional H(X|Y):", "conditional_entropy_x_given_y"),
+        ]
+    return "\n".join(lines)
+
+
+def format_json(result: dict[str, Any]) -> str:
+    """Format the result mapping as JSON.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+
+    Returns:
+        JSON string.
+    """
+    return json.dumps(result, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the information entropy CLI.
+
+    Args:
+        argv: Argument list override for testing (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        0 on success, 2 on input or computation error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        result = build_result(args)
+        if args.format == "json":
+            print(format_json(result))
+        else:
+            print(format_table(result, args.precision))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/weibull_distribution.py
+++ b/src/utils/weibull_distribution.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""Command-line utility for the Weibull distribution.
+
+Computes PDF, CDF, survival, hazard, quantiles, and moments for the two-
+parameter Weibull(k, lambda) distribution.  Pure Python via ``math.lgamma`` —
+no external dependencies.
+
+The shape parameter k sets the failure mode: k < 1 is a decreasing hazard
+(infant mortality), k = 1 is the constant-hazard exponential case, and k > 1 is
+an increasing hazard (wear-out).
+
+Usage examples:
+  weibull -x 500 -k 2 --lambda 1000
+  weibull -x 500 -k 2 --lambda 1000 --survival
+  weibull --quantile 0.05 -k 1.5 --lambda 800
+  weibull -k 2.5 --lambda 1200 --table 0 2000 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def weibull_pdf(x: float, k: float, lam: float) -> float:
+    """Probability density f(x) for Weibull(k, lam).
+
+    Args:
+        x: Evaluation point; values < 0 yield 0.0.
+        k: Shape parameter; must be > 0.
+        lam: Scale parameter; must be > 0.
+
+    Returns:
+        f(x) = (k/lam) * (x/lam)^(k-1) * exp(-(x/lam)^k), and 0.0 for x < 0.
+
+    Raises:
+        ValueError: If ``k`` or ``lam`` is not > 0.
+    """
+    _validate_params(k, lam)
+    if x < 0:
+        return 0.0
+    if x == 0:
+        # The density at the origin is 0, 1/lam, or unbounded depending on k.
+        if k > 1:
+            return 0.0
+        if k == 1:
+            return 1 / lam
+        return math.inf
+    z = x / lam
+    return (k / lam) * z ** (k - 1) * math.exp(-(z**k))
+
+
+def weibull_cdf(x: float, k: float, lam: float) -> float:
+    """Cumulative distribution F(x) = P(X <= x) for Weibull(k, lam).
+
+    Args:
+        x: Evaluation point; values <= 0 yield 0.0.
+        k: Shape parameter; must be > 0.
+        lam: Scale parameter; must be > 0.
+
+    Returns:
+        F(x) = 1 - exp(-(x/lam)^k), clipped to [0, 1].
+
+    Raises:
+        ValueError: If ``k`` or ``lam`` is not > 0.
+    """
+    _validate_params(k, lam)
+    if x <= 0:
+        return 0.0
+    return max(0.0, min(1.0, -math.expm1(-((x / lam) ** k))))
+
+
+def weibull_survival(x: float, k: float, lam: float) -> float:
+    """Survival function S(x) = P(X > x) for Weibull(k, lam).
+
+    Args:
+        x: Evaluation point; values <= 0 yield 1.0.
+        k: Shape parameter; must be > 0.
+        lam: Scale parameter; must be > 0.
+
+    Returns:
+        S(x) = exp(-(x/lam)^k), clipped to [0, 1].
+
+    Raises:
+        ValueError: If ``k`` or ``lam`` is not > 0.
+    """
+    _validate_params(k, lam)
+    if x <= 0:
+        return 1.0
+    return max(0.0, min(1.0, math.exp(-((x / lam) ** k))))
+
+
+def weibull_hazard(x: float, k: float, lam: float) -> float:
+    """Hazard rate h(x) = f(x) / S(x) for Weibull(k, lam).
+
+    Args:
+        x: Evaluation point; values < 0 yield 0.0.
+        k: Shape parameter; must be > 0.
+        lam: Scale parameter; must be > 0.
+
+    Returns:
+        h(x) = (k/lam) * (x/lam)^(k-1) — the instantaneous failure rate of a
+        unit that has already survived to x.  Computed in closed form, so it
+        stays finite in the far tail where f(x)/S(x) would divide 0 by 0.
+
+    Raises:
+        ValueError: If ``k`` or ``lam`` is not > 0.
+    """
+    _validate_params(k, lam)
+    if x < 0:
+        return 0.0
+    if x == 0:
+        if k > 1:
+            return 0.0
+        if k == 1:
+            return 1 / lam
+        return math.inf
+    return (k / lam) * (x / lam) ** (k - 1)
+
+
+def weibull_quantile(p: float, k: float, lam: float) -> float:
+    """Inverse CDF: the value x with P(X <= x) = p.
+
+    Args:
+        p: Target cumulative probability, in [0, 1).
+        k: Shape parameter; must be > 0.
+        lam: Scale parameter; must be > 0.
+
+    Returns:
+        x = lam * (-ln(1 - p))^(1/k).
+
+    Raises:
+        ValueError: If ``p`` is not in [0, 1), or ``k`` or ``lam`` is not > 0.
+    """
+    _validate_params(k, lam)
+    if not (0 <= p < 1):
+        raise ValueError(f"p must be in [0, 1), got {p}")
+    if p == 0:
+        return 0.0
+    return lam * (-math.log1p(-p)) ** (1 / k)
+
+
+def weibull_mean(k: float, lam: float) -> float:
+    """Expected value E[X] for Weibull(k, lam).
+
+    Args:
+        k: Shape parameter; must be > 0.
+        lam: Scale parameter; must be > 0.
+
+    Returns:
+        lam * Gamma(1 + 1/k), evaluated through ``math.lgamma`` so large
+        shape or scale values do not overflow the gamma function.
+
+    Raises:
+        ValueError: If ``k`` or ``lam`` is not > 0.
+    """
+    _validate_params(k, lam)
+    return lam * math.exp(math.lgamma(1 + 1 / k))
+
+
+def weibull_variance(k: float, lam: float) -> float:
+    """Variance Var(X) for Weibull(k, lam).
+
+    Args:
+        k: Shape parameter; must be > 0.
+        lam: Scale parameter; must be > 0.
+
+    Returns:
+        lam^2 * [Gamma(1 + 2/k) - Gamma(1 + 1/k)^2].
+
+    Raises:
+        ValueError: If ``k`` or ``lam`` is not > 0.
+    """
+    _validate_params(k, lam)
+    g1 = math.exp(math.lgamma(1 + 1 / k))
+    g2 = math.exp(math.lgamma(1 + 2 / k))
+    return max(0.0, lam**2 * (g2 - g1**2))
+
+
+def weibull_median(k: float, lam: float) -> float:
+    """Median failure time for Weibull(k, lam).
+
+    Args:
+        k: Shape parameter; must be > 0.
+        lam: Scale parameter; must be > 0.
+
+    Returns:
+        lam * (ln 2)^(1/k).
+
+    Raises:
+        ValueError: If ``k`` or ``lam`` is not > 0.
+    """
+    return weibull_quantile(0.5, k, lam)
+
+
+def failure_mode(k: float) -> str:
+    """Describe the hazard behaviour implied by the shape parameter.
+
+    Args:
+        k: Shape parameter; must be > 0.
+
+    Returns:
+        One of ``"infant mortality (decreasing hazard)"``,
+        ``"random failure (constant hazard, exponential)"``, or
+        ``"wear-out (increasing hazard)"``.
+
+    Raises:
+        ValueError: If ``k`` is not > 0.
+    """
+    if k <= 0:
+        raise ValueError(f"k must be > 0, got {k}")
+    if k < 1:
+        return "infant mortality (decreasing hazard)"
+    if k == 1:
+        return "random failure (constant hazard, exponential)"
+    return "wear-out (increasing hazard)"
+
+
+def table_rows(
+    min_x: float, max_x: float, step: float, k: float, lam: float
+) -> list[tuple[float, float, float, float, float]]:
+    """Build a PDF/CDF/survival/hazard table across a range of x.
+
+    Args:
+        min_x: First evaluation point; must be >= 0.
+        max_x: Last evaluation point; must be >= ``min_x``.
+        step: Increment between rows; must be > 0.
+        k: Shape parameter; must be > 0.
+        lam: Scale parameter; must be > 0.
+
+    Returns:
+        List of (x, pdf, cdf, survival, hazard) tuples.
+
+    Raises:
+        ValueError: If the range or step is invalid, or a parameter is not > 0.
+    """
+    if step <= 0:
+        raise ValueError(f"step must be > 0, got {step}")
+    if min_x < 0:
+        raise ValueError(f"min_x must be >= 0, got {min_x}")
+    if max_x < min_x:
+        raise ValueError(f"max_x must be >= min_x, got min={min_x}, max={max_x}")
+    _validate_params(k, lam)
+
+    rows: list[tuple[float, float, float, float, float]] = []
+    # Step through with an integer counter so float accumulation cannot drift.
+    count = int((max_x - min_x) / step) + 1
+    for i in range(count):
+        x = min_x + i * step
+        rows.append(
+            (
+                x,
+                weibull_pdf(x, k, lam),
+                weibull_cdf(x, k, lam),
+                weibull_survival(x, k, lam),
+                weibull_hazard(x, k, lam),
+            )
+        )
+    return rows
+
+
+def _validate_params(k: float, lam: float) -> None:
+    """Raise if the shape or scale parameter is not strictly positive."""
+    if k <= 0:
+        raise ValueError(f"k must be > 0, got {k}")
+    if lam <= 0:
+        raise ValueError(f"lambda must be > 0, got {lam}")
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and return the argument parser namespace.
+
+    Args:
+        argv: Argument list (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        Parsed :class:`argparse.Namespace`.
+    """
+    parser = argparse.ArgumentParser(
+        description="Weibull distribution calculator for reliability analysis.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  weibull -x 500 -k 2 --lambda 1000
+  weibull -x 500 -k 2 --lambda 1000 --survival
+  weibull --quantile 0.05 -k 1.5 --lambda 800
+  weibull -k 2.5 --lambda 1200 --table 0 2000 200
+""",
+    )
+    parser.add_argument(
+        "-x",
+        type=float,
+        default=None,
+        metavar="F",
+        help="evaluation point (required unless --quantile or --table is used)",
+    )
+    parser.add_argument(
+        "-k",
+        "--shape",
+        type=float,
+        required=True,
+        dest="k",
+        metavar="F",
+        help="shape parameter k; <1 infant mortality, 1 constant, >1 wear-out",
+    )
+    parser.add_argument(
+        "--lambda",
+        "--scale",
+        type=float,
+        required=True,
+        dest="lam",
+        metavar="F",
+        help="scale parameter lambda (characteristic life)",
+    )
+    parser.add_argument(
+        "--quantile",
+        type=float,
+        default=None,
+        metavar="F",
+        help="report the x at this cumulative probability instead of a point report",
+    )
+    parser.add_argument(
+        "--survival",
+        action="store_true",
+        help="lead the point report with S(x) = 1 - F(x)",
+    )
+    parser.add_argument(
+        "--table",
+        type=float,
+        nargs=3,
+        default=None,
+        metavar=("MIN", "MAX", "STEP"),
+        help="print a table over x = MIN..MAX instead of a single report",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="output format (default: table)",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=4,
+        metavar="PREC",
+        help="decimal places for output (default: 4)",
+    )
+    return parser.parse_args(argv)
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Return an error message string, or ``None`` if arguments are valid.
+
+    Args:
+        args: Parsed argument namespace from :func:`parse_args`.
+
+    Returns:
+        Error description string, or ``None`` when validation passes.
+    """
+    if args.k <= 0:
+        return f"-k must be > 0, got {args.k}"
+    if args.lam <= 0:
+        return f"--lambda must be > 0, got {args.lam}"
+    if args.precision < 0:
+        return "--precision must be non-negative"
+
+    if args.table is not None:
+        min_x, max_x, step = args.table
+        if min_x < 0:
+            return f"--table MIN must be >= 0, got {min_x}"
+        if max_x < min_x:
+            return f"--table MAX must be >= MIN, got MIN={min_x}, MAX={max_x}"
+        if step <= 0:
+            return f"--table STEP must be > 0, got {step}"
+        return None
+
+    if args.quantile is not None:
+        if not (0 <= args.quantile < 1):
+            return f"--quantile must be in [0, 1), got {args.quantile}"
+        return None
+
+    if args.x is None:
+        return "-x is required unless --quantile or --table is used"
+    if args.x < 0:
+        return f"-x must be >= 0, got {args.x}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(value: float, precision: int) -> str:
+    """Format a float to the requested number of decimal places."""
+    if math.isinf(value):
+        return "inf"
+    return f"{value:.{precision}f}"
+
+
+def build_result(args: argparse.Namespace) -> dict[str, Any]:
+    """Compute the requested figures into a single result mapping.
+
+    Args:
+        args: Validated argument namespace from :func:`parse_args`.
+
+    Returns:
+        Mapping of parameters, distribution moments, and whichever of the
+        point, quantile, or table sections was requested.
+
+    Raises:
+        ValueError: If a core computation rejects its inputs.
+    """
+    result: dict[str, Any] = {
+        "k": args.k,
+        "lambda": args.lam,
+        "failure_mode": failure_mode(args.k),
+        "mean": weibull_mean(args.k, args.lam),
+        "median": weibull_median(args.k, args.lam),
+        "variance": weibull_variance(args.k, args.lam),
+    }
+
+    if args.table is not None:
+        min_x, max_x, step = args.table
+        result["table"] = table_rows(min_x, max_x, step, args.k, args.lam)
+    elif args.quantile is not None:
+        result["quantile"] = {
+            "p": args.quantile,
+            "x": weibull_quantile(args.quantile, args.k, args.lam),
+        }
+    else:
+        result["point"] = {
+            "x": args.x,
+            "pdf": weibull_pdf(args.x, args.k, args.lam),
+            "cdf": weibull_cdf(args.x, args.k, args.lam),
+            "survival": weibull_survival(args.x, args.k, args.lam),
+            "hazard": weibull_hazard(args.x, args.k, args.lam),
+        }
+    return result
+
+
+def format_table(result: dict[str, Any], precision: int, survival: bool) -> str:
+    """Format the result mapping as an aligned text report.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+        precision: Decimal places for all floating-point output.
+        survival: If True, lead the point report with S(x) rather than F(x).
+
+    Returns:
+        Multi-line string ready to print.
+    """
+    lines = [
+        f"Weibull distribution  (k={_fmt(float(result['k']), precision)}, "
+        f"lambda={_fmt(float(result['lambda']), precision)})",
+        "",
+        f"  Failure mode: {result['failure_mode']}",
+        "",
+    ]
+
+    point = result.get("point")
+    if isinstance(point, dict):
+        x = _fmt(point["x"], precision)
+        ordered = [
+            (f"S(x > {x}):", "survival"),
+            (f"F(x <= {x}):", "cdf"),
+        ]
+        if not survival:
+            ordered.reverse()
+        # Labels carry the formatted x value, so their width varies with
+        # --precision; pad every row to the widest one in this report.
+        width = max(len(label) for label, _key in ordered + [("hazard h(x):", "")])
+        lines.append(f"  {'f(x):':<{width}} {_fmt(point['pdf'], precision):>14}")
+        for label, key in ordered:
+            lines.append(f"  {label:<{width}} {_fmt(point[key], precision):>14}")
+        lines.append(
+            f"  {'hazard h(x):':<{width}} {_fmt(point['hazard'], precision):>14}"
+        )
+        lines.append("")
+
+    quantile = result.get("quantile")
+    if isinstance(quantile, dict):
+        lines += [
+            f"  {'p:':<16} {_fmt(quantile['p'], precision):>14}",
+            f"  {'x at p:':<16} {_fmt(quantile['x'], precision):>14}",
+            "",
+        ]
+
+    rows = result.get("table")
+    if isinstance(rows, list):
+        lines.append(
+            f"  {'x':>10}  {'f(x)':>12}  {'F(x)':>12}  {'S(x)':>12}  {'h(x)':>12}"
+        )
+        for x, pdf, cdf, surv, hazard in rows:
+            lines.append(
+                f"  {_fmt(x, precision):>10}  {_fmt(pdf, precision):>12}  "
+                f"{_fmt(cdf, precision):>12}  {_fmt(surv, precision):>12}  "
+                f"{_fmt(hazard, precision):>12}"
+            )
+        lines.append("")
+
+    lines += [
+        f"  {'mean:':<16} {_fmt(float(result['mean']), precision):>14}",
+        f"  {'median:':<16} {_fmt(float(result['median']), precision):>14}",
+        f"  {'variance:':<16} {_fmt(float(result['variance']), precision):>14}",
+    ]
+    return "\n".join(lines)
+
+
+def format_json(result: dict[str, Any]) -> str:
+    """Format the result mapping as JSON.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+
+    Returns:
+        JSON string.
+    """
+    data = dict(result)
+    rows = data.get("table")
+    if isinstance(rows, list):
+        data["table"] = [
+            {"x": x, "pdf": pdf, "cdf": cdf, "survival": surv, "hazard": hazard}
+            for x, pdf, cdf, surv, hazard in rows
+        ]
+    return json.dumps(data, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the Weibull distribution CLI.
+
+    Args:
+        argv: Argument list override for testing (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        0 on success, 2 on input or computation error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        result = build_result(args)
+        if args.format == "json":
+            print(format_json(result))
+        else:
+            print(format_table(result, args.precision, args.survival))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_break_even.py
+++ b/tests/test_break_even.py
@@ -1,0 +1,497 @@
+"""Tests for the break-even analysis utility."""
+
+import argparse
+import json
+
+import pytest
+
+import src.utils.break_even as break_even_module
+from src.utils.break_even import (
+    breakeven_revenue,
+    breakeven_units,
+    build_result,
+    contribution_margin,
+    contribution_margin_ratio,
+    format_chart,
+    format_csv,
+    format_json,
+    format_table,
+    main,
+    margin_of_safety,
+    profit_at,
+    sweep_rows,
+    target_profit_units,
+    validate,
+)
+
+
+def _args(**overrides):
+    """Build a namespace with valid defaults, overridden per test."""
+    base = dict(
+        fixed=50000.0,
+        price=25.0,
+        variable=10.0,
+        target_profit=None,
+        actual_units=None,
+        sweep=None,
+        chart=False,
+        format="table",
+        precision=2,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# contribution_margin / contribution_margin_ratio
+# ---------------------------------------------------------------------------
+
+
+def test_contribution_margin_matches_formula():
+    assert contribution_margin(25.0, 10.0) == pytest.approx(15.0)
+
+
+def test_contribution_margin_ratio_matches_formula():
+    assert contribution_margin_ratio(25.0, 10.0) == pytest.approx(0.6)
+
+
+def test_contribution_margin_zero_variable_cost():
+    assert contribution_margin_ratio(25.0, 0.0) == pytest.approx(1.0)
+
+
+def test_contribution_margin_price_not_positive_raises():
+    with pytest.raises(ValueError, match="price must be > 0"):
+        contribution_margin(0.0, 10.0)
+
+
+def test_contribution_margin_negative_variable_raises():
+    with pytest.raises(ValueError, match="variable must be >= 0"):
+        contribution_margin(25.0, -1.0)
+
+
+def test_contribution_margin_ratio_invalid_price_raises():
+    with pytest.raises(ValueError, match="price must be > 0"):
+        contribution_margin_ratio(-5.0, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# breakeven_units / breakeven_revenue
+# ---------------------------------------------------------------------------
+
+
+def test_breakeven_units_matches_formula():
+    assert breakeven_units(50000.0, 25.0, 10.0) == pytest.approx(50000 / 15)
+
+
+def test_breakeven_units_zero_fixed_costs():
+    assert breakeven_units(0.0, 25.0, 10.0) == pytest.approx(0.0)
+
+
+def test_breakeven_units_no_margin_raises():
+    with pytest.raises(ValueError, match="price must exceed variable cost"):
+        breakeven_units(50000.0, 10.0, 10.0)
+
+
+def test_breakeven_units_negative_fixed_raises():
+    with pytest.raises(ValueError, match="fixed must be >= 0"):
+        breakeven_units(-1.0, 25.0, 10.0)
+
+
+def test_breakeven_revenue_matches_units_times_price():
+    units = breakeven_units(50000.0, 25.0, 10.0)
+    ratio = contribution_margin_ratio(25.0, 10.0)
+    assert breakeven_revenue(50000.0, ratio) == pytest.approx(units * 25.0)
+
+
+def test_breakeven_revenue_negative_fixed_raises():
+    with pytest.raises(ValueError, match="fixed must be >= 0"):
+        breakeven_revenue(-1.0, 0.5)
+
+
+@pytest.mark.parametrize("ratio", [0.0, -0.2, 1.5])
+def test_breakeven_revenue_invalid_ratio_raises(ratio):
+    with pytest.raises(ValueError, match=r"margin_ratio must be in \(0, 1\]"):
+        breakeven_revenue(50000.0, ratio)
+
+
+# ---------------------------------------------------------------------------
+# margin_of_safety
+# ---------------------------------------------------------------------------
+
+
+def test_margin_of_safety_above_breakeven():
+    assert margin_of_safety(5000.0, 4000.0) == pytest.approx(0.2)
+
+
+def test_margin_of_safety_below_breakeven_is_negative():
+    assert margin_of_safety(1000.0, 2000.0) == pytest.approx(-1.0)
+
+
+def test_margin_of_safety_at_breakeven_is_zero():
+    assert margin_of_safety(3000.0, 3000.0) == pytest.approx(0.0)
+
+
+def test_margin_of_safety_non_positive_actual_raises():
+    with pytest.raises(ValueError, match="actual_units must be > 0"):
+        margin_of_safety(0.0, 100.0)
+
+
+def test_margin_of_safety_negative_breakeven_raises():
+    with pytest.raises(ValueError, match="be_units must be >= 0"):
+        margin_of_safety(100.0, -1.0)
+
+
+# ---------------------------------------------------------------------------
+# target_profit_units / profit_at
+# ---------------------------------------------------------------------------
+
+
+def test_target_profit_units_matches_formula():
+    assert target_profit_units(50000.0, 25.0, 10.0, 20000.0) == pytest.approx(
+        70000 / 15
+    )
+
+
+def test_target_profit_zero_equals_breakeven():
+    assert target_profit_units(50000.0, 25.0, 10.0, 0.0) == pytest.approx(
+        breakeven_units(50000.0, 25.0, 10.0)
+    )
+
+
+def test_target_profit_units_accepts_negative_target():
+    assert target_profit_units(50000.0, 25.0, 10.0, -15000.0) == pytest.approx(
+        35000 / 15
+    )
+
+
+def test_target_profit_units_no_margin_raises():
+    with pytest.raises(ValueError, match="price must exceed variable cost"):
+        target_profit_units(50000.0, 10.0, 12.0, 100.0)
+
+
+def test_target_profit_units_negative_fixed_raises():
+    with pytest.raises(ValueError, match="fixed must be >= 0"):
+        target_profit_units(-1.0, 25.0, 10.0, 100.0)
+
+
+def test_profit_at_breakeven_volume_is_zero():
+    units = breakeven_units(50000.0, 25.0, 10.0)
+    assert profit_at(units, 50000.0, 25.0, 10.0) == pytest.approx(0.0)
+
+
+def test_profit_at_zero_units_is_negative_fixed():
+    assert profit_at(0.0, 50000.0, 25.0, 10.0) == pytest.approx(-50000.0)
+
+
+def test_profit_at_negative_units_raises():
+    with pytest.raises(ValueError, match="units must be >= 0"):
+        profit_at(-1.0, 50000.0, 25.0, 10.0)
+
+
+def test_profit_at_negative_fixed_raises():
+    with pytest.raises(ValueError, match="fixed must be >= 0"):
+        profit_at(10.0, -1.0, 25.0, 10.0)
+
+
+# ---------------------------------------------------------------------------
+# sweep_rows
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_rows_row_count_and_endpoints():
+    rows = sweep_rows(0.0, 8000.0, 2000.0, 50000.0, 25.0, 10.0)
+    assert len(rows) == 5
+    assert rows[0][0] == pytest.approx(0.0)
+    assert rows[-1][0] == pytest.approx(8000.0)
+
+
+def test_sweep_rows_profit_is_revenue_minus_cost():
+    rows = sweep_rows(0.0, 4000.0, 2000.0, 50000.0, 25.0, 10.0)
+    for _units, revenue, cost, profit in rows:
+        assert profit == pytest.approx(revenue - cost)
+
+
+def test_sweep_rows_crosses_zero_at_breakeven():
+    rows = sweep_rows(0.0, 8000.0, 1000.0, 50000.0, 25.0, 10.0)
+    profits = [row[3] for row in rows]
+    assert profits[0] < 0 < profits[-1]
+
+
+def test_sweep_rows_single_row_when_min_equals_max():
+    assert len(sweep_rows(100.0, 100.0, 50.0, 1000.0, 25.0, 10.0)) == 1
+
+
+def test_sweep_rows_non_positive_step_raises():
+    with pytest.raises(ValueError, match="step must be > 0"):
+        sweep_rows(0.0, 100.0, 0.0, 1000.0, 25.0, 10.0)
+
+
+def test_sweep_rows_negative_min_raises():
+    with pytest.raises(ValueError, match="min_units must be >= 0"):
+        sweep_rows(-1.0, 100.0, 10.0, 1000.0, 25.0, 10.0)
+
+
+def test_sweep_rows_max_below_min_raises():
+    with pytest.raises(ValueError, match="max_units must be >= min_units"):
+        sweep_rows(100.0, 50.0, 10.0, 1000.0, 25.0, 10.0)
+
+
+def test_sweep_rows_negative_fixed_raises():
+    with pytest.raises(ValueError, match="fixed must be >= 0"):
+        sweep_rows(0.0, 100.0, 10.0, -1.0, 25.0, 10.0)
+
+
+def test_sweep_rows_invalid_price_raises():
+    with pytest.raises(ValueError, match="price must be > 0"):
+        sweep_rows(0.0, 100.0, 10.0, 1000.0, 0.0, 10.0)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_minimal_args():
+    assert validate(_args()) is None
+
+
+def test_validate_negative_fixed():
+    result = validate(_args(fixed=-1.0))
+    assert result is not None and "--fixed" in result
+
+
+def test_validate_non_positive_price():
+    result = validate(_args(price=0.0))
+    assert result is not None and "--price must be > 0" in result
+
+
+def test_validate_negative_variable():
+    result = validate(_args(variable=-2.0))
+    assert result is not None and "--variable" in result
+
+
+def test_validate_price_not_above_variable():
+    result = validate(_args(price=10.0, variable=10.0))
+    assert result is not None and "--price must exceed --variable" in result
+
+
+def test_validate_negative_precision():
+    result = validate(_args(precision=-1))
+    assert result is not None and "--precision" in result
+
+
+def test_validate_non_positive_actual_units():
+    result = validate(_args(actual_units=0.0))
+    assert result is not None and "--actual-units" in result
+
+
+def test_validate_sweep_negative_min():
+    result = validate(_args(sweep=[-1.0, 100.0, 10.0]))
+    assert result is not None and "--sweep MIN" in result
+
+
+def test_validate_sweep_max_below_min():
+    result = validate(_args(sweep=[100.0, 50.0, 10.0]))
+    assert result is not None and "--sweep MAX" in result
+
+
+def test_validate_sweep_non_positive_step():
+    result = validate(_args(sweep=[0.0, 100.0, 0.0]))
+    assert result is not None and "--sweep STEP" in result
+
+
+def test_validate_sweep_valid():
+    assert validate(_args(sweep=[0.0, 100.0, 10.0], chart=True)) is None
+
+
+def test_validate_chart_without_sweep():
+    result = validate(_args(chart=True))
+    assert result is not None and "--chart requires --sweep" in result
+
+
+# ---------------------------------------------------------------------------
+# build_result
+# ---------------------------------------------------------------------------
+
+
+def test_build_result_core_keys_only():
+    result = build_result(_args())
+    assert result["breakeven_units"] == pytest.approx(50000 / 15)
+    assert "target_profit" not in result
+    assert "margin_of_safety" not in result
+    assert "sweep" not in result
+
+
+def test_build_result_includes_target_profit():
+    result = build_result(_args(target_profit=20000.0))
+    target = result["target_profit"]
+    assert target["units"] == pytest.approx(70000 / 15)
+    assert target["revenue"] == pytest.approx(70000 / 15 * 25.0)
+
+
+def test_build_result_includes_margin_of_safety():
+    result = build_result(_args(actual_units=5000.0))
+    mos = result["margin_of_safety"]
+    assert mos["units"] == pytest.approx(5000 - 50000 / 15)
+    assert mos["profit"] == pytest.approx(25000.0)
+
+
+def test_build_result_includes_sweep():
+    result = build_result(_args(sweep=[0.0, 4000.0, 2000.0]))
+    assert len(result["sweep"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# format_chart
+# ---------------------------------------------------------------------------
+
+
+def test_format_chart_empty_rows_is_empty_string():
+    assert format_chart([]) == ""
+
+
+def test_format_chart_losses_left_profits_right():
+    rows = sweep_rows(0.0, 8000.0, 4000.0, 50000.0, 25.0, 10.0)
+    out = format_chart(rows)
+    loss_line, profit_line = out.splitlines()[3], out.splitlines()[5]
+    assert loss_line.index("#") < loss_line.index("|")
+    assert profit_line.index("#") > profit_line.index("|")
+
+
+def test_format_chart_all_zero_profit_draws_no_bars():
+    # A price equal to variable cost plus zero fixed costs makes every row 0.
+    rows = sweep_rows(0.0, 2.0, 1.0, 0.0, 10.0, 10.0)
+    assert "#" not in format_chart(rows)
+
+
+# ---------------------------------------------------------------------------
+# format_table / format_csv / format_json
+# ---------------------------------------------------------------------------
+
+
+def test_format_table_core_only():
+    out = format_table(build_result(_args()), 2, chart=False)
+    assert "Break-even units" in out
+    assert "Target profit" not in out
+    assert "Margin of safety" not in out
+
+
+def test_format_table_with_optional_sections():
+    result = build_result(_args(target_profit=20000.0, actual_units=5000.0))
+    out = format_table(result, 2, chart=False)
+    assert "Target profit" in out
+    assert "Margin of safety" in out
+
+
+def test_format_table_sweep_without_chart():
+    result = build_result(_args(sweep=[0.0, 4000.0, 2000.0]))
+    out = format_table(result, 2, chart=False)
+    assert "profit" in out
+    assert "Profit / loss chart" not in out
+
+
+def test_format_table_sweep_with_chart():
+    result = build_result(_args(sweep=[0.0, 4000.0, 2000.0]))
+    out = format_table(result, 2, chart=True)
+    assert "Profit / loss chart" in out
+
+
+def test_format_csv_core_only():
+    out = format_csv(build_result(_args()), 2)
+    assert out.splitlines()[0] == "metric,value"
+    assert "breakeven_units,3333.33" in out
+
+
+def test_format_csv_with_optional_sections():
+    result = build_result(
+        _args(target_profit=20000.0, actual_units=5000.0, sweep=[0.0, 2000.0, 1000.0])
+    )
+    out = format_csv(result, 2)
+    assert "target_profit_units," in out
+    assert "margin_of_safety_ratio," in out
+    assert "units,revenue,cost,profit" in out
+
+
+def test_format_json_core_only():
+    data = json.loads(format_json(build_result(_args())))
+    assert data["breakeven_units"] == pytest.approx(50000 / 15)
+    assert "sweep" not in data
+
+
+def test_format_json_sweep_rows_become_objects():
+    data = json.loads(format_json(build_result(_args(sweep=[0.0, 2000.0, 1000.0]))))
+    assert data["sweep"][0]["units"] == pytest.approx(0.0)
+    assert data["sweep"][0]["profit"] == pytest.approx(-50000.0)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_basic_report(capsys):
+    rc = main(["--fixed", "50000", "--price", "25", "--variable", "10"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Break-even units" in out
+
+
+def test_main_json_format(capsys):
+    rc = main(
+        ["--fixed", "50000", "--price", "25", "--variable", "10", "--format", "json"]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert json.loads(out)["contribution_margin"] == pytest.approx(15.0)
+
+
+def test_main_csv_format(capsys):
+    rc = main(
+        ["--fixed", "50000", "--price", "25", "--variable", "10", "--format", "csv"]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.startswith("metric,value")
+
+
+def test_main_sweep_with_chart(capsys):
+    rc = main(
+        [
+            "--fixed",
+            "50000",
+            "--price",
+            "25",
+            "--variable",
+            "10",
+            "--sweep",
+            "0",
+            "8000",
+            "2000",
+            "--chart",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Profit / loss chart" in out
+
+
+def test_main_invalid_margin_returns_2(capsys):
+    assert main(["--fixed", "50000", "--price", "10", "--variable", "10"]) == 2
+    assert "Error" in capsys.readouterr().err
+
+
+def test_main_chart_without_sweep_returns_2(capsys):
+    rc = main(["--fixed", "50000", "--price", "25", "--variable", "10", "--chart"])
+    assert rc == 2
+    assert "--chart requires --sweep" in capsys.readouterr().err
+
+
+def test_main_computation_error_returns_2(monkeypatch, capsys):
+    """Cover the ValueError branch in main when a core function raises."""
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("forced break-even error")
+
+    monkeypatch.setattr(break_even_module, "breakeven_units", raise_value_error)
+    assert main(["--fixed", "50000", "--price", "25", "--variable", "10"]) == 2
+    assert "forced break-even error" in capsys.readouterr().err

--- a/tests/test_discount_rate.py
+++ b/tests/test_discount_rate.py
@@ -1,0 +1,450 @@
+"""Tests for the discount rate utility."""
+
+import argparse
+import json
+
+import pytest
+
+import src.utils.discount_rate as discount_module
+from src.utils.discount_rate import (
+    build_result,
+    discount_factor,
+    format_json,
+    format_table,
+    main,
+    nominal_rate,
+    npv,
+    payback_period,
+    present_value,
+    real_npv,
+    real_rate,
+    resolve_rates,
+    validate,
+)
+
+# A conventional project: up-front cost then three years of inflows.
+FLOWS = [-1000.0, 300.0, 400.0, 500.0]
+
+
+def _args(**overrides):
+    """Build a namespace with valid defaults, overridden per test."""
+    base = dict(
+        nominal=0.08,
+        real=None,
+        inflation=None,
+        fv=None,
+        periods=1.0,
+        cashflows=None,
+        format="table",
+        precision=4,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# real_rate / nominal_rate
+# ---------------------------------------------------------------------------
+
+
+def test_real_rate_matches_fisher_equation():
+    assert real_rate(0.08, 0.03) == pytest.approx(1.08 / 1.03 - 1)
+
+
+def test_real_rate_with_zero_inflation_equals_nominal():
+    assert real_rate(0.08, 0.0) == pytest.approx(0.08)
+
+
+def test_real_rate_is_negative_when_inflation_outruns_nominal():
+    assert real_rate(0.02, 0.05) < 0
+
+
+def test_real_rate_invalid_nominal_raises():
+    with pytest.raises(ValueError, match="nominal must be > -1"):
+        real_rate(-1.0, 0.03)
+
+
+def test_real_rate_invalid_inflation_raises():
+    with pytest.raises(ValueError, match="inflation must be > -1"):
+        real_rate(0.08, -1.5)
+
+
+def test_nominal_rate_matches_fisher_equation():
+    assert nominal_rate(0.05, 0.03) == pytest.approx(1.05 * 1.03 - 1)
+
+
+def test_nominal_rate_inverts_real_rate():
+    assert nominal_rate(real_rate(0.08, 0.03), 0.03) == pytest.approx(0.08)
+
+
+def test_nominal_rate_invalid_real_raises():
+    with pytest.raises(ValueError, match="real must be > -1"):
+        nominal_rate(-1.0, 0.03)
+
+
+def test_nominal_rate_invalid_inflation_raises():
+    with pytest.raises(ValueError, match="inflation must be > -1"):
+        nominal_rate(0.05, -1.0)
+
+
+# ---------------------------------------------------------------------------
+# discount_factor / present_value
+# ---------------------------------------------------------------------------
+
+
+def test_discount_factor_matches_formula():
+    assert discount_factor(0.08, 1) == pytest.approx(1 / 1.08)
+
+
+def test_discount_factor_at_zero_periods_is_one():
+    assert discount_factor(0.08, 0) == pytest.approx(1.0)
+
+
+def test_discount_factor_with_zero_rate_is_one():
+    assert discount_factor(0.0, 10) == pytest.approx(1.0)
+
+
+def test_discount_factor_negative_periods_raises():
+    with pytest.raises(ValueError, match="periods must be >= 0"):
+        discount_factor(0.08, -1)
+
+
+def test_discount_factor_invalid_rate_raises():
+    with pytest.raises(ValueError, match="rate must be > -1"):
+        discount_factor(-1.0, 5)
+
+
+def test_present_value_matches_formula():
+    assert present_value(10000.0, 0.08, 5) == pytest.approx(10000 / 1.08**5)
+
+
+def test_present_value_at_zero_periods_is_face_value():
+    assert present_value(10000.0, 0.08, 0) == pytest.approx(10000.0)
+
+
+def test_present_value_invalid_rate_raises():
+    with pytest.raises(ValueError, match="rate must be > -1"):
+        present_value(10000.0, -2.0, 5)
+
+
+# ---------------------------------------------------------------------------
+# npv / real_npv
+# ---------------------------------------------------------------------------
+
+
+def test_npv_matches_manual_sum():
+    expected = sum(cf / 1.08**t for t, cf in enumerate(FLOWS))
+    assert npv(0.08, FLOWS) == pytest.approx(expected)
+
+
+def test_npv_at_zero_rate_is_the_plain_sum():
+    assert npv(0.0, FLOWS) == pytest.approx(sum(FLOWS))
+
+
+def test_npv_first_flow_is_undiscounted():
+    assert npv(0.5, [-100.0]) == pytest.approx(-100.0)
+
+
+def test_npv_falls_as_the_discount_rate_rises():
+    assert npv(0.15, FLOWS) < npv(0.05, FLOWS)
+
+
+def test_npv_empty_flows_raises():
+    with pytest.raises(ValueError, match="at least one value"):
+        npv(0.08, [])
+
+
+def test_npv_invalid_rate_raises():
+    with pytest.raises(ValueError, match="rate must be > -1"):
+        npv(-1.0, FLOWS)
+
+
+def test_real_npv_discounts_at_the_real_rate():
+    assert real_npv(0.08, 0.03, FLOWS) == pytest.approx(
+        npv(real_rate(0.08, 0.03), FLOWS)
+    )
+
+
+def test_real_npv_with_zero_inflation_matches_nominal_npv():
+    assert real_npv(0.08, 0.0, FLOWS) == pytest.approx(npv(0.08, FLOWS))
+
+
+def test_real_npv_invalid_inflation_raises():
+    with pytest.raises(ValueError, match="inflation must be > -1"):
+        real_npv(0.08, -1.0, FLOWS)
+
+
+# ---------------------------------------------------------------------------
+# payback_period
+# ---------------------------------------------------------------------------
+
+
+def test_payback_period_interpolates_within_the_crossing_period():
+    # Cumulative discounted flow is -379.28 after period 2 and +17.63 after 3.
+    assert payback_period(FLOWS, 0.08) == pytest.approx(2.9556, abs=1e-4)
+
+
+def test_payback_period_zero_when_first_flow_is_already_positive():
+    assert payback_period([100.0, -50.0], 0.08) == 0.0
+
+
+def test_payback_period_none_when_never_recovered():
+    assert payback_period([-1000.0, 100.0, 100.0], 0.08) is None
+
+
+def test_payback_period_empty_flows_raises():
+    with pytest.raises(ValueError, match="at least one value"):
+        payback_period([], 0.08)
+
+
+def test_payback_period_invalid_rate_raises():
+    with pytest.raises(ValueError, match="rate must be > -1"):
+        payback_period(FLOWS, -1.0)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_nominal_only():
+    assert validate(_args()) is None
+
+
+def test_validate_requires_a_rate():
+    result = validate(_args(nominal=None))
+    assert result is not None and "one of --nominal or --real" in result
+
+
+def test_validate_real_without_inflation():
+    result = validate(_args(nominal=None, real=0.05))
+    assert result is not None and "--real requires --inflation" in result
+
+
+def test_validate_real_with_inflation():
+    assert validate(_args(nominal=None, real=0.05, inflation=0.03)) is None
+
+
+def test_validate_nominal_at_or_below_negative_one():
+    result = validate(_args(nominal=-1.0))
+    assert result is not None and "--nominal must be > -1" in result
+
+
+def test_validate_real_at_or_below_negative_one():
+    result = validate(_args(nominal=None, real=-1.0, inflation=0.03))
+    assert result is not None and "--real must be > -1" in result
+
+
+def test_validate_inflation_at_or_below_negative_one():
+    result = validate(_args(inflation=-1.0))
+    assert result is not None and "--inflation must be > -1" in result
+
+
+def test_validate_negative_periods():
+    result = validate(_args(periods=-1.0))
+    assert result is not None and "--periods" in result
+
+
+def test_validate_negative_precision():
+    result = validate(_args(precision=-1))
+    assert result is not None and "--precision" in result
+
+
+def test_validate_empty_cashflows():
+    result = validate(_args(cashflows=[]))
+    assert result is not None and "--cashflows" in result
+
+
+# ---------------------------------------------------------------------------
+# resolve_rates
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rates_nominal_only_leaves_real_unset():
+    nominal, real, inflation = resolve_rates(_args())
+    assert nominal == pytest.approx(0.08)
+    assert real is None
+    assert inflation is None
+
+
+def test_resolve_rates_derives_real_from_nominal_and_inflation():
+    nominal, real, inflation = resolve_rates(_args(inflation=0.03))
+    assert nominal == pytest.approx(0.08)
+    assert real == pytest.approx(real_rate(0.08, 0.03))
+    assert inflation == pytest.approx(0.03)
+
+
+def test_resolve_rates_derives_nominal_from_real_and_inflation():
+    nominal, real, _inflation = resolve_rates(
+        _args(nominal=None, real=0.05, inflation=0.03)
+    )
+    assert nominal == pytest.approx(nominal_rate(0.05, 0.03))
+    assert real == pytest.approx(0.05)
+
+
+def test_resolve_rates_prefers_fisher_value_over_supplied_real():
+    """--nominal wins: the reported real rate is the Fisher-derived one."""
+    _nominal, real, _inflation = resolve_rates(
+        _args(nominal=0.08, real=0.99, inflation=0.03)
+    )
+    assert real == pytest.approx(real_rate(0.08, 0.03))
+
+
+# ---------------------------------------------------------------------------
+# build_result
+# ---------------------------------------------------------------------------
+
+
+def test_build_result_rates_only():
+    result = build_result(_args())
+    assert result["real_rate"] is None
+    assert result["discount_factor_real"] is None
+    assert "lump_sum" not in result
+    assert "npv" not in result
+
+
+def test_build_result_with_inflation():
+    result = build_result(_args(inflation=0.03))
+    assert result["real_rate"] == pytest.approx(real_rate(0.08, 0.03))
+    assert result["discount_factor_real"] == pytest.approx(
+        discount_factor(real_rate(0.08, 0.03), 1.0)
+    )
+
+
+def test_build_result_lump_sum_without_inflation():
+    result = build_result(_args(fv=10000.0, periods=5.0))
+    lump = result["lump_sum"]
+    assert lump["present_value_nominal"] == pytest.approx(10000 / 1.08**5)
+    assert lump["present_value_real"] is None
+
+
+def test_build_result_lump_sum_with_inflation():
+    result = build_result(_args(fv=10000.0, periods=5.0, inflation=0.03))
+    assert result["lump_sum"]["present_value_real"] == pytest.approx(
+        present_value(10000.0, real_rate(0.08, 0.03), 5.0)
+    )
+
+
+def test_build_result_npv_without_inflation():
+    result = build_result(_args(cashflows=FLOWS))
+    assert result["npv"]["nominal"] == pytest.approx(npv(0.08, FLOWS))
+    assert result["npv"]["real"] is None
+
+
+def test_build_result_npv_with_inflation():
+    result = build_result(_args(cashflows=FLOWS, inflation=0.03))
+    assert result["npv"]["real"] == pytest.approx(real_npv(0.08, 0.03, FLOWS))
+    assert result["npv"]["payback_period"] == pytest.approx(2.9556, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# format_table / format_json
+# ---------------------------------------------------------------------------
+
+
+def test_format_table_rates_only_omits_inflation_rows():
+    out = format_table(build_result(_args()), 4)
+    assert "Nominal rate" in out
+    assert "Inflation:" not in out
+    assert "Discount factor (real)" not in out
+
+
+def test_format_table_with_inflation():
+    out = format_table(build_result(_args(inflation=0.03)), 4)
+    assert "Real rate (Fisher)" in out
+    assert "4.8544%" in out
+
+
+def test_format_table_lump_sum_section():
+    out = format_table(build_result(_args(fv=10000.0, periods=5.0)), 4)
+    assert "Present value (nominal)" in out
+    assert "Present value (real)" not in out
+
+
+def test_format_table_lump_sum_real_row_with_inflation():
+    out = format_table(build_result(_args(fv=10000.0, periods=5.0, inflation=0.03)), 4)
+    assert "Present value (real)" in out
+
+
+def test_format_table_npv_section():
+    out = format_table(build_result(_args(cashflows=FLOWS, inflation=0.03)), 4)
+    assert "NPV (nominal)" in out
+    assert "NPV (real)" in out
+    assert "purchasing power" in out
+
+
+def test_format_table_npv_without_inflation_omits_real_row():
+    out = format_table(build_result(_args(cashflows=FLOWS)), 4)
+    assert "NPV (real)" not in out
+
+
+def test_format_table_reports_never_when_payback_never_arrives():
+    out = format_table(build_result(_args(cashflows=[-1000.0, 100.0])), 4)
+    assert "never" in out
+
+
+def test_format_json_round_trips():
+    data = json.loads(format_json(build_result(_args(inflation=0.03))))
+    assert data["real_rate"] == pytest.approx(real_rate(0.08, 0.03))
+    assert data["inflation"] == pytest.approx(0.03)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_rate_report(capsys):
+    rc = main(["--nominal", "0.08", "--inflation", "0.03"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "4.8544%" in out
+
+
+def test_main_real_rate_input(capsys):
+    rc = main(["--real", "0.05", "--inflation", "0.03"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "8.1500%" in out
+
+
+def test_main_lump_sum(capsys):
+    rc = main(["--nominal", "0.08", "--fv", "10000", "--periods", "5"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "6,805.8320" in out
+
+
+def test_main_npv(capsys):
+    rc = main(["--nominal", "0.08", "--cashflows", "-1000", "300", "400", "500"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "NPV (nominal)" in out
+
+
+def test_main_json_format(capsys):
+    rc = main(["--nominal", "0.08", "--inflation", "0.03", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert json.loads(out)["nominal_rate"] == pytest.approx(0.08)
+
+
+def test_main_missing_rate_returns_2(capsys):
+    assert main([]) == 2
+    assert "Error" in capsys.readouterr().err
+
+
+def test_main_real_without_inflation_returns_2(capsys):
+    assert main(["--real", "0.05"]) == 2
+    assert "--real requires --inflation" in capsys.readouterr().err
+
+
+def test_main_computation_error_returns_2(monkeypatch, capsys):
+    """Cover the ValueError branch in main when a core function raises."""
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("forced discount error")
+
+    monkeypatch.setattr(discount_module, "discount_factor", raise_value_error)
+    assert main(["--nominal", "0.08"]) == 2
+    assert "forced discount error" in capsys.readouterr().err

--- a/tests/test_information_entropy.py
+++ b/tests/test_information_entropy.py
@@ -1,0 +1,527 @@
+"""Tests for the information entropy utility."""
+
+import argparse
+import json
+import math
+
+import pytest
+
+import src.utils.information_entropy as entropy_module
+from src.utils.information_entropy import (
+    base_value,
+    build_result,
+    conditional_entropy,
+    cross_entropy,
+    format_json,
+    format_table,
+    joint_entropy,
+    kl_divergence,
+    main,
+    marginals,
+    max_entropy,
+    mutual_information,
+    normalize,
+    normalize_joint,
+    parse_values,
+    shannon_entropy,
+    validate,
+)
+
+# A joint table for two perfectly correlated binary variables.
+PERFECT = [[0.5, 0.0], [0.0, 0.5]]
+# A joint table for two independent binary variables.
+INDEPENDENT = [[0.25, 0.25], [0.25, 0.25]]
+
+
+def _args(**overrides):
+    """Build a namespace with valid defaults, overridden per test."""
+    base = dict(
+        probs="0.5,0.5",
+        measure="entropy",
+        base="2",
+        probs_p=None,
+        probs_q=None,
+        joint=None,
+        format="table",
+        precision=4,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# normalize
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_scales_counts_to_probabilities():
+    assert normalize([3, 1]) == pytest.approx([0.75, 0.25])
+
+
+def test_normalize_leaves_a_distribution_unchanged():
+    assert normalize([0.2, 0.8]) == pytest.approx([0.2, 0.8])
+
+
+def test_normalize_empty_raises():
+    with pytest.raises(ValueError, match="at least one outcome"):
+        normalize([])
+
+
+def test_normalize_negative_raises():
+    with pytest.raises(ValueError, match="must be >= 0"):
+        normalize([0.5, -0.1])
+
+
+def test_normalize_zero_total_raises():
+    with pytest.raises(ValueError, match="positive total"):
+        normalize([0.0, 0.0])
+
+
+# ---------------------------------------------------------------------------
+# shannon_entropy / max_entropy
+# ---------------------------------------------------------------------------
+
+
+def test_shannon_entropy_fair_coin_is_one_bit():
+    assert shannon_entropy([0.5, 0.5]) == pytest.approx(1.0)
+
+
+def test_shannon_entropy_fair_die_is_log2_six():
+    assert shannon_entropy([1] * 6) == pytest.approx(math.log2(6))
+
+
+def test_shannon_entropy_certain_outcome_is_zero():
+    assert shannon_entropy([1.0, 0.0]) == pytest.approx(0.0)
+
+
+def test_shannon_entropy_in_nats():
+    assert shannon_entropy([0.5, 0.5], math.e) == pytest.approx(math.log(2))
+
+
+def test_shannon_entropy_in_hartleys():
+    assert shannon_entropy([0.1] * 10, 10.0) == pytest.approx(1.0)
+
+
+def test_shannon_entropy_accepts_unnormalized_counts():
+    assert shannon_entropy([2, 2]) == pytest.approx(1.0)
+
+
+def test_shannon_entropy_invalid_base_raises():
+    with pytest.raises(ValueError, match="base must be > 1"):
+        shannon_entropy([0.5, 0.5], 1.0)
+
+
+def test_max_entropy_matches_log():
+    assert max_entropy(8) == pytest.approx(3.0)
+
+
+def test_max_entropy_single_outcome_is_zero():
+    assert max_entropy(1) == pytest.approx(0.0)
+
+
+def test_max_entropy_zero_outcomes_raises():
+    with pytest.raises(ValueError, match="outcomes must be >= 1"):
+        max_entropy(0)
+
+
+def test_max_entropy_invalid_base_raises():
+    with pytest.raises(ValueError, match="base must be > 1"):
+        max_entropy(4, 0.5)
+
+
+def test_entropy_never_exceeds_max_entropy():
+    probs = [0.5, 0.3, 0.15, 0.05]
+    assert shannon_entropy(probs) <= max_entropy(len(probs))
+
+
+# ---------------------------------------------------------------------------
+# kl_divergence / cross_entropy
+# ---------------------------------------------------------------------------
+
+
+def test_kl_divergence_identical_distributions_is_zero():
+    assert kl_divergence([0.7, 0.3], [0.7, 0.3]) == pytest.approx(0.0)
+
+
+def test_kl_divergence_known_value():
+    expected = 0.7 * math.log2(0.7 / 0.5) + 0.3 * math.log2(0.3 / 0.5)
+    assert kl_divergence([0.7, 0.3], [0.5, 0.5]) == pytest.approx(expected)
+
+
+def test_kl_divergence_is_asymmetric():
+    forward = kl_divergence([0.7, 0.3], [0.5, 0.5])
+    reverse = kl_divergence([0.5, 0.5], [0.7, 0.3])
+    assert forward != pytest.approx(reverse)
+
+
+def test_kl_divergence_skips_zero_probability_in_p():
+    assert kl_divergence([1.0, 0.0], [0.5, 0.5]) == pytest.approx(1.0)
+
+
+def test_kl_divergence_zero_in_q_raises():
+    with pytest.raises(ValueError, match="KL divergence is infinite"):
+        kl_divergence([0.5, 0.5], [1.0, 0.0])
+
+
+def test_kl_divergence_length_mismatch_raises():
+    with pytest.raises(ValueError, match="same length"):
+        kl_divergence([0.5, 0.5], [1.0])
+
+
+def test_kl_divergence_invalid_base_raises():
+    with pytest.raises(ValueError, match="base must be > 1"):
+        kl_divergence([0.5, 0.5], [0.5, 0.5], 1.0)
+
+
+def test_cross_entropy_equals_entropy_plus_kl():
+    p, q = [0.7, 0.3], [0.5, 0.5]
+    assert cross_entropy(p, q) == pytest.approx(
+        shannon_entropy(p) + kl_divergence(p, q)
+    )
+
+
+def test_cross_entropy_with_identical_distributions_is_entropy():
+    assert cross_entropy([0.7, 0.3], [0.7, 0.3]) == pytest.approx(
+        shannon_entropy([0.7, 0.3])
+    )
+
+
+def test_cross_entropy_skips_zero_probability_in_p():
+    assert cross_entropy([1.0, 0.0], [0.5, 0.5]) == pytest.approx(1.0)
+
+
+def test_cross_entropy_zero_in_q_raises():
+    with pytest.raises(ValueError, match="cross-entropy is infinite"):
+        cross_entropy([0.5, 0.5], [1.0, 0.0])
+
+
+def test_cross_entropy_length_mismatch_raises():
+    with pytest.raises(ValueError, match="same length"):
+        cross_entropy([0.5, 0.5], [1.0])
+
+
+def test_cross_entropy_invalid_base_raises():
+    with pytest.raises(ValueError, match="base must be > 1"):
+        cross_entropy([0.5, 0.5], [0.5, 0.5], 1.0)
+
+
+# ---------------------------------------------------------------------------
+# normalize_joint / marginals
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_joint_scales_counts():
+    assert normalize_joint([[1, 1], [1, 1]]) == [[0.25, 0.25], [0.25, 0.25]]
+
+
+def test_normalize_joint_empty_raises():
+    with pytest.raises(ValueError, match="at least one row"):
+        normalize_joint([])
+
+
+def test_normalize_joint_empty_row_raises():
+    with pytest.raises(ValueError, match="at least one column"):
+        normalize_joint([[]])
+
+
+def test_normalize_joint_ragged_raises():
+    with pytest.raises(ValueError, match="same length"):
+        normalize_joint([[0.5, 0.5], [1.0]])
+
+
+def test_marginals_of_independent_table():
+    px, py = marginals(INDEPENDENT)
+    assert px == pytest.approx([0.5, 0.5])
+    assert py == pytest.approx([0.5, 0.5])
+
+
+def test_marginals_of_asymmetric_table():
+    px, py = marginals([[0.4, 0.2], [0.1, 0.3]])
+    assert px == pytest.approx([0.6, 0.4])
+    assert py == pytest.approx([0.5, 0.5])
+
+
+# ---------------------------------------------------------------------------
+# joint_entropy / mutual_information / conditional_entropy
+# ---------------------------------------------------------------------------
+
+
+def test_joint_entropy_of_independent_table_is_two_bits():
+    assert joint_entropy(INDEPENDENT) == pytest.approx(2.0)
+
+
+def test_mutual_information_of_independent_table_is_zero():
+    assert mutual_information(INDEPENDENT) == pytest.approx(0.0)
+
+
+def test_mutual_information_of_perfect_dependence_is_one_bit():
+    assert mutual_information(PERFECT) == pytest.approx(1.0)
+
+
+def test_mutual_information_is_never_negative():
+    assert mutual_information([[0.3, 0.2], [0.2, 0.3]]) >= 0.0
+
+
+def test_conditional_entropy_of_independent_table_is_marginal_entropy():
+    assert conditional_entropy(INDEPENDENT) == pytest.approx(1.0)
+
+
+def test_conditional_entropy_of_perfect_dependence_is_zero():
+    assert conditional_entropy(PERFECT) == pytest.approx(0.0)
+
+
+def test_chain_rule_holds():
+    joint = [[0.4, 0.2], [0.1, 0.3]]
+    px, _py = marginals(joint)
+    assert joint_entropy(joint) == pytest.approx(
+        shannon_entropy(px) + conditional_entropy(joint)
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_values / base_value
+# ---------------------------------------------------------------------------
+
+
+def test_parse_values_comma_separated():
+    assert parse_values("0.7,0.3") == [0.7, 0.3]
+
+
+def test_parse_values_whitespace_separated():
+    assert parse_values("3 1 1") == [3.0, 1.0, 1.0]
+
+
+def test_parse_values_empty_raises():
+    with pytest.raises(ValueError, match="no numeric values"):
+        parse_values("  ")
+
+
+def test_parse_values_non_numeric_raises():
+    with pytest.raises(ValueError, match="could not parse"):
+        parse_values("0.5,abc")
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"), [("2", 2.0), ("10", 10.0), ("e", math.e)]
+)
+def test_base_value_choices(text, expected):
+    assert base_value(text) == pytest.approx(expected)
+
+
+def test_base_value_unsupported_raises():
+    with pytest.raises(ValueError, match="base must be one of"):
+        base_value("7")
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_entropy_valid():
+    assert validate(_args()) is None
+
+
+def test_validate_negative_precision():
+    result = validate(_args(precision=-1))
+    assert result is not None and "--precision" in result
+
+
+def test_validate_entropy_missing_probs():
+    result = validate(_args(probs=None))
+    assert result is not None and "--probs is required" in result
+
+
+def test_validate_kl_missing_vectors():
+    result = validate(_args(measure="kl", probs_p="0.5,0.5"))
+    assert result is not None and "--probs-p and --probs-q" in result
+
+
+def test_validate_kl_valid():
+    assert validate(_args(measure="kl", probs_p="0.7,0.3", probs_q="0.5,0.5")) is None
+
+
+def test_validate_mi_missing_joint():
+    result = validate(_args(measure="mi"))
+    assert result is not None and "--joint is required" in result
+
+
+def test_validate_conditional_valid():
+    assert validate(_args(measure="conditional", joint=["0.5,0", "0,0.5"])) is None
+
+
+# ---------------------------------------------------------------------------
+# build_result
+# ---------------------------------------------------------------------------
+
+
+def test_build_result_entropy_keys():
+    result = build_result(_args(probs="1,1,1,1"))
+    assert result["outcomes"] == 4
+    assert result["entropy"] == pytest.approx(2.0)
+    assert result["efficiency"] == pytest.approx(1.0)
+
+
+def test_build_result_entropy_single_outcome_efficiency_is_one():
+    result = build_result(_args(probs="1"))
+    assert result["max_entropy"] == pytest.approx(0.0)
+    assert result["efficiency"] == pytest.approx(1.0)
+
+
+def test_build_result_entropy_respects_base():
+    result = build_result(_args(probs="0.5,0.5", base="e"))
+    assert result["unit"] == "nats"
+    assert result["entropy"] == pytest.approx(math.log(2))
+
+
+def test_build_result_kl_keys():
+    result = build_result(_args(measure="kl", probs_p="0.7,0.3", probs_q="0.5,0.5"))
+    assert result["kl_divergence"] == pytest.approx(
+        kl_divergence([0.7, 0.3], [0.5, 0.5])
+    )
+    assert result["kl_reverse"] != pytest.approx(result["kl_divergence"])
+
+
+def test_build_result_cross_keys():
+    result = build_result(_args(measure="cross", probs_p="1,0", probs_q="0.9,0.1"))
+    assert result["cross_entropy"] == pytest.approx(-math.log2(0.9))
+
+
+def test_build_result_reports_infinite_reverse_kl_as_none():
+    """A zero in P makes D(Q||P) infinite; the requested measure still runs."""
+    result = build_result(_args(measure="cross", probs_p="1,0", probs_q="0.9,0.1"))
+    assert result["kl_reverse"] is None
+
+
+def test_kl_or_none_returns_value_when_finite():
+    assert entropy_module._kl_or_none([0.7, 0.3], [0.5, 0.5], 2.0) == pytest.approx(
+        kl_divergence([0.7, 0.3], [0.5, 0.5])
+    )
+
+
+def test_kl_or_none_reraises_unrelated_value_error():
+    with pytest.raises(ValueError, match="same length"):
+        entropy_module._kl_or_none([0.5, 0.5], [1.0], 2.0)
+
+
+def test_build_result_mi_keys():
+    result = build_result(_args(measure="mi", joint=["0.25,0.25", "0.25,0.25"]))
+    assert result["mutual_information"] == pytest.approx(0.0)
+    assert result["joint_entropy"] == pytest.approx(2.0)
+
+
+def test_build_result_conditional_both_directions():
+    result = build_result(_args(measure="conditional", joint=["0.4,0.2", "0.1,0.3"]))
+    assert result["conditional_entropy_y_given_x"] == pytest.approx(
+        conditional_entropy([[0.4, 0.2], [0.1, 0.3]])
+    )
+    assert result["conditional_entropy_x_given_y"] == pytest.approx(
+        conditional_entropy([[0.4, 0.1], [0.2, 0.3]])
+    )
+
+
+# ---------------------------------------------------------------------------
+# format_table / format_json
+# ---------------------------------------------------------------------------
+
+
+def test_format_table_entropy():
+    out = format_table(build_result(_args()), 4)
+    assert "Shannon entropy" in out
+    assert "Efficiency" in out
+
+
+def test_format_table_kl():
+    result = build_result(_args(measure="kl", probs_p="0.7,0.3", probs_q="0.5,0.5"))
+    out = format_table(result, 4)
+    assert "KL divergence" in out
+    assert "asymmetric" in out
+
+
+def test_format_table_shows_infinite_reverse_kl():
+    result = build_result(_args(measure="kl", probs_p="1,0", probs_q="0.9,0.1"))
+    assert "infinite" in format_table(result, 4)
+
+
+def test_format_table_cross_uses_cross_title():
+    result = build_result(_args(measure="cross", probs_p="0.7,0.3", probs_q="0.5,0.5"))
+    out = format_table(result, 4)
+    assert out.startswith("Cross-entropy")
+
+
+def test_format_table_mi():
+    result = build_result(_args(measure="mi", joint=["0.25,0.25", "0.25,0.25"]))
+    out = format_table(result, 4)
+    assert out.startswith("Mutual information")
+    assert "I(X;Y)" in out
+
+
+def test_format_table_conditional_uses_conditional_title():
+    result = build_result(_args(measure="conditional", joint=["0.5,0", "0,0.5"]))
+    assert format_table(result, 4).startswith("Conditional entropy")
+
+
+def test_format_json_round_trips():
+    data = json.loads(format_json(build_result(_args())))
+    assert data["measure"] == "entropy"
+    assert data["entropy"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_entropy_report(capsys):
+    rc = main(["--probs", "0.167,0.167,0.167,0.167,0.167,0.167"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "2.5850" in out
+
+
+def test_main_kl_report(capsys):
+    rc = main(["--measure", "kl", "--probs-p", "0.7,0.3", "--probs-q", "0.5,0.5"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0.1187" in out
+
+
+def test_main_mi_report(capsys):
+    rc = main(["--measure", "mi", "--joint", "0.25,0.25", "--joint", "0.25,0.25"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Mutual information" in out
+
+
+def test_main_json_format(capsys):
+    rc = main(["--probs", "0.5,0.5", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert json.loads(out)["entropy"] == pytest.approx(1.0)
+
+
+def test_main_missing_probs_returns_2(capsys):
+    assert main([]) == 2
+    assert "Error" in capsys.readouterr().err
+
+
+def test_main_infinite_kl_returns_2(capsys):
+    rc = main(["--measure", "kl", "--probs-p", "0.5,0.5", "--probs-q", "1,0"])
+    assert rc == 2
+    assert "infinite" in capsys.readouterr().err
+
+
+def test_main_unparseable_values_returns_2(capsys):
+    assert main(["--probs", "0.5,abc"]) == 2
+    assert "could not parse" in capsys.readouterr().err
+
+
+def test_main_computation_error_returns_2(monkeypatch, capsys):
+    """Cover the ValueError branch in main when a core function raises."""
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("forced entropy error")
+
+    monkeypatch.setattr(entropy_module, "shannon_entropy", raise_value_error)
+    assert main(["--probs", "0.5,0.5"]) == 2
+    assert "forced entropy error" in capsys.readouterr().err

--- a/tests/test_weibull_distribution.py
+++ b/tests/test_weibull_distribution.py
@@ -1,0 +1,531 @@
+"""Tests for the Weibull distribution utility."""
+
+import argparse
+import json
+import math
+
+import pytest
+
+import src.utils.weibull_distribution as weibull_module
+from src.utils.weibull_distribution import (
+    build_result,
+    failure_mode,
+    format_json,
+    format_table,
+    main,
+    table_rows,
+    validate,
+    weibull_cdf,
+    weibull_hazard,
+    weibull_mean,
+    weibull_median,
+    weibull_pdf,
+    weibull_quantile,
+    weibull_survival,
+    weibull_variance,
+)
+
+
+def _args(**overrides):
+    """Build a namespace with valid defaults, overridden per test."""
+    base = dict(
+        x=500.0,
+        k=2.0,
+        lam=1000.0,
+        quantile=None,
+        survival=False,
+        table=None,
+        format="table",
+        precision=4,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# weibull_pdf
+# ---------------------------------------------------------------------------
+
+
+def test_weibull_pdf_matches_formula():
+    expected = (2 / 1000) * (0.5**1) * math.exp(-0.25)
+    assert weibull_pdf(500.0, 2.0, 1000.0) == pytest.approx(expected)
+
+
+def test_weibull_pdf_reduces_to_exponential_when_k_is_one():
+    assert weibull_pdf(500.0, 1.0, 1000.0) == pytest.approx(math.exp(-0.5) / 1000)
+
+
+def test_weibull_pdf_negative_x_is_zero():
+    assert weibull_pdf(-1.0, 2.0, 1000.0) == 0.0
+
+
+def test_weibull_pdf_at_origin_wear_out_is_zero():
+    assert weibull_pdf(0.0, 2.0, 1000.0) == 0.0
+
+
+def test_weibull_pdf_at_origin_exponential_is_rate():
+    assert weibull_pdf(0.0, 1.0, 1000.0) == pytest.approx(0.001)
+
+
+def test_weibull_pdf_at_origin_infant_mortality_is_infinite():
+    assert math.isinf(weibull_pdf(0.0, 0.5, 1000.0))
+
+
+def test_weibull_pdf_invalid_shape_raises():
+    with pytest.raises(ValueError, match="k must be > 0"):
+        weibull_pdf(500.0, 0.0, 1000.0)
+
+
+def test_weibull_pdf_invalid_scale_raises():
+    with pytest.raises(ValueError, match="lambda must be > 0"):
+        weibull_pdf(500.0, 2.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# weibull_cdf / weibull_survival
+# ---------------------------------------------------------------------------
+
+
+def test_weibull_cdf_matches_formula():
+    assert weibull_cdf(500.0, 2.0, 1000.0) == pytest.approx(1 - math.exp(-0.25))
+
+
+def test_weibull_cdf_at_scale_is_one_minus_exp_neg_one():
+    assert weibull_cdf(1000.0, 2.0, 1000.0) == pytest.approx(1 - math.exp(-1))
+
+
+def test_weibull_cdf_at_or_below_zero_is_zero():
+    assert weibull_cdf(0.0, 2.0, 1000.0) == 0.0
+    assert weibull_cdf(-5.0, 2.0, 1000.0) == 0.0
+
+
+def test_weibull_cdf_invalid_shape_raises():
+    with pytest.raises(ValueError, match="k must be > 0"):
+        weibull_cdf(500.0, -1.0, 1000.0)
+
+
+def test_weibull_survival_matches_formula():
+    assert weibull_survival(500.0, 2.0, 1000.0) == pytest.approx(math.exp(-0.25))
+
+
+def test_weibull_survival_at_or_below_zero_is_one():
+    assert weibull_survival(0.0, 2.0, 1000.0) == 1.0
+    assert weibull_survival(-5.0, 2.0, 1000.0) == 1.0
+
+
+def test_weibull_survival_complements_cdf():
+    assert weibull_survival(750.0, 1.5, 900.0) + weibull_cdf(
+        750.0, 1.5, 900.0
+    ) == pytest.approx(1.0)
+
+
+def test_weibull_survival_invalid_scale_raises():
+    with pytest.raises(ValueError, match="lambda must be > 0"):
+        weibull_survival(500.0, 2.0, -3.0)
+
+
+# ---------------------------------------------------------------------------
+# weibull_hazard
+# ---------------------------------------------------------------------------
+
+
+def test_weibull_hazard_equals_pdf_over_survival():
+    x, k, lam = 500.0, 2.0, 1000.0
+    assert weibull_hazard(x, k, lam) == pytest.approx(
+        weibull_pdf(x, k, lam) / weibull_survival(x, k, lam)
+    )
+
+
+def test_weibull_hazard_is_constant_when_k_is_one():
+    assert weibull_hazard(100.0, 1.0, 1000.0) == pytest.approx(0.001)
+    assert weibull_hazard(9000.0, 1.0, 1000.0) == pytest.approx(0.001)
+
+
+def test_weibull_hazard_increases_when_k_above_one():
+    assert weibull_hazard(200.0, 2.5, 1000.0) < weibull_hazard(800.0, 2.5, 1000.0)
+
+
+def test_weibull_hazard_decreases_when_k_below_one():
+    assert weibull_hazard(200.0, 0.5, 1000.0) > weibull_hazard(800.0, 0.5, 1000.0)
+
+
+def test_weibull_hazard_stays_finite_in_the_far_tail():
+    """The closed form avoids the 0/0 that f(x)/S(x) hits far out in the tail."""
+    assert math.isfinite(weibull_hazard(20000.0, 3.0, 1000.0))
+
+
+def test_weibull_hazard_negative_x_is_zero():
+    assert weibull_hazard(-1.0, 2.0, 1000.0) == 0.0
+
+
+def test_weibull_hazard_at_origin_wear_out_is_zero():
+    assert weibull_hazard(0.0, 2.0, 1000.0) == 0.0
+
+
+def test_weibull_hazard_at_origin_exponential_is_rate():
+    assert weibull_hazard(0.0, 1.0, 1000.0) == pytest.approx(0.001)
+
+
+def test_weibull_hazard_at_origin_infant_mortality_is_infinite():
+    assert math.isinf(weibull_hazard(0.0, 0.5, 1000.0))
+
+
+def test_weibull_hazard_invalid_shape_raises():
+    with pytest.raises(ValueError, match="k must be > 0"):
+        weibull_hazard(500.0, 0.0, 1000.0)
+
+
+# ---------------------------------------------------------------------------
+# weibull_quantile
+# ---------------------------------------------------------------------------
+
+
+def test_weibull_quantile_matches_formula():
+    assert weibull_quantile(0.05, 1.5, 800.0) == pytest.approx(
+        800 * (-math.log(0.95)) ** (1 / 1.5)
+    )
+
+
+def test_weibull_quantile_inverts_cdf():
+    x = weibull_quantile(0.3, 2.0, 1000.0)
+    assert weibull_cdf(x, 2.0, 1000.0) == pytest.approx(0.3)
+
+
+def test_weibull_quantile_at_zero_is_zero():
+    assert weibull_quantile(0.0, 2.0, 1000.0) == 0.0
+
+
+def test_weibull_quantile_at_one_minus_exp_neg_one_is_scale():
+    assert weibull_quantile(1 - math.exp(-1), 2.0, 1000.0) == pytest.approx(1000.0)
+
+
+@pytest.mark.parametrize("p", [-0.1, 1.0, 1.5])
+def test_weibull_quantile_out_of_range_raises(p):
+    with pytest.raises(ValueError, match=r"p must be in \[0, 1\)"):
+        weibull_quantile(p, 2.0, 1000.0)
+
+
+def test_weibull_quantile_invalid_shape_raises():
+    with pytest.raises(ValueError, match="k must be > 0"):
+        weibull_quantile(0.5, 0.0, 1000.0)
+
+
+# ---------------------------------------------------------------------------
+# weibull_mean / weibull_variance / weibull_median
+# ---------------------------------------------------------------------------
+
+
+def test_weibull_mean_matches_gamma_formula():
+    assert weibull_mean(2.0, 1000.0) == pytest.approx(1000 * math.gamma(1.5))
+
+
+def test_weibull_mean_reduces_to_scale_when_k_is_one():
+    assert weibull_mean(1.0, 1000.0) == pytest.approx(1000.0)
+
+
+def test_weibull_mean_invalid_scale_raises():
+    with pytest.raises(ValueError, match="lambda must be > 0"):
+        weibull_mean(2.0, 0.0)
+
+
+def test_weibull_variance_matches_gamma_formula():
+    expected = 1000**2 * (math.gamma(2.0) - math.gamma(1.5) ** 2)
+    assert weibull_variance(2.0, 1000.0) == pytest.approx(expected)
+
+
+def test_weibull_variance_of_exponential_is_scale_squared():
+    assert weibull_variance(1.0, 1000.0) == pytest.approx(1000**2)
+
+
+def test_weibull_variance_never_negative_for_large_shape():
+    assert weibull_variance(200.0, 1000.0) >= 0.0
+
+
+def test_weibull_variance_invalid_shape_raises():
+    with pytest.raises(ValueError, match="k must be > 0"):
+        weibull_variance(-1.0, 1000.0)
+
+
+def test_weibull_median_matches_formula():
+    assert weibull_median(2.0, 1000.0) == pytest.approx(1000 * math.log(2) ** 0.5)
+
+
+def test_weibull_median_has_half_the_mass_below_it():
+    assert weibull_cdf(weibull_median(1.7, 640.0), 1.7, 640.0) == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# failure_mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("k", "fragment"),
+    [(0.5, "infant mortality"), (1.0, "constant hazard"), (3.0, "wear-out")],
+)
+def test_failure_mode_by_shape(k, fragment):
+    assert fragment in failure_mode(k)
+
+
+def test_failure_mode_invalid_shape_raises():
+    with pytest.raises(ValueError, match="k must be > 0"):
+        failure_mode(0.0)
+
+
+# ---------------------------------------------------------------------------
+# table_rows
+# ---------------------------------------------------------------------------
+
+
+def test_table_rows_row_count_and_endpoints():
+    rows = table_rows(0.0, 2000.0, 500.0, 2.5, 1200.0)
+    assert len(rows) == 5
+    assert rows[0][0] == pytest.approx(0.0)
+    assert rows[-1][0] == pytest.approx(2000.0)
+
+
+def test_table_rows_cdf_and_survival_complement():
+    for _x, _pdf, cdf, surv, _hazard in table_rows(0.0, 1000.0, 250.0, 2.0, 800.0):
+        assert cdf + surv == pytest.approx(1.0)
+
+
+def test_table_rows_cdf_is_monotone():
+    cdfs = [row[2] for row in table_rows(0.0, 2000.0, 200.0, 2.0, 1000.0)]
+    assert cdfs == sorted(cdfs)
+
+
+def test_table_rows_single_row_when_min_equals_max():
+    assert len(table_rows(100.0, 100.0, 50.0, 2.0, 1000.0)) == 1
+
+
+def test_table_rows_non_positive_step_raises():
+    with pytest.raises(ValueError, match="step must be > 0"):
+        table_rows(0.0, 100.0, 0.0, 2.0, 1000.0)
+
+
+def test_table_rows_negative_min_raises():
+    with pytest.raises(ValueError, match="min_x must be >= 0"):
+        table_rows(-1.0, 100.0, 10.0, 2.0, 1000.0)
+
+
+def test_table_rows_max_below_min_raises():
+    with pytest.raises(ValueError, match="max_x must be >= min_x"):
+        table_rows(100.0, 50.0, 10.0, 2.0, 1000.0)
+
+
+def test_table_rows_invalid_shape_raises():
+    with pytest.raises(ValueError, match="k must be > 0"):
+        table_rows(0.0, 100.0, 10.0, 0.0, 1000.0)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_point_valid():
+    assert validate(_args()) is None
+
+
+def test_validate_non_positive_shape():
+    result = validate(_args(k=0.0))
+    assert result is not None and "-k must be > 0" in result
+
+
+def test_validate_non_positive_scale():
+    result = validate(_args(lam=0.0))
+    assert result is not None and "--lambda must be > 0" in result
+
+
+def test_validate_negative_precision():
+    result = validate(_args(precision=-1))
+    assert result is not None and "--precision" in result
+
+
+def test_validate_table_valid():
+    assert validate(_args(x=None, table=[0.0, 2000.0, 200.0])) is None
+
+
+def test_validate_table_negative_min():
+    result = validate(_args(table=[-1.0, 100.0, 10.0]))
+    assert result is not None and "--table MIN" in result
+
+
+def test_validate_table_max_below_min():
+    result = validate(_args(table=[100.0, 50.0, 10.0]))
+    assert result is not None and "--table MAX" in result
+
+
+def test_validate_table_non_positive_step():
+    result = validate(_args(table=[0.0, 100.0, 0.0]))
+    assert result is not None and "--table STEP" in result
+
+
+def test_validate_quantile_valid():
+    assert validate(_args(x=None, quantile=0.05)) is None
+
+
+def test_validate_quantile_out_of_range():
+    result = validate(_args(quantile=1.0))
+    assert result is not None and "--quantile must be in" in result
+
+
+def test_validate_missing_x():
+    result = validate(_args(x=None))
+    assert result is not None and "-x is required" in result
+
+
+def test_validate_negative_x():
+    result = validate(_args(x=-1.0))
+    assert result is not None and "-x must be >= 0" in result
+
+
+# ---------------------------------------------------------------------------
+# build_result
+# ---------------------------------------------------------------------------
+
+
+def test_build_result_point_section():
+    result = build_result(_args())
+    assert result["point"]["survival"] == pytest.approx(math.exp(-0.25))
+    assert "table" not in result
+    assert "quantile" not in result
+
+
+def test_build_result_quantile_section():
+    result = build_result(_args(x=None, quantile=0.05))
+    assert result["quantile"]["x"] == pytest.approx(weibull_quantile(0.05, 2.0, 1000.0))
+    assert "point" not in result
+
+
+def test_build_result_table_section():
+    result = build_result(_args(x=None, table=[0.0, 1000.0, 500.0]))
+    assert len(result["table"]) == 3
+    assert "point" not in result
+
+
+def test_build_result_includes_moments_and_mode():
+    result = build_result(_args())
+    assert result["mean"] == pytest.approx(weibull_mean(2.0, 1000.0))
+    assert "wear-out" in str(result["failure_mode"])
+
+
+# ---------------------------------------------------------------------------
+# format_table / format_json
+# ---------------------------------------------------------------------------
+
+
+def test_format_table_point_leads_with_cdf_by_default():
+    out = format_table(build_result(_args()), 4, survival=False)
+    lines = [line for line in out.splitlines() if "(x" in line]
+    assert lines[1].strip().startswith("F(x")
+
+
+def test_format_table_point_leads_with_survival_when_requested():
+    out = format_table(build_result(_args()), 4, survival=True)
+    lines = [line for line in out.splitlines() if "(x" in line]
+    assert lines[1].strip().startswith("S(x")
+
+
+def test_format_table_reports_failure_mode_and_moments():
+    out = format_table(build_result(_args(k=0.7)), 4, survival=False)
+    assert "infant mortality" in out
+    assert "variance:" in out
+
+
+def test_format_table_quantile_section():
+    out = format_table(build_result(_args(x=None, quantile=0.05)), 4, survival=False)
+    assert "x at p:" in out
+
+
+def test_format_table_table_section():
+    out = format_table(
+        build_result(_args(x=None, table=[0.0, 1000.0, 500.0])), 4, survival=False
+    )
+    assert "h(x)" in out
+    assert "1000.0000" in out
+
+
+def test_format_table_renders_infinite_density_as_inf():
+    out = format_table(build_result(_args(x=0.0, k=0.5)), 4, survival=False)
+    assert "inf" in out
+
+
+def test_format_json_point():
+    data = json.loads(format_json(build_result(_args())))
+    assert data["point"]["cdf"] == pytest.approx(1 - math.exp(-0.25))
+
+
+def test_format_json_table_rows_become_objects():
+    data = json.loads(
+        format_json(build_result(_args(x=None, table=[0.0, 500.0, 500.0])))
+    )
+    assert data["table"][0]["x"] == pytest.approx(0.0)
+    assert data["table"][1]["survival"] == pytest.approx(math.exp(-0.25))
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_point_report(capsys):
+    rc = main(["-x", "500", "-k", "2", "--lambda", "1000"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0.7788" in out
+
+
+def test_main_survival_flag(capsys):
+    rc = main(["-x", "500", "-k", "2", "--lambda", "1000", "--survival"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "S(x >" in out
+
+
+def test_main_quantile(capsys):
+    rc = main(["--quantile", "0.05", "-k", "1.5", "--lambda", "800"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "110.4410" in out
+
+
+def test_main_table(capsys):
+    rc = main(["-k", "2.5", "--lambda", "1200", "--table", "0", "2000", "500"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "2000.0000" in out
+
+
+def test_main_scale_alias_accepted(capsys):
+    rc = main(["-x", "500", "--shape", "2", "--scale", "1000"])
+    assert rc == 0
+    assert "Weibull" in capsys.readouterr().out
+
+
+def test_main_json_format(capsys):
+    rc = main(["-x", "500", "-k", "2", "--lambda", "1000", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert json.loads(out)["k"] == pytest.approx(2.0)
+
+
+def test_main_missing_x_returns_2(capsys):
+    assert main(["-k", "2", "--lambda", "1000"]) == 2
+    assert "Error" in capsys.readouterr().err
+
+
+def test_main_invalid_shape_returns_2(capsys):
+    assert main(["-x", "500", "-k", "0", "--lambda", "1000"]) == 2
+
+
+def test_main_computation_error_returns_2(monkeypatch, capsys):
+    """Cover the ValueError branch in main when a core function raises."""
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("forced weibull error")
+
+    monkeypatch.setattr(weibull_module, "weibull_mean", raise_value_error)
+    assert main(["-x", "500", "-k", "2", "--lambda", "1000"]) == 2
+    assert "forced weibull error" in capsys.readouterr().err


### PR DESCRIPTION
Adds four pure-Python CLI tools, each with a table/JSON report, argument validation returning exit code 2, and 100% test coverage.

## Tools

| Command | Module | Issue |
|---------|--------|-------|
| `breakeven` | `src/utils/break_even.py` | #14 |
| `entropy` | `src/utils/information_entropy.py` | #32 |
| `weibull` | `src/utils/weibull_distribution.py` | #34 |
| `discount` | `src/utils/discount_rate.py` | #42 |

- **`breakeven`** — cost-volume-profit analysis: break-even units and revenue, contribution margin and ratio, target-profit volume, margin of safety. `--sweep MIN MAX STEP` adds a profit/loss table; `--chart` renders it as a text bar chart with losses left of the break-even axis and profits right. `--format {table,json,csv}`.
- **`entropy`** — Shannon entropy, KL divergence, cross-entropy, mutual information, conditional entropy, in bits, nats, or hartleys. Input vectors normalize internally, so raw counts work alongside probabilities.
- **`weibull`** — PDF, CDF, survival, hazard, quantile, mean, median, variance for Weibull(k, λ), with the shape parameter's failure mode named (infant mortality, constant hazard, wear-out). `--table MIN MAX STEP`.
- **`discount`** — Fisher-equation real and nominal rates, discount factors, present value, nominal and inflation-adjusted NPV, discounted payback period.

## Decisions worth reviewing

- **`--chart` is text-only.** The `docs/tool_ideas.md` spec offered a matplotlib curve "if available", but matplotlib is not in `AGENTS/skills/approved-packages.md` and RULES.md §5 requires approval before adding a dependency.
- **`entropy` normalizes inputs.** The spec's own six-sided-die example (`0.167` × 6) sums to 1.002 and would fail a strict "must sum to 1" check.
- **`real_npv` treats cash flows as constant-dollar** and discounts at the real rate; discounting nominal flows at the real rate would double-count inflation. Stated in the docstring and printed under the report.
- **Reverse KL reports `infinite` rather than aborting.** It is a supplementary figure; when P has a zero the requested measure is still well defined.
- **`weibull_hazard` uses the closed form** `(k/lam) * (x/lam)^(k-1)` rather than `f(x)/S(x)`, which divides zero by zero in the far tail.

## Verification

- 1598 tests pass in ~2.8s (up from 1288); 100% coverage over 6392 statements
- `ruff check src/ tests/` clean; `mypy` clean on the four new modules
- All four console scripts verified after `uv sync`
- Spot-checked against closed forms: fair-die entropy 2.585 bits, KL(0.7/0.3 ‖ 0.5/0.5) = 0.1187 bits, Weibull S(500; k=2, λ=1000) = e^-0.25 = 0.7788, real rate 1.08/1.03 − 1 = 4.8544%

## Notes

- Issues #32 and #34 cite `docs/tool_ideas.md` entries #23 and #26, but entropy is entry #21 and weibull is entry #24 there. The correctly-titled sections were used; the doc's numbering drift was left alone.
- `README.md` and `CHANGELOG.md` updated; the four console scripts are registered in `pyproject.toml`. CHANGELOG entries sit under `[Unreleased]` pending a `0.23.0` release.

Closes #14
Closes #32
Closes #34
Closes #42