### PR TITLE
feat: add mlreg, logreg, and slopeint CLI tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Binary logistic regression tool (`logreg`) — Newton-Raphson (IRLS) fit reporting coefficients as log-odds and odds ratios, with Wald standard errors, z-statistics, p-values, and confidence intervals (#10)
+  - Model fit: log-likelihood against the intercept-only null, McFadden pseudo-R², AIC, and BIC; classification: confusion matrix with accuracy, precision, recall, and F1 at a configurable `--threshold`
+  - Standard errors come from the exact inverse observed information rather than a quasi-Newton approximation, verified against a numerical Hessian to 1e-9 and the coefficients against a scipy optimiser to 1e-8
+  - Degenerate fits raise instead of returning quietly: perfectly separable classes have no finite MLE and are reported as such, and a non-converged run raises rather than handing back the last iterate
+  - `--predict-file` scores new observations; any two distinct target values are accepted, not just 0/1
 - Slope-intercept line tool (`slopeint`) — construct a line from two points, point-slope, or standard form `Ax + By = C`, and report it in every representation (#55)
   - Standard form is normalised to primitive integer coefficients through exact rational arithmetic (`fractions.Fraction`), so `y = 1.8x + 32` reports as `9x - 5y = -160` rather than as rounded floats
   - Evaluates y at an x, solves x for a y, intersects a second line, projects a point onto the line with the perpendicular distance and the closest point, and emits the perpendicular or parallel line through a point

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Multiple linear regression tool (`mlreg`) — OLS across several predictors with coefficient estimates, standard errors, t-statistics, p-values, and confidence intervals (#3)
+  - Predictions carry both interval kinds: a confidence interval for the mean response and the always-wider prediction interval for a single new observation
+  - Model fit reports R², adjusted R², residual standard error, and the overall F-test; `--vif` adds variance inflation factors, flagging any predictor above 10
+  - The overall p-value is evaluated from the incomplete-beta tail directly instead of as `1 - cdf`, which cancels to exactly 0 for a strongly significant model where the true value is near 1e-35
+  - Collinear or constant predictors and a constant response are rejected with a named error rather than producing unidentified coefficients or a negative F-statistic
+  - Verified against numpy and scipy oracles: coefficients, standard errors, R², and both interval kinds to 1e-10 or better
 - Binary logistic regression tool (`logreg`) — Newton-Raphson (IRLS) fit reporting coefficients as log-odds and odds ratios, with Wald standard errors, z-statistics, p-values, and confidence intervals (#10)
   - Model fit: log-likelihood against the intercept-only null, McFadden pseudo-R², AIC, and BIC; classification: confusion matrix with accuracy, precision, recall, and F1 at a configurable `--threshold`
   - Standard errors come from the exact inverse observed information rather than a quasi-Newton approximation, verified against a numerical Hessian to 1e-9 and the coefficients against a scipy optimiser to 1e-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+- Slope-intercept line tool (`slopeint`) — construct a line from two points, point-slope, or standard form `Ax + By = C`, and report it in every representation (#55)
+  - Standard form is normalised to primitive integer coefficients through exact rational arithmetic (`fractions.Fraction`), so `y = 1.8x + 32` reports as `9x - 5y = -160` rather than as rounded floats
+  - Evaluates y at an x, solves x for a y, intersects a second line, projects a point onto the line with the perpendicular distance and the closest point, and emits the perpendicular or parallel line through a point
+  - Degenerate cases are named rather than returned as infinities: a vertical line reports having no slope-intercept form, a horizontal line reports that solving for x has no answer, and parallel lines are distinguished from coincident ones
+  - Complements `linreg`, which estimates a line from noisy data; `slopeint` operates on an exact, known one
+
+---
+
 ## [0.23.0] — 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Degenerate cases are named rather than returned as infinities: a vertical line reports having no slope-intercept form, a horizontal line reports that solving for x has no answer, and parallel lines are distinguished from coincident ones
   - Complements `linreg`, which estimates a line from noisy data; `slopeint` operates on an exact, known one
 
+### Fixed
+- `linreg` distribution kernels were producing wrong p-values and interval bounds (issue #59)
+  - `incomplete_beta` seeded its continued fraction at `d = 0`, dropping the leading term of the Lentz recurrence. It returned 0.2285 for `I_0.4(2,3)` against a true 0.5248, and the error reached every t- and F-based p-value in the module. Now seeded at `d = 1 / (1 - (a+b)x/(a+1))` and agrees with `scipy.special.betainc` to 1e-9
+  - `t_cdf` substituted a normal approximation above `df = 30`, capping accuracy at ~3e-3 relative and putting a visible step in the reported p-value at the df 30/31 boundary. Now exact at every df
+  - `inverse_t_cdf` used a third-order Cornish-Fisher expansion below `df = 30` and a normal quantile above it, off by 18% at df=5, p=0.975 and 29% at p=0.995. This is the t-critical value behind every confidence and prediction interval `linreg` prints, so those bounds were materially too narrow — at df=5 the 95% critical value was 1.9837 where the true value is 2.5706. Now obtained by bisecting the exact CDF, matching scipy to 1e-8
+  - `f_cdf` was computed as `1 - I_x(...)`, and its caller then subtracted that from 1 again, losing significant digits twice. Now evaluated in direct form
+  - Added scipy oracle tests across all four kernels. The previous tests asserted only edge cases and the *shape* of the large-df shortcut, which is why a continued fraction seeded incorrectly passed everything
+
+### Removed
+- `standard_normal_cdf` and `inverse_normal_cdf` from `src.utils.linear_regression`, unused once the normal-approximation shortcuts were dropped. Neither was part of the module's documented surface; equivalents remain in `pearson_correlation` and `normal_gaussian`
+
 ---
 
 ## [0.23.0] — 2026-08-18

--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Break-Even Analysis** | Cost-volume-profit analysis: break-even units and revenue, contribution margin and ratio, margin of safety, and the volume needed to hit a target profit; optional profit/loss sweep across a unit range with a text bar chart |
 | **Information Entropy** | Shannon entropy, KL divergence, cross-entropy, mutual information, and conditional entropy in bits, nats, or hartleys; accepts raw counts as well as probabilities |
 | **Weibull Distribution** | PDF, CDF, survival, hazard rate, quantiles, mean, median, and variance for Weibull(k, λ), with the shape parameter's failure mode named (infant mortality, constant hazard, or wear-out) |
+| **Multiple Regression** | OLS across several predictors with coefficient inference, R² and adjusted R², the overall F-test, variance inflation factors, and predictions carrying both confidence and prediction intervals |
 | **Logistic Regression** | Binary classifier fitted by Newton-Raphson with odds ratios, Wald intervals, log-likelihood, AIC/BIC, McFadden pseudo-R², a confusion matrix, and accuracy/precision/recall/F1 |
 | **Slope-Intercept Lines** | Build a line from two points, point-slope, or standard form; convert between representations; evaluate, solve, intersect, project onto, and measure distance to it |
 | **Discount Rates & NPV** | Real and nominal discount rates via the Fisher equation, discount factors, present value of a lump sum, and nominal and inflation-adjusted NPV with discounted payback period |
 | **Monte Carlo Simulator** | Empirically estimate probabilities for `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, `linboot` experiments with confidence intervals and analytical comparison |
-| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, `chisq`, `anova`, `life`, `breakeven`, `entropy`, `weibull`, `discount`, `slopeint`, and `logreg` commands |
+| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, `chisq`, `anova`, `life`, `breakeven`, `entropy`, `weibull`, `discount`, `slopeint`, `logreg`, and `mlreg` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
 
@@ -109,6 +110,7 @@ pip install -e .
 | `entropy` | Shannon entropy, KL divergence, cross-entropy, mutual information, and conditional entropy in bits, nats, or hartleys |
 | `weibull` | PDF, CDF, survival, hazard, quantiles, and moments for the Weibull(k, λ) reliability distribution |
 | `discount` | Real and nominal discount rates (Fisher), discount factors, present value, and inflation-adjusted NPV |
+| `mlreg` | Multiple linear regression with confidence and prediction intervals, VIF, and the overall F-test |
 | `logreg` | Binary logistic regression with odds ratios, model fit statistics, and classification metrics |
 | `slopeint` | Slope-intercept line algebra: construction, standard-form conversion, intersection, perpendicular projection, and point distance |
 | `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
@@ -1769,6 +1771,43 @@ discount --nominal 0.08 --inflation 0.03 --cashflows -1000 300 400 500
 ---
 
 <details>
+<summary><strong><code>mlreg</code></strong> — Multiple Linear Regression</summary>
+
+Extends `linreg` from one predictor to many. Reports coefficient estimates with standard errors, t-statistics, p-values, and confidence intervals; model fit via R², adjusted R², residual standard error, and the overall F-test; and optional variance inflation factors for multicollinearity.
+
+The distinction between the two interval kinds is the point of the tool. A **confidence interval** covers the *mean* response at a set of predictor values. A **prediction interval** covers a *single new observation* and is always wider, because it absorbs residual scatter on top of the uncertainty in the fitted surface. Both widen as the prediction point moves away from the centre of the training data.
+
+The overall p-value is computed from the incomplete-beta tail directly rather than as `1 - cdf`. For a strongly significant model the CDF rounds to exactly 1.0 in floating point, and the subtraction form would report `p = 0` where the true value is near 1e-35 — precisely the models where the number is read most closely.
+
+```bash
+# Fit from a CSV, every non-target column as a predictor
+mlreg --file housing.csv --target price
+
+# Chosen predictors, with multicollinearity diagnostics
+mlreg --file data.csv --target sales --features advertising headcount --vif
+
+# Predict new observations with 90% intervals
+mlreg --file train.csv --target output --predict-file new_inputs.csv --alpha 0.10
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| | `--file CSV` | Training data with a header row (required) |
+| | `--target COL` | Response column (required) |
+| | `--features COL [COL ...]` | Predictor columns (default: every column except the target) |
+| | `--alpha F` | Significance level for all intervals (default: 0.05) |
+| | `--predict-file CSV` | Predict these observations, with both interval kinds |
+| | `--vif` | Report variance inflation factors |
+| | `--format {table,json,csv}` | Output format (default: table) |
+| `-P` | `--precision` | Decimal places for output (default: 4) |
+
+</details>
+
+---
+
+<details>
 <summary><strong><code>logreg</code></strong> — Logistic Regression</summary>
 
 The classification counterpart to `linreg`: reach for it when the outcome is binary rather than continuous. Fitted by Newton-Raphson (iteratively reweighted least squares), which converges in a handful of iterations on well-conditioned data. Coefficients are reported as odds ratios alongside the log-odds estimates, since the odds ratio is the form that travels to non-technical readers.
@@ -1961,6 +2000,7 @@ simulate --experiment linboot --params x=1,2,3,4,5 y=2.1,3.9,6.2,7.8,10.1 predic
 | Entropy | `src.utils.information_entropy` | `shannon_entropy`, `kl_divergence`, `cross_entropy`, `mutual_information`, `conditional_entropy`, `joint_entropy` |
 | Weibull | `src.utils.weibull_distribution` | `weibull_pdf`, `weibull_cdf`, `weibull_survival`, `weibull_hazard`, `weibull_quantile`, `weibull_mean` |
 | Discount Rate | `src.utils.discount_rate` | `real_rate`, `nominal_rate`, `discount_factor`, `present_value`, `npv`, `real_npv`, `payback_period` |
+| Multiple Regression | `src.utils.multiple_regression` | `fit`, `predict`, `variance_inflation_factors`, `t_cdf`, `t_quantile`, `f_sf` |
 | Logistic Regression | `src.utils.logistic_regression` | `fit`, `predict_proba`, `predict_class`, `log_odds`, `sigmoid`, `confusion_matrix`, `classification_metrics` |
 | Slope-Intercept | `src.utils.slope_intercept` | `line_from_points`, `line_from_standard`, `to_standard`, `evaluate`, `solve_for_x`, `intersection`, `perpendicular_slope`, `distance_to_point`, `foot_of_perpendicular` |
 | Monte Carlo | `src.utils.monte_carlo` | `simulate_binomial`, `simulate_birthday`, `simulate_streak`, `simulate_poisson`, `simulate_power`, `simulate_permutation`, `simulate_bayes`, `simulate_season`, `simulate_linboot` |
@@ -3028,6 +3068,35 @@ t05 = weibull_quantile(0.05, 1.5, 800)
 # Mean time to failure, and what the shape parameter implies
 mttf = weibull_mean(2, 1000)
 mode = failure_mode(2)  # 'wear-out (increasing hazard)'
+```
+
+</details>
+
+<details>
+<summary><strong>Multiple Linear Regression</strong></summary>
+
+```python
+from src.utils.multiple_regression import fit, predict, variance_inflation_factors
+
+X = [[12, 3.0], [18, 4.5], [25, 2.0], [31, 6.5], [40, 5.0], [52, 7.5], [61, 4.0]]
+y = [44.0, 61.2, 70.5, 99.8, 118.4, 155.1, 166.0]
+
+model = fit(X, y, names=["advertising", "headcount"])
+
+# Coefficient inference
+model.coefficients, model.std_errors, model.p_values
+model.confidence_intervals(0.05)
+
+# Model fit and the overall F-test
+model.r_squared, model.adj_r_squared, model.f_statistic, model.f_p_value
+
+# A prediction carries both interval kinds; the PI is always the wider one
+out = predict(model, [45, 5.0], alpha=0.05)
+out["ci_lower"], out["ci_upper"]   # mean response
+out["pi_lower"], out["pi_upper"]   # single new observation
+
+# Multicollinearity check
+vifs = variance_inflation_factors(X)
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Break-Even Analysis** | Cost-volume-profit analysis: break-even units and revenue, contribution margin and ratio, margin of safety, and the volume needed to hit a target profit; optional profit/loss sweep across a unit range with a text bar chart |
 | **Information Entropy** | Shannon entropy, KL divergence, cross-entropy, mutual information, and conditional entropy in bits, nats, or hartleys; accepts raw counts as well as probabilities |
 | **Weibull Distribution** | PDF, CDF, survival, hazard rate, quantiles, mean, median, and variance for Weibull(k, λ), with the shape parameter's failure mode named (infant mortality, constant hazard, or wear-out) |
+| **Slope-Intercept Lines** | Build a line from two points, point-slope, or standard form; convert between representations; evaluate, solve, intersect, project onto, and measure distance to it |
 | **Discount Rates & NPV** | Real and nominal discount rates via the Fisher equation, discount factors, present value of a lump sum, and nominal and inflation-adjusted NPV with discounted payback period |
 | **Monte Carlo Simulator** | Empirically estimate probabilities for `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, `linboot` experiments with confidence intervals and analytical comparison |
-| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, `chisq`, `anova`, `life`, `breakeven`, `entropy`, `weibull`, and `discount` commands |
+| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, `chisq`, `anova`, `life`, `breakeven`, `entropy`, `weibull`, `discount`, and `slopeint` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
 
@@ -107,6 +108,7 @@ pip install -e .
 | `entropy` | Shannon entropy, KL divergence, cross-entropy, mutual information, and conditional entropy in bits, nats, or hartleys |
 | `weibull` | PDF, CDF, survival, hazard, quantiles, and moments for the Weibull(k, λ) reliability distribution |
 | `discount` | Real and nominal discount rates (Fisher), discount factors, present value, and inflation-adjusted NPV |
+| `slopeint` | Slope-intercept line algebra: construction, standard-form conversion, intersection, perpendicular projection, and point distance |
 | `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
 
 ---
@@ -1765,6 +1767,53 @@ discount --nominal 0.08 --inflation 0.03 --cashflows -1000 300 400 500
 ---
 
 <details>
+<summary><strong><code>slopeint</code></strong> — Slope-Intercept Lines</summary>
+
+Line algebra for an *exact*, known line, as opposed to `linreg`, which *estimates* one from noisy data. The two pair: `linreg` produces `m` and `b`, `slopeint` consumes them for evaluation, intersection, and projection. A line can be entered three ways — two points, point-slope, or standard form `Ax + By = C` — and is reported in all of them, with standard form normalised to primitive integer coefficients via exact rational arithmetic rather than float rounding.
+
+Degenerate cases are named rather than returned as infinities: a vertical line reports that it has no slope-intercept form, a horizontal line reports that `--solve` has no answer, and parallel lines are distinguished from coincident ones.
+
+```bash
+# Unit conversion: Fahrenheit from Celsius, y = 1.8x + 32
+slopeint --points 0,32 100,212
+
+# What is 37 degrees C in F?
+slopeint --slope 1.8 --intercept 32 --at 37
+
+# Straight-line depreciation: $30k asset, $5k salvage, 5-year life
+slopeint --points 0,30000 5,5000 --table 0 5 1
+
+# Break-even as an intersection of a cost line and a revenue line
+slopeint --slope 10 --intercept 50000 --intersect 25,0
+
+# Perpendicular line through a point, and the distance to it
+slopeint --slope 2 --intercept 1 --point 4,3 --perpendicular --distance
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| | `--points X1,Y1 X2,Y2` | Derive the line from two points |
+| `-m` | `--slope F` | Slope m, with `--intercept` or `--point` |
+| `-b` | `--intercept F` | y-intercept b, with `--slope` |
+| | `--point X,Y` | Anchor for point-slope form, or the target for `--distance`, `--perpendicular`, `--parallel` |
+| | `--standard A B C` | Read the line from standard form Ax + By = C |
+| | `--at F` | Evaluate y at this x |
+| | `--solve F` | Solve for the x that gives this y |
+| | `--intersect M,B` | Intersect with a second line given as slope,intercept |
+| | `--perpendicular` | Report the perpendicular line through `--point` |
+| | `--parallel` | Report the parallel line through `--point` |
+| | `--distance` | Perpendicular distance from `--point` to the line, and the closest point on it |
+| | `--table MIN MAX STEP` | Print a table of (x, y) over x = MIN..MAX |
+| | `--format {table,json}` | Output format (default: table) |
+| `-P` | `--precision` | Decimal places for output (default: 4) |
+
+</details>
+
+---
+
+<details>
 <summary><strong><code>simulate</code></strong> — Monte Carlo Probability Simulator</summary>
 
 Runs repeated random experiments to estimate probabilities empirically, with optional confidence intervals and analytical comparison against `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, and `linboot`.
@@ -1871,6 +1920,7 @@ simulate --experiment linboot --params x=1,2,3,4,5 y=2.1,3.9,6.2,7.8,10.1 predic
 | Entropy | `src.utils.information_entropy` | `shannon_entropy`, `kl_divergence`, `cross_entropy`, `mutual_information`, `conditional_entropy`, `joint_entropy` |
 | Weibull | `src.utils.weibull_distribution` | `weibull_pdf`, `weibull_cdf`, `weibull_survival`, `weibull_hazard`, `weibull_quantile`, `weibull_mean` |
 | Discount Rate | `src.utils.discount_rate` | `real_rate`, `nominal_rate`, `discount_factor`, `present_value`, `npv`, `real_npv`, `payback_period` |
+| Slope-Intercept | `src.utils.slope_intercept` | `line_from_points`, `line_from_standard`, `to_standard`, `evaluate`, `solve_for_x`, `intersection`, `perpendicular_slope`, `distance_to_point`, `foot_of_perpendicular` |
 | Monte Carlo | `src.utils.monte_carlo` | `simulate_binomial`, `simulate_birthday`, `simulate_streak`, `simulate_poisson`, `simulate_power`, `simulate_permutation`, `simulate_bayes`, `simulate_season`, `simulate_linboot` |
 
 ---
@@ -2936,6 +2986,36 @@ t05 = weibull_quantile(0.05, 1.5, 800)
 # Mean time to failure, and what the shape parameter implies
 mttf = weibull_mean(2, 1000)
 mode = failure_mode(2)  # 'wear-out (increasing hazard)'
+```
+
+</details>
+
+<details>
+<summary><strong>Slope-Intercept Lines</strong></summary>
+
+```python
+from src.utils.slope_intercept import (
+    distance_to_point,
+    evaluate,
+    intersection,
+    line_from_points,
+    to_standard,
+)
+
+# Celsius to Fahrenheit, derived from two known points
+m, b = line_from_points((0, 32), (100, 212))  # (1.8, 32.0)
+
+# 37 degrees C in Fahrenheit
+f = evaluate(m, b, 37)  # 98.6
+
+# Same line as primitive integer standard form: 9x - 5y = -160
+a, b_coef, c = to_standard(m, b)
+
+# Break-even: where a cost line meets a revenue line
+units, revenue = intersection((10, 50000), (25, 0))
+
+# Perpendicular distance from a point to a line
+d = distance_to_point(2, 1, (4, 3))
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ A command-line utility and Python library for calculating statistics, odds, and 
 | **Break-Even Analysis** | Cost-volume-profit analysis: break-even units and revenue, contribution margin and ratio, margin of safety, and the volume needed to hit a target profit; optional profit/loss sweep across a unit range with a text bar chart |
 | **Information Entropy** | Shannon entropy, KL divergence, cross-entropy, mutual information, and conditional entropy in bits, nats, or hartleys; accepts raw counts as well as probabilities |
 | **Weibull Distribution** | PDF, CDF, survival, hazard rate, quantiles, mean, median, and variance for Weibull(k, λ), with the shape parameter's failure mode named (infant mortality, constant hazard, or wear-out) |
+| **Logistic Regression** | Binary classifier fitted by Newton-Raphson with odds ratios, Wald intervals, log-likelihood, AIC/BIC, McFadden pseudo-R², a confusion matrix, and accuracy/precision/recall/F1 |
 | **Slope-Intercept Lines** | Build a line from two points, point-slope, or standard form; convert between representations; evaluate, solve, intersect, project onto, and measure distance to it |
 | **Discount Rates & NPV** | Real and nominal discount rates via the Fisher equation, discount factors, present value of a lump sum, and nominal and inflation-adjusted NPV with discounted payback period |
 | **Monte Carlo Simulator** | Empirically estimate probabilities for `binomial`, `birthday`, `streak`, `poisson`, `power`, `permutation`, `bayes`, `season`, `linboot` experiments with confidence intervals and analytical comparison |
-| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, `chisq`, `anova`, `life`, `breakeven`, `entropy`, `weibull`, `discount`, and `slopeint` commands |
+| **Command-line Interface** | `binom`, `bayes`, `birthday`, `normal`, `zscore`, `expected`, `poisson`, `prime`, `streak`, `pythag`, `pearson`, `spearman`, `linreg`, `sample`, `bootci`, `confint`, `pvalue`, `ttest`, `forecast`, `collatz`, `jevons`, `simulate`, `sigmoid`, `euler`, `gini`, `crt`, `subnet`, `geometric`, `chisq`, `anova`, `life`, `breakeven`, `entropy`, `weibull`, `discount`, `slopeint`, and `logreg` commands |
 | **Minimal Dependencies** | Core calculations use pure Python; Spearman correlation and Monte Carlo simulation use scipy/numpy for numerical robustness |
 
 
@@ -108,6 +109,7 @@ pip install -e .
 | `entropy` | Shannon entropy, KL divergence, cross-entropy, mutual information, and conditional entropy in bits, nats, or hartleys |
 | `weibull` | PDF, CDF, survival, hazard, quantiles, and moments for the Weibull(k, λ) reliability distribution |
 | `discount` | Real and nominal discount rates (Fisher), discount factors, present value, and inflation-adjusted NPV |
+| `logreg` | Binary logistic regression with odds ratios, model fit statistics, and classification metrics |
 | `slopeint` | Slope-intercept line algebra: construction, standard-form conversion, intersection, perpendicular projection, and point distance |
 | `simulate` | Monte Carlo estimation with confidence intervals and analytical comparison |
 
@@ -1767,6 +1769,45 @@ discount --nominal 0.08 --inflation 0.03 --cashflows -1000 300 400 500
 ---
 
 <details>
+<summary><strong><code>logreg</code></strong> — Logistic Regression</summary>
+
+The classification counterpart to `linreg`: reach for it when the outcome is binary rather than continuous. Fitted by Newton-Raphson (iteratively reweighted least squares), which converges in a handful of iterations on well-conditioned data. Coefficients are reported as odds ratios alongside the log-odds estimates, since the odds ratio is the form that travels to non-technical readers.
+
+Standard errors come from the exact inverse observed information, not a quasi-Newton approximation. Degenerate fits are refused rather than returned: perfectly separable classes have no finite maximum-likelihood estimate, so the fit reports that instead of handing back runaway coefficients, and a run that fails to converge raises rather than returning the last iterate.
+
+```bash
+# Fit from a CSV, every non-target column as a feature
+logreg --file patient_data.csv --target disease
+
+# Chosen features, lower cutoff to favour recall over precision
+logreg --file churn.csv --target churned --features tenure spend --threshold 0.3
+
+# Score new observations with the fitted model
+logreg --file train.csv --target clicked --predict-file new_users.csv
+
+# 99% coefficient intervals, JSON out
+logreg --file iris.csv --target setosa --alpha 0.01 --format json
+```
+
+**Options:**
+
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| | `--file CSV` | Training data with a header row (required) |
+| | `--target COL` | Binary outcome column (required); any two distinct values are accepted, not just 0/1 |
+| | `--features COL [COL ...]` | Predictor columns (default: every column except the target) |
+| | `--threshold F` | Probability cutoff for the positive class (default: 0.5) |
+| | `--alpha F` | Significance level for coefficient intervals (default: 0.05) |
+| | `--predict-file CSV` | Score these observations with the fitted model |
+| | `--max-iter INT` | Maximum Newton-Raphson iterations (default: 50) |
+| | `--format {table,json}` | Output format (default: table) |
+| `-P` | `--precision` | Decimal places for output (default: 4) |
+
+</details>
+
+---
+
+<details>
 <summary><strong><code>slopeint</code></strong> — Slope-Intercept Lines</summary>
 
 Line algebra for an *exact*, known line, as opposed to `linreg`, which *estimates* one from noisy data. The two pair: `linreg` produces `m` and `b`, `slopeint` consumes them for evaluation, intersection, and projection. A line can be entered three ways — two points, point-slope, or standard form `Ax + By = C` — and is reported in all of them, with standard form normalised to primitive integer coefficients via exact rational arithmetic rather than float rounding.
@@ -1920,6 +1961,7 @@ simulate --experiment linboot --params x=1,2,3,4,5 y=2.1,3.9,6.2,7.8,10.1 predic
 | Entropy | `src.utils.information_entropy` | `shannon_entropy`, `kl_divergence`, `cross_entropy`, `mutual_information`, `conditional_entropy`, `joint_entropy` |
 | Weibull | `src.utils.weibull_distribution` | `weibull_pdf`, `weibull_cdf`, `weibull_survival`, `weibull_hazard`, `weibull_quantile`, `weibull_mean` |
 | Discount Rate | `src.utils.discount_rate` | `real_rate`, `nominal_rate`, `discount_factor`, `present_value`, `npv`, `real_npv`, `payback_period` |
+| Logistic Regression | `src.utils.logistic_regression` | `fit`, `predict_proba`, `predict_class`, `log_odds`, `sigmoid`, `confusion_matrix`, `classification_metrics` |
 | Slope-Intercept | `src.utils.slope_intercept` | `line_from_points`, `line_from_standard`, `to_standard`, `evaluate`, `solve_for_x`, `intersection`, `perpendicular_slope`, `distance_to_point`, `foot_of_perpendicular` |
 | Monte Carlo | `src.utils.monte_carlo` | `simulate_binomial`, `simulate_birthday`, `simulate_streak`, `simulate_poisson`, `simulate_power`, `simulate_permutation`, `simulate_bayes`, `simulate_season`, `simulate_linboot` |
 
@@ -2986,6 +3028,41 @@ t05 = weibull_quantile(0.05, 1.5, 800)
 # Mean time to failure, and what the shape parameter implies
 mttf = weibull_mean(2, 1000)
 mode = failure_mode(2)  # 'wear-out (increasing hazard)'
+```
+
+</details>
+
+<details>
+<summary><strong>Logistic Regression</strong></summary>
+
+```python
+from src.utils.logistic_regression import (
+    classification_metrics,
+    confusion_matrix,
+    fit,
+    predict_class,
+    predict_proba,
+)
+
+X = [[25, 1.2], [31, 0.4], [47, 2.9], [52, 0.1], [38, 1.7], [29, 2.2]]
+y = [0, 0, 1, 0, 1, 1]
+
+model = fit(X, y, names=["age", "score"])
+
+# Log-odds estimates, and the same effects as odds ratios
+model.coefficients
+model.odds_ratios
+
+# Model fit
+model.pseudo_r2, model.aic, model.bic
+
+# Score an observation and label it
+p = predict_proba(model.coefficients, [40, 1.5])
+label = predict_class(p, threshold=0.5)
+
+# In-sample classification quality
+labels = [predict_class(predict_proba(model.coefficients, row)) for row in X]
+metrics = classification_metrics(confusion_matrix(y, labels))
 ```
 
 </details>

--- a/docs/tool_ideas.md
+++ b/docs/tool_ideas.md
@@ -27,8 +27,10 @@ For the full list of implemented tools and their CLI entry points, see `README.m
 | `geometric` | Geometric distribution PMF, CDF, and survival |
 | `gini` | Gini coefficient and Lorenz curve |
 | `jevons` | Jevons paradox / rebound effect modeling |
+| `logreg` | Binary logistic regression with odds ratios and classification metrics |
 | `life` | Life-in-weeks grid visualiser |
 | `linreg` | Simple linear regression |
+| `mlreg` | Multiple linear regression with confidence and prediction intervals |
 | `normal` | Gaussian PDF, CDF, and quantile |
 | `pearson` | Pearson correlation coefficient |
 | `poisson` | Poisson PMF, CDF, and survival |
@@ -36,6 +38,7 @@ For the full list of implemented tools and their CLI entry points, see `README.m
 | `pvalue` | p-value and hypothesis test calculator |
 | `pythag` | Pythagorean win expectation |
 | `sample` | Sample size calculator |
+| `slopeint` | Slope-intercept line algebra, conversion, intersection, and projection |
 | `simulate` | Monte Carlo probability simulator |
 | `sigmoid` | Sigmoid function σ(x), derivative, inverse logit, and Unicode sparkline |
 | `spearman` | Spearman rank correlation |
@@ -264,38 +267,7 @@ vartest --test bartlett --data "1.2,1.5,1.3" "2.1,2.4,2.2,2.0" --alpha 0.01
 
 ---
 
-## 8. `mlreg` — Multiple Linear Regression with Prediction Intervals
-
-### Dependencies
-- **Required:** `numpy` (matrix algebra for OLS: $(X^TX)^{-1}X^Ty$)
-- **Optional:** `pandas` (named-column CSV ingestion; falls back to `csv` module with positional columns)
-
-### Architecture
-- Fits OLS multiple regression and produces full inference output including individual and joint prediction intervals, driven entirely by user-supplied data
-- **Core functions:** `fit(X, y)` → coefficients, SE, t-stats, p-values, R², adjusted R², F-stat; `predict(X_new, model, alpha)` → point estimate, confidence interval (mean response), prediction interval (individual response)
-- CLI flags: `--file CSV`, `--target COL`, `--features COL [...]` (default: all non-target numeric columns), `--alpha F`, `--predict-file CSV`, `--vif` (variance inflation factors for multicollinearity), `--format {table,json,csv}`, `--precision INT`
-- Output: coefficient table (estimate, SE, t, p, 95% CI), model summary (R², adjusted R², RMSE, F-stat, overall p), optional prediction table with PI bounds
-
-```bash
-# Fit a multiple regression from a CSV file
-mlreg --file housing.csv --target price
-
-# Include only selected features and compute VIF
-mlreg --file data.csv --target sales --features advertising headcount --vif
-
-# Predict new observations with 90% prediction intervals
-mlreg --file train.csv --target output --predict-file new_inputs.csv --alpha 0.10 --format json
-```
-
-### Target User Base
-- Analysts and data scientists: _who need a CLI multiple regression tool without opening a notebook or statistical package_
-- Researchers: _reporting coefficient estimates with standard errors and prediction intervals_
-- Engineers: _modeling a response variable (yield, latency, defect rate) as a function of multiple controllable inputs_
-- Extends `linreg` to multiple predictors and adds the critical distinction between confidence intervals (mean response variance) and prediction intervals (individual response variance)
-
----
-
-## 9. `taylor` — Taylor Series Approximation
+## 8. `taylor` — Taylor Series Approximation
 
 ### Architecture
 - **Core functions:** `taylor_series(func, a, x, n)` → approximation value and coefficients; `taylor_error(func, a, x, n)` → actual value, approximation, absolute and relative error
@@ -327,7 +299,7 @@ taylor --func ln --center 1 --eval 1.5 --order 10 --compare --format json
 
 ---
 
-## 10. `compound` — Compound Interest & Time Value of Money
+## 9. `compound` — Compound Interest & Time Value of Money
 
 ### Architecture
 - **Core functions:** `future_value(pv, r, n, t)`, `present_value(fv, r, n, t)`, `annuity(pmt, r, n, t)`, `pmt_from_pv(pv, r, n, t)`, `effective_rate(nom_rate, n)`, `continuous_compound(pv, r, t)`
@@ -362,7 +334,7 @@ compound --mode payment --pv 50000 --rate 0.06 --periods 12 --time 5 --schedule
 
 ---
 
-## 11. `matrix` — Matrix Operations & Linear Algebra
+## 10. `matrix` — Matrix Operations & Linear Algebra
 
 ### Dependencies
 - **Optional:** `numpy` (efficient operations on large matrices, eigenvalues, SVD); falls back to pure-Python nested lists for small matrices
@@ -399,7 +371,7 @@ matrix --op eigen --matrix "[[6,-1],[2,3]]" --format json
 
 ---
 
-## 12. `fibonacci` — Fibonacci Sequence & Golden Ratio
+## 11. `fibonacci` — Fibonacci Sequence & Golden Ratio
 
 ### Architecture
 - **Core functions:** `fib(n)` (n-th Fibonacci number), `fib_seq(n)` (first n terms), `golden_ratio()`, `fib_ratio(n)` (ratio F(n)/F(n-1) approaching φ), `lucas(n)` (Lucas numbers), `binet_formula(n)` (closed-form calculation)
@@ -433,37 +405,7 @@ fibonacci --approx 40
 
 ---
 
-## 13. `logreg` — Logistic Regression
-
-### Architecture
-- **Core functions:** `fit(X, y)` → coefficients, SE, z-stats, p-values, log-likelihood; `predict_proba(X, coeffs)` → probability; `predict_class(X, coeffs, threshold)` → binary label; `log_odds(p)` → logit
-- Gradient-descent or Newton-Raphson fitting via `math` — no required external dependencies; optional `numpy` for matrix operations on larger datasets
-- CLI flags: `--file CSV`, `--target COL`, `--features COL [...]` (default: all non-target), `--threshold F` (classification cutoff, default 0.5), `--alpha F` (significance level), `--predict-file CSV`, `--format {table,json,csv}`, `--max-iter INT`, `--precision INT`
-- Output: coefficient table (estimate, SE, z-stat, p-value, OR = exp(coeff)), model summary (log-likelihood, AIC, BIC, pseudo-R²), confusion matrix, accuracy/precision/recall/F1
-
-### Application
-Logistic regression is the workhorse binary classifier, directly modeling the probability of a binary outcome as a sigmoid function of linear predictors. Underpins medical diagnosis (disease yes/no), marketing (click/no-click), credit scoring (default/no-default), and any domain where the outcome is binary and interpretability matters. Coefficients as odds ratios make results directly communicable to non-technical stakeholders.
-
-```bash
-# Fit logistic regression from CSV; default threshold 0.5
-logreg --file patient_data.csv --target disease
-
-# Specify features and lower classification threshold (favor recall)
-logreg --file churn.csv --target churned --features tenure spend logins --threshold 0.3
-
-# Score new observations
-logreg --file train.csv --target clicked --predict-file new_users.csv --format json
-```
-
-### Target User Base
-- Data scientists and analysts: _baseline binary classifier before trying more complex models_
-- Medical and public health researchers: _odds ratio estimation and risk factor analysis_
-- Marketing and product analysts: _conversion and churn modeling_
-- The "classification" counterpart to `linreg` — users who reach "my outcome is binary" will reach for `logreg` just as `linreg` users reach for it when the outcome is continuous
-
----
-
-## 14. `grover` — Grover's Quantum Search Algorithm Simulator
+## 12. `grover` — Grover's Quantum Search Algorithm Simulator
 
 ### Architecture
 - **Core functions:** `optimal_iterations(n)` → `floor(π/4 · √n)`; `success_probability(n, k, iterations)` → analytical amplitude calculation; `amplitude_evolution(n, k, t)` → probability at each step; `speedup_ratio(n)` → classical vs quantum step ratio
@@ -493,7 +435,7 @@ grover --compare --sweep 16 1048576
 
 ---
 
-## 15. `exponential` — Exponential Distribution Calculator
+## 13. `exponential` — Exponential Distribution Calculator
 
 ### Architecture
 - **Core functions:** `exp_pdf(x, lam)`, `exp_cdf(x, lam)`, `exp_survival(x, lam)`, `exp_hazard(x, lam)`, `exp_quantile(p, lam)`
@@ -523,7 +465,7 @@ The continuous analog of the geometric distribution; models waiting times betwee
 
 ---
 
-## 16. `describe` — Descriptive Statistics
+## 14. `describe` — Descriptive Statistics
 
 ### Architecture
 - **Core functions:** `describe(data)` → n, mean, median, mode, std, variance, min, max, q1, q3, iqr, skewness, kurtosis, range, cv (coefficient of variation)
@@ -553,7 +495,7 @@ Produces a one-shot summary of a dataset's location, spread, shape, and outlier 
 
 ---
 
-## 17. `effect` — Effect Size Calculator
+## 15. `effect` — Effect Size Calculator
 
 ### Architecture
 - **Core functions:** `cohens_d(mean1, mean2, std1, std2, n1, n2)` → d and pooled SE; `eta_squared(ss_between, ss_total)` → η²; `omega_squared(ss_between, ms_within, k, n)` → ω²; `odds_ratio(a, b, c, d)` → OR and 95% CI; `risk_ratio(a, b, c, d)` → RR; `r_from_t(t, df)` → Pearson r
@@ -583,7 +525,7 @@ p-values tell you whether an effect exists; effect sizes tell you how large it i
 
 ---
 
-## 18. `combinatorics` — Permutations, Combinations & Counting
+## 16. `combinatorics` — Permutations, Combinations & Counting
 
 ### Architecture
 - **Core functions:** `permutations(n, r)`, `combinations(n, r)` (via `math.comb`), `multinomial(n, *ks)`, `derangements(n)`, `catalan(n)`, `stirling2(n, k)` (Stirling numbers, second kind), `bell(n)` (Bell numbers)
@@ -619,41 +561,6 @@ Counting functions underpin probability calculations everywhere — the denomina
 
 ---
 
-## 19. `slopeint` — Slope-Intercept Line Calculator
-
-### Architecture
-- **Core functions:** `slope(p1, p2)`, `line_from_points(p1, p2)`, `line_from_point_slope(point, m)`, `line_from_standard(a, b, c)`, `to_standard(m, b)`, `evaluate(m, b, x)`, `solve_for_x(m, b, y)`, `x_intercept(m, b)`, `y_intercept(m, b)`, `intersection(line1, line2)`, `is_parallel(m1, m2)`, `is_perpendicular(m1, m2)`, `perpendicular_slope(m)`, `distance_to_point(m, b, point)`, `angle_of_inclination(m)`
-- Pure Python via `math` — no external dependencies
-- CLI flags: `--points X1,Y1 X2,Y2`, `--slope F`, `--intercept F`, `--point X,Y`, `--standard A B C`, `--at F` (evaluate y at x), `--solve F` (solve x for y), `--intersect M,B`, `--perpendicular`, `--parallel`, `--distance`, `--table MIN MAX STEP`, `--format {table,json}`, `--precision INT`
-- Output: the fitted equation in slope-intercept and standard form, both intercepts, angle of inclination; optional evaluation, intersection, perpendicular distance, or range table
-- Edge cases handled explicitly: vertical line (`x1 == x2`) reports `x = c` rather than infinite slope; horizontal line (`m == 0`) raises on `--solve` instead of dividing by zero; `--intersect` distinguishes parallel from coincident; parallel/perpendicular predicates use float tolerance, not exact `==`
-
-### Application
-Lines in `y = mx + b` form are the most-used model in applied math, and the arithmetic around them — two-point construction, conversion to and from `Ax + By = C`, intersections, perpendicular projection — is exactly the kind of error-prone algebra worth a CLI. Distinct from `linreg`: `linreg` *estimates* a line from noisy sample data with standard errors and p-values, while `slopeint` manipulates an *exact*, known line. The two pair naturally — `linreg` produces `m` and `b`, `slopeint` consumes them for prediction, intersection, and projection. Break-even geometry is the same operation as intersecting a cost line with a revenue line, giving a cross-check against `breakeven`.
-
-```bash
-# Unit conversion: Fahrenheit from Celsius, y = 1.8x + 32
-slopeint --points 0,32 100,212
-
-# Straight-line depreciation: $30k asset, $5k salvage, 5-year life
-slopeint --points 0,30000 5,5000 --table 0 5 1
-
-# Cost model $50k fixed + $10/unit against revenue $25/unit — break-even as an intersection
-slopeint --slope 10 --intercept 50000 --intersect 25,0
-
-# Perpendicular line through a point, and the distance to it
-slopeint --slope 2 --intercept 1 --point 4,3 --perpendicular
-slopeint --slope 2 --intercept 1 --point 4,3 --distance
-```
-
-### Target User Base
-- Students and educators: _working through algebra and precalculus where the line is given rather than fitted_
-- Analysts: _evaluating, intersecting, or projecting a line already fitted by `linreg` without writing code_
-- Engineers and lab technicians: _calibration curves, unit conversion, and quick projection math_
-- Finance and operations users: _straight-line depreciation schedules and linear cost/revenue models, complementing `breakeven`_
-
----
-
 ## Summary Table
 
 | Command | Distribution / Concept | Deps (optional*) | Zero-dep fallback? | Closest existing tool | Issue |
@@ -665,17 +572,14 @@ slopeint --slope 2 --intercept 1 --point 4,3 --distance
 | `randforest`   | Random forest classifier / regressor         | `scikit-learn`, `numpy`*, `pandas`*| ✅ numpy/pandas    | `linreg`                  | #21 |
 | `ewma`         | EWMA control chart + variance limits         | None                               | N/A                | `forecast`                | #22 |
 | `vartest`      | Variance equality tests (F, Levene, Bartlett)| None                               | N/A                | `ttest`                   | #23 |
-| `mlreg`        | Multiple linear regression + pred. intervals | `numpy`, `pandas`*                 | N/A                | `linreg`                  | #3  |
 | `taylor`       | Taylor series approximation                  | None                               | N/A                | N/A                       | #24 |
 | `compound`     | Compound interest & time value of money      | None                               | N/A                | `expected`                | #25 |
-| `matrix`       | Matrix operations & linear algebra           | `numpy`*                           | ✅ nested lists    | `mlreg`                   | #26 |
+| `matrix`       | Matrix operations & linear algebra           | `numpy`*                           | ✅ nested lists    | `mlreg` (implemented)     | #26 |
 | `fibonacci`    | Fibonacci sequence & golden ratio            | None                               | N/A                | N/A                       | #27 |
-| `logreg`       | Logistic regression (binary classifier)      | `numpy`*                           | ✅ gradient descent| `linreg`                  | #10 |
 | `grover`       | Grover's quantum search algorithm simulator  | None                               | N/A                | `prime` / `fibonacci`     | #16 |
 | `exponential`  | Exponential distribution                     | None                               | N/A                | `poisson` / `geometric`   | #31 |
 | `describe`     | Descriptive statistics summary               | None                               | N/A                | all tools                 | #30 |
 | `effect`       | Effect size (Cohen's d, eta², odds ratio)    | None                               | N/A                | `ttest` / `chisq`         | #33 |
 | `combinatorics`| Permutations, combinations, counting         | None                               | N/A                | `hypergeo` / `binom`      | #35 |
-| `slopeint`     | Slope-intercept line algebra & geometry      | None                               | N/A                | `linreg`                  | #55 |
 
 \* _Optional dependency: functionality exists but reduced output capability without the package._

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ breakeven = "src.utils.break_even:main"
 entropy = "src.utils.information_entropy:main"
 weibull = "src.utils.weibull_distribution:main"
 discount = "src.utils.discount_rate:main"
+slopeint = "src.utils.slope_intercept:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ weibull = "src.utils.weibull_distribution:main"
 discount = "src.utils.discount_rate:main"
 slopeint = "src.utils.slope_intercept:main"
 logreg = "src.utils.logistic_regression:main"
+mlreg = "src.utils.multiple_regression:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ entropy = "src.utils.information_entropy:main"
 weibull = "src.utils.weibull_distribution:main"
 discount = "src.utils.discount_rate:main"
 slopeint = "src.utils.slope_intercept:main"
+logreg = "src.utils.logistic_regression:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/utils/linear_regression.py
+++ b/src/utils/linear_regression.py
@@ -209,22 +209,32 @@ def predict(
 
 
 def t_cdf(t: float, df: int) -> float:
-    """Approximate CDF of Student's t-distribution."""
+    """CDF of Student's t-distribution.
+
+    Evaluated from the incomplete-beta identity at every df.  A normal
+    approximation was previously substituted above df = 30, which capped
+    accuracy at roughly 3e-3 relative and made the reported p-value depend on
+    a sample-size threshold rather than on the data.
+
+    Args:
+        t: Evaluation point.
+        df: Degrees of freedom; must be >= 1.
+
+    Returns:
+        ``P(T <= t)`` in [0, 1].
+
+    Raises:
+        ValueError: If ``df`` < 1.
+    """
     if df < 1:
         raise ValueError("Degrees of freedom must be at least 1")
 
     if math.isinf(t):
         return 1.0 if t > 0 else 0.0
 
-    # Use normal approximation for large df
-    if df > 30:
-        return standard_normal_cdf(t)
-
-    # For small df, use approximation
-    # This is a simplified implementation
     x = df / (df + t * t)
-    p = 0.5 * (1.0 + math.copysign(1.0, t) * (1.0 - incomplete_beta(df / 2, 0.5, x)))
-    return p
+    tail = 0.5 * incomplete_beta(df / 2, 0.5, x)
+    return 1.0 - tail if t > 0 else tail
 
 
 def incomplete_beta(a: float, b: float, x: float) -> float:
@@ -255,13 +265,22 @@ def incomplete_beta(a: float, b: float, x: float) -> float:
     # Compute front factor
     front = math.exp(a * math.log(x) + b * math.log(1.0 - x) - log_beta) / a
 
-    # Continued fraction using Lentz's algorithm
+    # Continued fraction using the modified Lentz algorithm.
+    #
+    # The leading term matters: the recurrence must start from
+    # d = 1 / (1 - (a+b)x/(a+1)) with f seeded to that same d.  Starting from
+    # d = 0 and f = 1 drops the first term of the continued fraction, which is
+    # what this function did previously -- it returned 0.2285 for I_0.4(2,3)
+    # against a true value of 0.5248, and the error propagated into every
+    # t- and F-based p-value in this module.
     max_iter = 200
 
-    # Initialize
-    f = 1.0
+    d = 1.0 - (a + b) * x / (a + 1.0)
+    if abs(d) < _TINY:
+        d = _TINY
+    d = 1.0 / d
+    f = d
     c = 1.0
-    d = 0.0
 
     for m in range(1, max_iter):
         m_float = float(m)
@@ -312,99 +331,38 @@ def incomplete_beta(a: float, b: float, x: float) -> float:
     return front * f
 
 
-def standard_normal_cdf(z: float) -> float:
-    """CDF of standard normal distribution using error function."""
-    return 0.5 * (1.0 + math.erf(z / math.sqrt(2.0)))
-
-
 def inverse_t_cdf(p: float, df: int) -> float:
-    """Approximate inverse CDF (quantile function) of Student's t-distribution."""
-    if p <= 0.0 or p >= 1.0:
-        raise ValueError("p must be between 0 and 1")
+    """Inverse CDF (quantile function) of Student's t-distribution.
 
-    # For large df, use normal approximation
-    if df > 30:
-        return inverse_normal_cdf(p)
+    Obtained by bisecting :func:`t_cdf`, which is monotonic.  The previous
+    implementation used a third-order Cornish-Fisher expansion below df = 30
+    and a normal quantile above it; both were badly off in the tails -- 18% at
+    df = 5 and p = 0.975, 29% at p = 0.995 -- and that error went straight into
+    the t-critical value behind every confidence and prediction interval.
 
-    # For small df, use iterative approximation
-    # Start with normal approximation
-    z = inverse_normal_cdf(p)
+    Args:
+        p: Cumulative probability, strictly between 0 and 1.
+        df: Degrees of freedom; must be >= 1.
 
-    # Apply correction for finite df using Cornish-Fisher expansion
-    # This is a simplified 3rd-order approximation
-    g1 = (z * z - 1.0) / 4.0
-    g2 = (5.0 * z * z * z - 16.0 * z) / 96.0
+    Returns:
+        The t with ``P(T <= t) = p``.
 
-    t = z + g1 / df + g2 / (df * df)
-
-    return t
-
-
-def inverse_normal_cdf(p: float) -> float:
-    """Approximate inverse CDF of standard normal distribution.
-
-    Uses rational approximation (Beasley-Springer-Moro algorithm).
+    Raises:
+        ValueError: If ``p`` is not in (0, 1) or ``df`` < 1.
     """
     if p <= 0.0 or p >= 1.0:
         raise ValueError("p must be between 0 and 1")
+    if df < 1:
+        raise ValueError("Degrees of freedom must be at least 1")
 
-    # Coefficients for rational approximation
-    a = (
-        -3.969683028665376e1,
-        2.209460984245205e2,
-        -2.759285104469687e2,
-        1.383577518672690e2,
-        -3.066479806614716e1,
-        2.506628277459239e0,
-    )
-    b = (
-        -5.447609879822406e1,
-        1.615858368580409e2,
-        -1.556989798598866e2,
-        6.680131188771972e1,
-        -1.328068155288572e1,
-    )
-    c = (
-        -7.784894002430293e-3,
-        -3.223964580411365e-1,
-        -2.400758277161838e0,
-        -2.549732539343734e0,
-        4.374664141464968e0,
-        2.938163982698783e0,
-    )
-    d = (
-        7.784695709041462e-3,
-        3.224671290700398e-1,
-        2.445134137142996e0,
-        3.754408661907416e0,
-    )
-
-    p_low = 0.02425
-    p_high = 1.0 - p_low
-
-    # Rational approximation for lower region
-    if p < p_low:
-        q = math.sqrt(-2.0 * math.log(p))
-        x = (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / (
-            (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0
-        )
-        return x
-
-    # Rational approximation for upper region
-    if p > p_high:
-        q = math.sqrt(-2.0 * math.log(1.0 - p))
-        x = -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / (
-            (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0
-        )
-        return x
-
-    # Rational approximation for central region
-    q = p - 0.5
-    r = q * q
-    x = ((((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q) / (
-        ((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1.0
-    )
-    return x
+    low, high = -1.0e6, 1.0e6
+    for _ in range(200):
+        mid = (low + high) / 2.0
+        if t_cdf(mid, df) < p:
+            low = mid
+        else:
+            high = mid
+    return (low + high) / 2.0
 
 
 def f_statistic(model: RegressionResult) -> float:
@@ -438,8 +396,11 @@ def f_cdf(f: float, df1: int, df2: int) -> float:
     if math.isinf(f):
         return 1.0
 
-    x = df2 / (df2 + df1 * f)
-    return 1.0 - incomplete_beta(df2 / 2.0, df1 / 2.0, x)
+    # Direct form.  Computing this as 1 - I_x(df2/2, df1/2) subtracts a value
+    # near 1 from 1, and the caller then subtracts the result from 1 again to
+    # get the p-value, so the significant digits were lost twice over.
+    x = df1 * f / (df1 * f + df2)
+    return incomplete_beta(df1 / 2.0, df2 / 2.0, x)
 
 
 def p_value_t(t: float, df: int, sided: str = "two") -> float:

--- a/src/utils/logistic_regression.py
+++ b/src/utils/logistic_regression.py
@@ -1,0 +1,945 @@
+#!/usr/bin/env python3
+"""Command-line utility for binary logistic regression.
+
+Models the probability of a binary outcome as a sigmoid of a linear predictor:
+
+    P(y = 1 | x) = 1 / (1 + exp(-(b0 + b1*x1 + ... + bk*xk)))
+
+Fitted by Newton-Raphson (iteratively reweighted least squares), which
+converges in a handful of iterations on well-conditioned data and reports
+coefficients as odds ratios -- the form that travels to non-technical readers.
+
+The classification counterpart to ``linreg``: reach for this when the outcome
+is binary rather than continuous.
+
+Usage examples:
+  # Fit from a CSV, all non-target columns as features
+  logreg --file patient_data.csv --target disease
+
+  # Chosen features, lower cutoff to favour recall
+  logreg --file churn.csv --target churned --features tenure spend --threshold 0.3
+
+  # Score new observations with the fitted model
+  logreg --file train.csv --target clicked --predict-file new_users.csv
+
+  # JSON for downstream processing
+  logreg --file iris.csv --target setosa --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import sys
+from typing import Any
+
+import numpy as np
+
+# Convergence is declared when the largest absolute coefficient change between
+# Newton steps drops below this.
+_DEFAULT_TOL = 1e-8
+
+# Probabilities are clamped this far from 0 and 1 before taking logs, so a
+# saturated fit yields a large finite log-likelihood instead of -inf.
+_EPS = 1e-12
+
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def sigmoid(z: float) -> float:
+    """Logistic function, evaluated without overflowing on large |z|.
+
+    Args:
+        z: Linear predictor value.
+
+    Returns:
+        ``1 / (1 + exp(-z))`` in [0, 1].
+    """
+    if z >= 0.0:
+        return 1.0 / (1.0 + math.exp(-z))
+    exp_z = math.exp(z)
+    return exp_z / (1.0 + exp_z)
+
+
+def log_odds(p: float) -> float:
+    """Logit of a probability -- the inverse of :func:`sigmoid`.
+
+    Args:
+        p: Probability, strictly between 0 and 1.
+
+    Returns:
+        ``log(p / (1 - p))``.
+
+    Raises:
+        ValueError: If ``p`` is outside the open interval (0, 1), where the
+            logit is undefined.
+    """
+    if not 0.0 < p < 1.0:
+        raise ValueError(f"probability must be strictly between 0 and 1, got {p}")
+    return math.log(p / (1.0 - p))
+
+
+def _sigmoid_vec(z: np.ndarray) -> np.ndarray:
+    """Vectorised, overflow-safe sigmoid.
+
+    Args:
+        z: Array of linear predictor values.
+
+    Returns:
+        Array of probabilities the same shape as ``z``.
+    """
+    out = np.empty_like(z, dtype=float)
+    positive = z >= 0
+    out[positive] = 1.0 / (1.0 + np.exp(-z[positive]))
+    exp_z = np.exp(z[~positive])
+    out[~positive] = exp_z / (1.0 + exp_z)
+    return out
+
+
+def log_likelihood(y: np.ndarray, probs: np.ndarray) -> float:
+    """Bernoulli log-likelihood of the fitted probabilities.
+
+    Args:
+        y: Observed 0/1 outcomes.
+        probs: Fitted probabilities, same length as ``y``.
+
+    Returns:
+        ``sum(y*log(p) + (1-y)*log(1-p))``, with probabilities clamped away
+        from 0 and 1 so a saturated fit stays finite.
+    """
+    clipped = np.clip(probs, _EPS, 1.0 - _EPS)
+    return float(np.sum(y * np.log(clipped) + (1.0 - y) * np.log(1.0 - clipped)))
+
+
+def normal_sf(z: float) -> float:
+    """Upper-tail probability of the standard normal distribution.
+
+    Args:
+        z: Standard normal deviate.
+
+    Returns:
+        ``P(Z > z)``.
+    """
+    return 0.5 * math.erfc(z / math.sqrt(2.0))
+
+
+def two_sided_p(z: float) -> float:
+    """Two-sided normal p-value for a Wald z-statistic.
+
+    Args:
+        z: Wald statistic (coefficient divided by its standard error).
+
+    Returns:
+        ``2 * P(Z > |z|)``.
+    """
+    return 2.0 * normal_sf(abs(z))
+
+
+def _solve_information(hessian: np.ndarray, rhs: np.ndarray) -> np.ndarray:
+    """Solve against the information matrix, naming the failure it can hit.
+
+    Args:
+        hessian: Observed information matrix ``X' W X``.
+        rhs: Right-hand side -- the score vector for a Newton step, or the
+            identity matrix to obtain the covariance.
+
+    Returns:
+        The solution array.
+
+    Raises:
+        ValueError: If the matrix is singular, which means the predictors are
+            collinear or constant, or the classes are perfectly separated.
+    """
+    try:
+        return np.linalg.solve(hessian, rhs)
+    except np.linalg.LinAlgError as exc:
+        raise ValueError(
+            "the information matrix is singular: predictors are collinear, "
+            "constant, or the classes are perfectly separated"
+        ) from exc
+
+
+class LogisticModel:
+    """Fitted binary logistic regression and its inference statistics."""
+
+    def __init__(
+        self,
+        coefficients: list[float],
+        std_errors: list[float],
+        names: list[str],
+        loglik: float,
+        null_loglik: float,
+        n: int,
+        iterations: int,
+    ):
+        """Store a fit and derive its Wald statistics.
+
+        Args:
+            coefficients: Estimates, intercept first.
+            std_errors: Standard errors aligned with ``coefficients``.
+            names: Term names aligned with ``coefficients``.
+            loglik: Log-likelihood at the fitted coefficients.
+            null_loglik: Log-likelihood of the intercept-only model.
+            n: Number of observations.
+            iterations: Newton steps taken before convergence.
+        """
+        self.coefficients = coefficients
+        self.std_errors = std_errors
+        self.names = names
+        self.loglik = loglik
+        self.null_loglik = null_loglik
+        self.n = n
+        self.iterations = iterations
+
+        self.z_stats = [
+            coef / se if se > 0 else math.inf
+            for coef, se in zip(coefficients, std_errors)
+        ]
+        self.p_values = [two_sided_p(z) for z in self.z_stats]
+        self.odds_ratios = [math.exp(coef) for coef in coefficients]
+
+    @property
+    def k(self) -> int:
+        """Number of estimated parameters, intercept included."""
+        return len(self.coefficients)
+
+    @property
+    def aic(self) -> float:
+        """Akaike information criterion, ``2k - 2*loglik``."""
+        return 2.0 * self.k - 2.0 * self.loglik
+
+    @property
+    def bic(self) -> float:
+        """Bayesian information criterion, ``k*log(n) - 2*loglik``."""
+        return self.k * math.log(self.n) - 2.0 * self.loglik
+
+    @property
+    def pseudo_r2(self) -> float:
+        """McFadden's pseudo-R², ``1 - loglik / null_loglik``."""
+        if self.null_loglik == 0.0:
+            return 0.0
+        return 1.0 - self.loglik / self.null_loglik
+
+    def confidence_intervals(self, alpha: float) -> list[tuple[float, float]]:
+        """Wald confidence intervals for each coefficient.
+
+        Args:
+            alpha: Significance level, e.g. 0.05 for 95% intervals.
+
+        Returns:
+            ``(lower, upper)`` per coefficient, on the log-odds scale.
+        """
+        z_crit = normal_quantile(1.0 - alpha / 2.0)
+        return [
+            (coef - z_crit * se, coef + z_crit * se)
+            for coef, se in zip(self.coefficients, self.std_errors)
+        ]
+
+
+def normal_quantile(p: float) -> float:
+    """Inverse standard normal CDF via bisection on :func:`normal_sf`.
+
+    Args:
+        p: Cumulative probability, strictly between 0 and 1.
+
+    Returns:
+        The z with ``P(Z <= z) = p``.
+
+    Raises:
+        ValueError: If ``p`` is not in the open interval (0, 1).
+    """
+    if not 0.0 < p < 1.0:
+        raise ValueError(f"probability must be strictly between 0 and 1, got {p}")
+    low, high = -40.0, 40.0
+    for _ in range(200):
+        mid = (low + high) / 2.0
+        if 1.0 - normal_sf(mid) < p:
+            low = mid
+        else:
+            high = mid
+    return (low + high) / 2.0
+
+
+def fit(
+    features: list[list[float]],
+    outcomes: list[float],
+    names: list[str] | None = None,
+    max_iter: int = 50,
+    tol: float = _DEFAULT_TOL,
+) -> LogisticModel:
+    """Fit a binary logistic regression by Newton-Raphson (IRLS).
+
+    An intercept column is prepended automatically.
+
+    Args:
+        features: One row per observation, one value per predictor.
+        outcomes: Binary 0/1 outcomes, one per row.
+        names: Predictor names; defaults to ``x1``..``xk``.
+        max_iter: Maximum Newton steps before giving up.
+        tol: Convergence threshold on the largest coefficient change.
+
+    Returns:
+        The fitted :class:`LogisticModel`.
+
+    Raises:
+        ValueError: If the data are empty or ragged, the outcome is not
+            binary, there are fewer observations than parameters, the
+            predictors are collinear or the data perfectly separable, or the
+            fit fails to converge within ``max_iter``.
+    """
+    if not features:
+        raise ValueError("no observations to fit")
+    if len(features) != len(outcomes):
+        raise ValueError(
+            f"got {len(features)} feature rows but {len(outcomes)} outcomes"
+        )
+
+    width = len(features[0])
+    if width == 0:
+        raise ValueError("no predictor columns to fit")
+    if any(len(row) != width for row in features):
+        raise ValueError("all feature rows must have the same number of columns")
+
+    distinct = sorted(set(outcomes))
+    if distinct != [0.0, 1.0]:
+        raise ValueError(
+            "the target must be binary and take both values; got "
+            f"{[f'{v:g}' for v in distinct]}"
+        )
+
+    design = np.column_stack(
+        [np.ones(len(features)), np.asarray(features, dtype=float)]
+    )
+    y = np.asarray(outcomes, dtype=float)
+    n, k = design.shape
+    if n <= k:
+        raise ValueError(
+            f"need more observations than parameters, got n={n} and k={k}; "
+            "the fit would be exactly determined or underdetermined"
+        )
+
+    beta = np.zeros(k)
+    iterations = 0
+    for iterations in range(1, max_iter + 1):
+        eta = design @ beta
+        probs = _sigmoid_vec(eta)
+        weights = probs * (1.0 - probs)
+
+        hessian = design.T @ (design * weights[:, None])
+        gradient = design.T @ (y - probs)
+        step = _solve_information(hessian, gradient)
+
+        # No separate "coefficients diverged" guard here.  On separable data
+        # the weights collapse toward zero and the information matrix goes
+        # singular, or the step never shrinks below tol -- both already raise.
+        # Traced over separations from adjacent to 1e6 apart, the coefficients
+        # never ran away before one of those two fired.
+        beta = beta + step
+        if np.max(np.abs(step)) < tol:
+            break
+    else:
+        raise ValueError(
+            f"Newton-Raphson did not converge in {max_iter} iterations; "
+            "raise --max-iter or check for near-separable data"
+        )
+
+    probs = _sigmoid_vec(design @ beta)
+    weights = probs * (1.0 - probs)
+    hessian = design.T @ (design * weights[:, None])
+    covariance = _solve_information(hessian, np.eye(k))
+    std_errors = np.sqrt(np.abs(np.diag(covariance)))
+
+    base_rate = float(np.mean(y))
+    null_ll = float(
+        n
+        * (base_rate * math.log(base_rate) + (1 - base_rate) * math.log(1 - base_rate))
+    )
+    term_names = ["(intercept)"] + (
+        list(names) if names else [f"x{i + 1}" for i in range(width)]
+    )
+    return LogisticModel(
+        coefficients=[float(v) for v in beta],
+        std_errors=[float(v) for v in std_errors],
+        names=term_names,
+        loglik=log_likelihood(y, probs),
+        null_loglik=null_ll,
+        n=n,
+        iterations=iterations,
+    )
+
+
+def predict_proba(coefficients: list[float], row: list[float]) -> float:
+    """Predicted probability for one observation.
+
+    Args:
+        coefficients: Fitted coefficients, intercept first.
+        row: Predictor values, without the intercept.
+
+    Returns:
+        ``P(y = 1 | row)``.
+
+    Raises:
+        ValueError: If the row length does not match the coefficients.
+    """
+    if len(row) != len(coefficients) - 1:
+        raise ValueError(f"expected {len(coefficients) - 1} predictors, got {len(row)}")
+    total = coefficients[0] + sum(c * v for c, v in zip(coefficients[1:], row))
+    return sigmoid(total)
+
+
+def predict_class(probability: float, threshold: float = 0.5) -> int:
+    """Turn a probability into a 0/1 label.
+
+    Args:
+        probability: Predicted probability of the positive class.
+        threshold: Cutoff at or above which the label is 1.
+
+    Returns:
+        1 when ``probability >= threshold``, else 0.
+    """
+    return int(probability >= threshold)
+
+
+def confusion_matrix(actual: list[float], predicted: list[int]) -> dict[str, int]:
+    """Count the four outcome cells.
+
+    Args:
+        actual: Observed 0/1 outcomes.
+        predicted: Predicted 0/1 labels, same length.
+
+    Returns:
+        Mapping with ``tp``, ``fp``, ``tn``, and ``fn`` counts.
+
+    Raises:
+        ValueError: If the two sequences differ in length.
+    """
+    if len(actual) != len(predicted):
+        raise ValueError(
+            f"got {len(actual)} actual values but {len(predicted)} predictions"
+        )
+    cells = {"tp": 0, "fp": 0, "tn": 0, "fn": 0}
+    for truth, guess in zip(actual, predicted):
+        if truth == 1 and guess == 1:
+            cells["tp"] += 1
+        elif truth == 0 and guess == 1:
+            cells["fp"] += 1
+        elif truth == 0 and guess == 0:
+            cells["tn"] += 1
+        else:
+            cells["fn"] += 1
+    return cells
+
+
+def classification_metrics(cells: dict[str, int]) -> dict[str, float]:
+    """Accuracy, precision, recall, and F1 from a confusion matrix.
+
+    Precision, recall, and F1 are reported as 0.0 when their denominator is
+    zero -- a model that never predicts the positive class has no precision to
+    speak of, and saying 0 is clearer than refusing to answer.
+
+    Args:
+        cells: Mapping from :func:`confusion_matrix`.
+
+    Returns:
+        Mapping with ``accuracy``, ``precision``, ``recall``, and ``f1``.
+
+    Raises:
+        ValueError: If the matrix is empty.
+    """
+    tp, fp, tn, fn = cells["tp"], cells["fp"], cells["tn"], cells["fn"]
+    total = tp + fp + tn + fn
+    if total == 0:
+        raise ValueError("confusion matrix is empty")
+
+    precision = tp / (tp + fp) if tp + fp else 0.0
+    recall = tp / (tp + fn) if tp + fn else 0.0
+    f1 = 2.0 * precision * recall / (precision + recall) if precision + recall else 0.0
+    return {
+        "accuracy": (tp + tn) / total,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CSV input
+# ---------------------------------------------------------------------------
+
+
+def read_csv(path: str) -> tuple[list[str], list[dict[str, str]]]:
+    """Read a CSV with a header row.
+
+    Args:
+        path: Path to the file.
+
+    Returns:
+        ``(column_names, rows)`` where each row maps column name to raw text.
+
+    Raises:
+        ValueError: If the file is missing, unreadable, or has no header.
+    """
+    try:
+        with open(path, newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            if reader.fieldnames is None:
+                raise ValueError(f"{path} is empty; a header row is required")
+            return list(reader.fieldnames), [dict(row) for row in reader]
+    except OSError as exc:
+        raise ValueError(f"could not read {path}: {exc}") from exc
+
+
+def extract_columns(
+    rows: list[dict[str, str]], columns: list[str]
+) -> list[list[float]]:
+    """Pull named columns from CSV rows as floats.
+
+    Args:
+        rows: Rows from :func:`read_csv`.
+        columns: Column names to extract, in order.
+
+    Returns:
+        One list of floats per row.
+
+    Raises:
+        ValueError: If a column is missing or a value is not numeric.
+    """
+    table: list[list[float]] = []
+    for index, row in enumerate(rows, start=2):  # line 1 is the header
+        values: list[float] = []
+        for column in columns:
+            if column not in row or row[column] is None:
+                raise ValueError(f"column {column!r} missing on line {index}")
+            try:
+                values.append(float(row[column]))
+            except ValueError:
+                raise ValueError(
+                    f"column {column!r} on line {index} is not numeric: {row[column]!r}"
+                ) from None
+        table.append(values)
+    return table
+
+
+def encode_binary(values: list[float]) -> list[float]:
+    """Map a two-valued column onto 0 and 1.
+
+    Already-binary 0/1 columns pass through untouched; any other pair of values
+    is mapped with the smaller to 0 and the larger to 1.
+
+    Args:
+        values: Raw numeric target column.
+
+    Returns:
+        The column encoded as 0.0 and 1.0.
+
+    Raises:
+        ValueError: If the column does not take exactly two distinct values.
+    """
+    distinct = sorted(set(values))
+    if len(distinct) != 2:
+        raise ValueError(
+            "the target column must take exactly two distinct values, got "
+            f"{len(distinct)}: {[f'{v:g}' for v in distinct[:5]]}"
+        )
+    low, high = distinct
+    return [0.0 if value == low else 1.0 for value in values]
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and return the argument parser namespace.
+
+    Args:
+        argv: Argument list (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        Parsed :class:`argparse.Namespace`.
+    """
+    parser = argparse.ArgumentParser(
+        description="Binary logistic regression with odds ratios and fit metrics.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  logreg --file patient_data.csv --target disease
+  logreg --file churn.csv --target churned --features tenure spend --threshold 0.3
+  logreg --file train.csv --target clicked --predict-file new_users.csv
+  logreg --file iris.csv --target setosa --format json
+""",
+    )
+    parser.add_argument(
+        "--file",
+        required=True,
+        metavar="CSV",
+        help="training data with a header row",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        metavar="COL",
+        help="binary outcome column",
+    )
+    parser.add_argument(
+        "--features",
+        nargs="+",
+        default=None,
+        metavar="COL",
+        help="predictor columns (default: every column except the target)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        metavar="F",
+        help="probability cutoff for the positive class (default: 0.5)",
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=0.05,
+        metavar="F",
+        help="significance level for coefficient intervals (default: 0.05)",
+    )
+    parser.add_argument(
+        "--predict-file",
+        default=None,
+        metavar="CSV",
+        help="score these observations with the fitted model",
+    )
+    parser.add_argument(
+        "--max-iter",
+        type=int,
+        default=50,
+        metavar="INT",
+        help="maximum Newton-Raphson iterations (default: 50)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="output format (default: table)",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=4,
+        metavar="PREC",
+        help="decimal places for output (default: 4)",
+    )
+    return parser.parse_args(argv)
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Return an error message string, or ``None`` if arguments are valid.
+
+    Args:
+        args: Parsed argument namespace from :func:`parse_args`.
+
+    Returns:
+        Error description string, or ``None`` when validation passes.
+    """
+    if not 0.0 < args.threshold < 1.0:
+        return f"--threshold must be strictly between 0 and 1, got {args.threshold}"
+    if not 0.0 < args.alpha < 1.0:
+        return f"--alpha must be strictly between 0 and 1, got {args.alpha}"
+    if args.max_iter < 1:
+        return f"--max-iter must be >= 1, got {args.max_iter}"
+    if args.precision < 0:
+        return f"--precision must be non-negative, got {args.precision}"
+    if args.features is not None and args.target in args.features:
+        return f"the target column {args.target!r} cannot also be a feature"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Result assembly
+# ---------------------------------------------------------------------------
+
+
+def resolve_features(columns: list[str], args: argparse.Namespace) -> list[str]:
+    """Decide which columns are predictors.
+
+    Args:
+        columns: Every column in the training file.
+        args: Parsed argument namespace.
+
+    Returns:
+        Predictor column names.
+
+    Raises:
+        ValueError: If the target is absent, a named feature is absent, or no
+            predictors remain.
+    """
+    if args.target not in columns:
+        raise ValueError(
+            f"target column {args.target!r} not in file; available: "
+            f"{', '.join(columns)}"
+        )
+    if args.features is None:
+        features = [name for name in columns if name != args.target]
+    else:
+        missing = [name for name in args.features if name not in columns]
+        if missing:
+            raise ValueError(
+                f"feature column(s) not in file: {', '.join(missing)}; "
+                f"available: {', '.join(columns)}"
+            )
+        features = list(args.features)
+    if not features:
+        raise ValueError("no predictor columns left after removing the target")
+    return features
+
+
+def build_result(args: argparse.Namespace) -> dict[str, Any]:
+    """Fit the model and assemble every reported quantity.
+
+    Args:
+        args: Validated argument namespace from :func:`parse_args`.
+
+    Returns:
+        Result mapping ready for formatting.
+
+    Raises:
+        ValueError: On unreadable input, bad column selection, or a fit that
+            cannot converge.
+    """
+    columns, rows = read_csv(args.file)
+    if not rows:
+        raise ValueError(f"{args.file} has a header but no data rows")
+
+    feature_names = resolve_features(columns, args)
+    design = extract_columns(rows, feature_names)
+    raw_target = [values[0] for values in extract_columns(rows, [args.target])]
+    outcomes = encode_binary(raw_target)
+
+    model = fit(design, outcomes, names=feature_names, max_iter=args.max_iter)
+    intervals = model.confidence_intervals(args.alpha)
+
+    probabilities = [predict_proba(model.coefficients, row) for row in design]
+    labels = [predict_class(p, args.threshold) for p in probabilities]
+    cells = confusion_matrix(outcomes, labels)
+
+    result: dict[str, Any] = {
+        "n": model.n,
+        "features": feature_names,
+        "target": args.target,
+        "threshold": args.threshold,
+        "iterations": model.iterations,
+        "coefficients": [
+            {
+                "term": name,
+                "estimate": coef,
+                "std_error": se,
+                "z": z,
+                "p_value": p,
+                "odds_ratio": odds,
+                "ci_lower": lo,
+                "ci_upper": hi,
+            }
+            for name, coef, se, z, p, odds, (lo, hi) in zip(
+                model.names,
+                model.coefficients,
+                model.std_errors,
+                model.z_stats,
+                model.p_values,
+                model.odds_ratios,
+                intervals,
+            )
+        ],
+        "fit": {
+            "log_likelihood": model.loglik,
+            "null_log_likelihood": model.null_loglik,
+            "pseudo_r2": model.pseudo_r2,
+            "aic": model.aic,
+            "bic": model.bic,
+        },
+        "confusion": cells,
+        "metrics": classification_metrics(cells),
+    }
+
+    if args.predict_file is not None:
+        _, new_rows = read_csv(args.predict_file)
+        if not new_rows:
+            raise ValueError(f"{args.predict_file} has a header but no data rows")
+        new_design = extract_columns(new_rows, feature_names)
+        result["predictions"] = [
+            {
+                "row": index,
+                "probability": (prob := predict_proba(model.coefficients, row)),
+                "predicted": predict_class(prob, args.threshold),
+            }
+            for index, row in enumerate(new_design, start=1)
+        ]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(value: float, precision: int) -> str:
+    """Format a float to fixed precision.
+
+    Args:
+        value: Number to render.
+        precision: Decimal places.
+
+    Returns:
+        Formatted string, or ``inf`` for a non-finite value.
+    """
+    if not math.isfinite(value):
+        return "inf" if value > 0 else "-inf"
+    return f"{value:.{precision}f}"
+
+
+def _stars(p_value: float) -> str:
+    """Conventional significance markers for a p-value.
+
+    Args:
+        p_value: Two-sided p-value.
+
+    Returns:
+        ``***``, ``**``, ``*``, ``.``, or an empty string.
+    """
+    if p_value < 0.001:
+        return "***"
+    if p_value < 0.01:
+        return "**"
+    if p_value < 0.05:
+        return "*"
+    if p_value < 0.1:
+        return "."
+    return ""
+
+
+def format_table(result: dict[str, Any], precision: int) -> str:
+    """Render the result as an aligned plain-text report.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+        precision: Decimal places for numeric output.
+
+    Returns:
+        Multi-line report string.
+    """
+    width = max(len(row["term"]) for row in result["coefficients"])
+    lines = [
+        f"Logistic regression: {result['target']} ~ {' + '.join(result['features'])}",
+        f"n = {result['n']}, converged in {result['iterations']} iterations",
+        "",
+        "Coefficients",
+        "------------",
+        f"  {'term':<{width}}  {'estimate':>12}  {'std.err':>10}  {'z':>8}  "
+        f"{'p':>10}  {'odds ratio':>12}",
+    ]
+    for row in result["coefficients"]:
+        lines.append(
+            f"  {row['term']:<{width}}  {_fmt(row['estimate'], precision):>12}  "
+            f"{_fmt(row['std_error'], precision):>10}  {_fmt(row['z'], 3):>8}  "
+            f"{_fmt(row['p_value'], 4):>10}  "
+            f"{_fmt(row['odds_ratio'], precision):>12} {_stars(row['p_value'])}"
+        )
+    lines.append("")
+    lines.append("  Signif. codes: *** p<0.001, ** p<0.01, * p<0.05, . p<0.1")
+
+    fit_stats = result["fit"]
+    lines += [
+        "",
+        "Model fit",
+        "---------",
+        f"  Log-likelihood:      {_fmt(fit_stats['log_likelihood'], precision)}",
+        f"  Null log-likelihood: {_fmt(fit_stats['null_log_likelihood'], precision)}",
+        f"  McFadden pseudo-R²:  {_fmt(fit_stats['pseudo_r2'], precision)}",
+        f"  AIC:                 {_fmt(fit_stats['aic'], precision)}",
+        f"  BIC:                 {_fmt(fit_stats['bic'], precision)}",
+    ]
+
+    cells = result["confusion"]
+    metrics = result["metrics"]
+    lines += [
+        "",
+        f"Classification at threshold {result['threshold']:g}",
+        "-" * (28 + len(f"{result['threshold']:g}")),
+        f"  {'':<12}{'pred 0':>8}{'pred 1':>8}",
+        f"  {'actual 0':<12}{cells['tn']:>8}{cells['fp']:>8}",
+        f"  {'actual 1':<12}{cells['fn']:>8}{cells['tp']:>8}",
+        "",
+        f"  Accuracy:   {_fmt(metrics['accuracy'], precision)}",
+        f"  Precision:  {_fmt(metrics['precision'], precision)}",
+        f"  Recall:     {_fmt(metrics['recall'], precision)}",
+        f"  F1:         {_fmt(metrics['f1'], precision)}",
+    ]
+
+    if "predictions" in result:
+        lines += [
+            "",
+            "Predictions",
+            "-----------",
+            f"  {'row':>5}  {'probability':>12}  {'class':>5}",
+        ]
+        for row in result["predictions"]:
+            lines.append(
+                f"  {row['row']:>5}  {_fmt(row['probability'], precision):>12}  "
+                f"{row['predicted']:>5}"
+            )
+    return "\n".join(lines)
+
+
+def format_json(result: dict[str, Any]) -> str:
+    """Render the result as indented JSON.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+
+    Returns:
+        JSON document string.
+    """
+    return json.dumps(result, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the logistic regression CLI.
+
+    Args:
+        argv: Argument list override for testing (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        0 on success, 2 on input or computation error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        result = build_result(args)
+        if args.format == "json":
+            print(format_json(result))
+        else:
+            print(format_table(result, args.precision))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/multiple_regression.py
+++ b/src/utils/multiple_regression.py
@@ -1,0 +1,854 @@
+#!/usr/bin/env python3
+"""Command-line utility for multiple linear regression with prediction intervals.
+
+Fits ordinary least squares across several predictors:
+
+    y = b0 + b1*x1 + ... + bk*xk + e
+
+and reports the full inference set -- coefficient estimates with standard
+errors, t-statistics, p-values, and confidence intervals; model fit via R²,
+adjusted R², residual standard error, and the overall F-test; optional variance
+inflation factors; and predictions carrying both interval kinds.
+
+The distinction between the two intervals is the point of the tool.  A
+confidence interval covers the *mean* response at a set of predictor values; a
+prediction interval covers a *single new observation* and is always wider,
+because it must absorb the residual scatter as well as the uncertainty in the
+fitted surface.
+
+Extends ``linreg`` from one predictor to many.
+
+Usage examples:
+  # Fit from a CSV, every non-target column as a predictor
+  mlreg --file housing.csv --target price
+
+  # Chosen predictors, with multicollinearity diagnostics
+  mlreg --file data.csv --target sales --features advertising headcount --vif
+
+  # Predict new observations with 90% intervals
+  mlreg --file train.csv --target output --predict-file new_inputs.csv --alpha 0.10
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import sys
+from typing import Any
+
+import numpy as np
+
+# The exact regularised incomplete beta and its F/t tail functions already live
+# in the ANOVA module, verified there against scipy.  They are imported rather
+# than copied: the equivalents in linear_regression.py substitute a normal
+# approximation above df = 30, which would quietly bias coefficient p-values on
+# any dataset larger than a few dozen rows.
+from src.utils.anova import regularized_incomplete_beta, t_sf_two_sided
+
+# A design matrix whose condition number exceeds this is treated as rank
+# deficient for reporting purposes even when numpy can still factor it.
+_CONDITION_LIMIT = 1e12
+
+
+# ---------------------------------------------------------------------------
+# Distribution helpers
+# ---------------------------------------------------------------------------
+
+
+def f_sf(f_stat: float, df1: int, df2: int) -> float:
+    """Upper-tail probability ``P(F > f_stat)`` for F(df1, df2).
+
+    Evaluated straight from the incomplete-beta identity rather than as
+    ``1 - cdf``.  The subtraction form cancels catastrophically in the far
+    tail: for F = 1417 on (2, 37) df the CDF rounds to exactly 1.0, so
+    ``1 - cdf`` reports a p-value of 0 where the true value is near 1e-35.
+    Highly significant models are exactly where that matters.
+
+    Args:
+        f_stat: Observed F-statistic; must be >= 0.
+        df1: Numerator degrees of freedom; must be >= 1.
+        df2: Denominator degrees of freedom; must be >= 1.
+
+    Returns:
+        ``P(F > f_stat)`` in [0, 1].
+
+    Raises:
+        ValueError: If ``df1``/``df2`` < 1 or ``f_stat`` < 0.
+    """
+    if df1 < 1 or df2 < 1:
+        raise ValueError(f"df1 and df2 must be >= 1, got df1={df1}, df2={df2}")
+    if f_stat < 0:
+        raise ValueError(f"f_stat must be >= 0, got {f_stat}")
+    if f_stat == 0:
+        return 1.0
+    if math.isinf(f_stat):
+        return 0.0
+    return regularized_incomplete_beta(df2 / (df2 + df1 * f_stat), df2 / 2, df1 / 2)
+
+
+def t_cdf(t_stat: float, df: float) -> float:
+    """Cumulative distribution function of Student's t.
+
+    Args:
+        t_stat: Evaluation point.
+        df: Degrees of freedom; must be > 0.
+
+    Returns:
+        ``P(T <= t_stat)`` in [0, 1].
+
+    Raises:
+        ValueError: If ``df`` <= 0.
+    """
+    if df <= 0:
+        raise ValueError(f"df must be > 0, got {df}")
+    tail = 0.5 * regularized_incomplete_beta(df / (df + t_stat * t_stat), df / 2, 0.5)
+    return 1.0 - tail if t_stat > 0 else tail
+
+
+def t_quantile(p: float, df: float) -> float:
+    """Inverse CDF of Student's t, by bisection on :func:`t_cdf`.
+
+    Args:
+        p: Cumulative probability, strictly between 0 and 1.
+        df: Degrees of freedom; must be > 0.
+
+    Returns:
+        The t with ``P(T <= t) = p``.
+
+    Raises:
+        ValueError: If ``p`` is not in (0, 1) or ``df`` <= 0.
+    """
+    if not 0.0 < p < 1.0:
+        raise ValueError(f"probability must be strictly between 0 and 1, got {p}")
+    if df <= 0:
+        raise ValueError(f"df must be > 0, got {df}")
+
+    low, high = -1e4, 1e4
+    for _ in range(300):
+        mid = (low + high) / 2.0
+        if t_cdf(mid, df) < p:
+            low = mid
+        else:
+            high = mid
+    return (low + high) / 2.0
+
+
+# ---------------------------------------------------------------------------
+# Core model
+# ---------------------------------------------------------------------------
+
+
+class MultipleRegression:
+    """A fitted OLS model and everything derived from it."""
+
+    def __init__(
+        self,
+        coefficients: list[float],
+        names: list[str],
+        xtx_inv: np.ndarray,
+        residuals: np.ndarray,
+        fitted: np.ndarray,
+        observed: np.ndarray,
+    ):
+        """Derive inference statistics from a completed least-squares solve.
+
+        Args:
+            coefficients: Estimates, intercept first.
+            names: Term names aligned with ``coefficients``.
+            xtx_inv: Inverse of ``X'X`` for the design matrix with intercept.
+            residuals: Observed minus fitted values.
+            fitted: Fitted values.
+            observed: Observed response values.
+        """
+        self.coefficients = coefficients
+        self.names = names
+        self.xtx_inv = xtx_inv
+        self.residuals = residuals
+        self.fitted = fitted
+        self.observed = observed
+
+        self.n = len(observed)
+        self.k = len(coefficients)
+        self.df = self.n - self.k
+
+        self.sse = float(np.sum(residuals**2))
+        self.sst = float(np.sum((observed - np.mean(observed)) ** 2))
+        self.ssr = self.sst - self.sse
+
+        self.mse = self.sse / self.df
+        self.residual_std_error = math.sqrt(self.mse)
+
+        self.std_errors = [
+            math.sqrt(self.mse * max(value, 0.0)) for value in np.diag(xtx_inv)
+        ]
+        self.t_stats = [
+            coef / se if se > 0 else math.inf
+            for coef, se in zip(coefficients, self.std_errors)
+        ]
+        self.p_values = [t_sf_two_sided(t, self.df) for t in self.t_stats]
+
+    @property
+    def r_squared(self) -> float:
+        """Fraction of the response variance the model explains."""
+        return 1.0 - self.sse / self.sst
+
+    @property
+    def adj_r_squared(self) -> float:
+        """R² penalised for the number of predictors."""
+        return 1.0 - (1.0 - self.r_squared) * (self.n - 1) / self.df
+
+    @property
+    def df_model(self) -> int:
+        """Numerator degrees of freedom for the overall F-test."""
+        return self.k - 1
+
+    @property
+    def f_statistic(self) -> float:
+        """Overall F-statistic against the intercept-only model.
+
+        No zero-denominator guard is needed: ``fit`` rejects a model with no
+        predictors and one whose response is constant, and normal-equation
+        roundoff leaves the residual mean square strictly positive even on an
+        exactly-linear response -- around 1e-30 rather than 0.
+        """
+        return (self.ssr / self.df_model) / self.mse
+
+    @property
+    def f_p_value(self) -> float:
+        """p-value for the overall F-test."""
+        return f_sf(self.f_statistic, self.df_model, self.df)
+
+    def confidence_intervals(self, alpha: float) -> list[tuple[float, float]]:
+        """Two-sided intervals for each coefficient.
+
+        Args:
+            alpha: Significance level, e.g. 0.05 for 95% intervals.
+
+        Returns:
+            ``(lower, upper)`` per coefficient.
+        """
+        crit = t_quantile(1.0 - alpha / 2.0, self.df)
+        return [
+            (coef - crit * se, coef + crit * se)
+            for coef, se in zip(self.coefficients, self.std_errors)
+        ]
+
+
+def fit(
+    features: list[list[float]],
+    outcomes: list[float],
+    names: list[str] | None = None,
+) -> MultipleRegression:
+    """Fit OLS with an automatically prepended intercept.
+
+    Args:
+        features: One row per observation, one value per predictor.
+        outcomes: Response values, one per row.
+        names: Predictor names; defaults to ``x1``..``xk``.
+
+    Returns:
+        The fitted :class:`MultipleRegression`.
+
+    Raises:
+        ValueError: If the data are empty or ragged, the row counts disagree,
+            there are no residual degrees of freedom, or the predictors are
+            collinear.
+    """
+    if not features:
+        raise ValueError("no observations to fit")
+    if len(features) != len(outcomes):
+        raise ValueError(
+            f"got {len(features)} feature rows but {len(outcomes)} responses"
+        )
+
+    width = len(features[0])
+    if width == 0:
+        raise ValueError("no predictor columns to fit")
+    if any(len(row) != width for row in features):
+        raise ValueError("all feature rows must have the same number of columns")
+
+    design = np.column_stack(
+        [np.ones(len(features)), np.asarray(features, dtype=float)]
+    )
+    y = np.asarray(outcomes, dtype=float)
+    n, k = design.shape
+    if n <= k:
+        raise ValueError(
+            f"need more observations than parameters, got n={n} and k={k}; "
+            "with no residual degrees of freedom the fit cannot be tested"
+        )
+
+    if float(np.var(y)) == 0.0:
+        raise ValueError(
+            f"the response is constant at {y[0]:g}; there is no variance to "
+            "explain and no F-test to run"
+        )
+
+    gram = design.T @ design
+    if np.linalg.matrix_rank(gram) < k or np.linalg.cond(gram) > _CONDITION_LIMIT:
+        raise ValueError(
+            "the predictors are collinear: X'X is rank deficient, so the "
+            "coefficients are not identified; drop or combine redundant columns"
+        )
+
+    xtx_inv = np.linalg.inv(gram)
+    beta = xtx_inv @ design.T @ y
+    fitted = design @ beta
+
+    return MultipleRegression(
+        coefficients=[float(v) for v in beta],
+        names=["(intercept)"]
+        + (list(names) if names else [f"x{i + 1}" for i in range(width)]),
+        xtx_inv=xtx_inv,
+        residuals=y - fitted,
+        fitted=fitted,
+        observed=y,
+    )
+
+
+def predict(
+    model: MultipleRegression, row: list[float], alpha: float = 0.05
+) -> dict[str, float]:
+    """Point estimate with both interval kinds for one new observation.
+
+    Args:
+        model: A fitted :class:`MultipleRegression`.
+        row: Predictor values, without the intercept.
+        alpha: Significance level for the intervals.
+
+    Returns:
+        Mapping with ``fit``, ``ci_lower``, ``ci_upper``, ``pi_lower``,
+        ``pi_upper``, and the two standard errors behind them.
+
+    Raises:
+        ValueError: If the row width does not match the model.
+    """
+    if len(row) != model.k - 1:
+        raise ValueError(f"expected {model.k - 1} predictors, got {len(row)}")
+
+    x0 = np.concatenate([[1.0], np.asarray(row, dtype=float)])
+    point = float(x0 @ np.asarray(model.coefficients))
+
+    leverage = float(x0 @ model.xtx_inv @ x0)
+    se_mean = math.sqrt(model.mse * max(leverage, 0.0))
+    se_single = math.sqrt(model.mse * (1.0 + max(leverage, 0.0)))
+    crit = t_quantile(1.0 - alpha / 2.0, model.df)
+
+    return {
+        "fit": point,
+        "se_mean": se_mean,
+        "se_single": se_single,
+        "ci_lower": point - crit * se_mean,
+        "ci_upper": point + crit * se_mean,
+        "pi_lower": point - crit * se_single,
+        "pi_upper": point + crit * se_single,
+    }
+
+
+def variance_inflation_factors(features: list[list[float]]) -> list[float]:
+    """Variance inflation factor for each predictor.
+
+    Each VIF is ``1 / (1 - R²)`` from regressing that predictor on all the
+    others.  Values above roughly 5 to 10 are the usual multicollinearity
+    warning.
+
+    Args:
+        features: One row per observation, one value per predictor.
+
+    Returns:
+        One VIF per predictor column, ``inf`` where a predictor is an exact
+        linear combination of the others.
+
+    Raises:
+        ValueError: If there are fewer than two predictors, which leaves
+            nothing to regress against.
+    """
+    matrix = np.asarray(features, dtype=float)
+    if matrix.ndim != 2 or matrix.shape[1] < 2:
+        raise ValueError("variance inflation needs at least two predictors")
+
+    factors: list[float] = []
+    for index in range(matrix.shape[1]):
+        target = matrix[:, index]
+        others = np.delete(matrix, index, axis=1)
+        design = np.column_stack([np.ones(len(others)), others])
+
+        coefficients, *_ = np.linalg.lstsq(design, target, rcond=None)
+        residuals = target - design @ coefficients
+        total = float(np.sum((target - np.mean(target)) ** 2))
+        if total == 0:
+            factors.append(math.inf)
+            continue
+        r_squared = 1.0 - float(np.sum(residuals**2)) / total
+        factors.append(math.inf if r_squared >= 1.0 else 1.0 / (1.0 - r_squared))
+    return factors
+
+
+# ---------------------------------------------------------------------------
+# CSV input
+# ---------------------------------------------------------------------------
+
+
+def read_csv(path: str) -> tuple[list[str], list[dict[str, str]]]:
+    """Read a CSV with a header row.
+
+    Args:
+        path: Path to the file.
+
+    Returns:
+        ``(column_names, rows)`` where each row maps column name to raw text.
+
+    Raises:
+        ValueError: If the file is missing, unreadable, or has no header.
+    """
+    try:
+        with open(path, newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            if reader.fieldnames is None:
+                raise ValueError(f"{path} is empty; a header row is required")
+            return list(reader.fieldnames), [dict(row) for row in reader]
+    except OSError as exc:
+        raise ValueError(f"could not read {path}: {exc}") from exc
+
+
+def extract_columns(
+    rows: list[dict[str, str]], columns: list[str]
+) -> list[list[float]]:
+    """Pull named columns from CSV rows as floats.
+
+    Args:
+        rows: Rows from :func:`read_csv`.
+        columns: Column names to extract, in order.
+
+    Returns:
+        One list of floats per row.
+
+    Raises:
+        ValueError: If a column is missing or a value is not numeric.
+    """
+    table: list[list[float]] = []
+    for index, row in enumerate(rows, start=2):  # line 1 is the header
+        values: list[float] = []
+        for column in columns:
+            if column not in row or row[column] is None:
+                raise ValueError(f"column {column!r} missing on line {index}")
+            try:
+                values.append(float(row[column]))
+            except ValueError:
+                raise ValueError(
+                    f"column {column!r} on line {index} is not numeric: {row[column]!r}"
+                ) from None
+        table.append(values)
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and return the argument parser namespace.
+
+    Args:
+        argv: Argument list (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        Parsed :class:`argparse.Namespace`.
+    """
+    parser = argparse.ArgumentParser(
+        description="Multiple linear regression with confidence and prediction "
+        "intervals.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  mlreg --file housing.csv --target price
+  mlreg --file data.csv --target sales --features advertising headcount --vif
+  mlreg --file train.csv --target output --predict-file new_inputs.csv --alpha 0.10
+""",
+    )
+    parser.add_argument(
+        "--file",
+        required=True,
+        metavar="CSV",
+        help="training data with a header row",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        metavar="COL",
+        help="response column",
+    )
+    parser.add_argument(
+        "--features",
+        nargs="+",
+        default=None,
+        metavar="COL",
+        help="predictor columns (default: every column except the target)",
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=0.05,
+        metavar="F",
+        help="significance level for all intervals (default: 0.05)",
+    )
+    parser.add_argument(
+        "--predict-file",
+        default=None,
+        metavar="CSV",
+        help="predict these observations, with both interval kinds",
+    )
+    parser.add_argument(
+        "--vif",
+        action="store_true",
+        help="report variance inflation factors for multicollinearity",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json", "csv"],
+        default="table",
+        help="output format (default: table)",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=4,
+        metavar="PREC",
+        help="decimal places for output (default: 4)",
+    )
+    return parser.parse_args(argv)
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Return an error message string, or ``None`` if arguments are valid.
+
+    Args:
+        args: Parsed argument namespace from :func:`parse_args`.
+
+    Returns:
+        Error description string, or ``None`` when validation passes.
+    """
+    if not 0.0 < args.alpha < 1.0:
+        return f"--alpha must be strictly between 0 and 1, got {args.alpha}"
+    if args.precision < 0:
+        return f"--precision must be non-negative, got {args.precision}"
+    if args.features is not None and args.target in args.features:
+        return f"the target column {args.target!r} cannot also be a feature"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Result assembly
+# ---------------------------------------------------------------------------
+
+
+def resolve_features(columns: list[str], args: argparse.Namespace) -> list[str]:
+    """Decide which columns are predictors.
+
+    Args:
+        columns: Every column in the training file.
+        args: Parsed argument namespace.
+
+    Returns:
+        Predictor column names.
+
+    Raises:
+        ValueError: If the target is absent, a named feature is absent, or no
+            predictors remain.
+    """
+    if args.target not in columns:
+        raise ValueError(
+            f"target column {args.target!r} not in file; available: "
+            f"{', '.join(columns)}"
+        )
+    if args.features is None:
+        features = [name for name in columns if name != args.target]
+    else:
+        missing = [name for name in args.features if name not in columns]
+        if missing:
+            raise ValueError(
+                f"feature column(s) not in file: {', '.join(missing)}; "
+                f"available: {', '.join(columns)}"
+            )
+        features = list(args.features)
+    if not features:
+        raise ValueError("no predictor columns left after removing the target")
+    return features
+
+
+def build_result(args: argparse.Namespace) -> dict[str, Any]:
+    """Fit the model and assemble every reported quantity.
+
+    Args:
+        args: Validated argument namespace from :func:`parse_args`.
+
+    Returns:
+        Result mapping ready for formatting.
+
+    Raises:
+        ValueError: On unreadable input, bad column selection, or a design
+            matrix that cannot be fitted.
+    """
+    columns, rows = read_csv(args.file)
+    if not rows:
+        raise ValueError(f"{args.file} has a header but no data rows")
+
+    feature_names = resolve_features(columns, args)
+    design = extract_columns(rows, feature_names)
+    response = [values[0] for values in extract_columns(rows, [args.target])]
+
+    model = fit(design, response, names=feature_names)
+    intervals = model.confidence_intervals(args.alpha)
+
+    result: dict[str, Any] = {
+        "n": model.n,
+        "target": args.target,
+        "features": feature_names,
+        "alpha": args.alpha,
+        "coefficients": [
+            {
+                "term": name,
+                "estimate": coef,
+                "std_error": se,
+                "t": t_stat,
+                "p_value": p,
+                "ci_lower": low,
+                "ci_upper": high,
+            }
+            for name, coef, se, t_stat, p, (low, high) in zip(
+                model.names,
+                model.coefficients,
+                model.std_errors,
+                model.t_stats,
+                model.p_values,
+                intervals,
+            )
+        ],
+        "fit": {
+            "r_squared": model.r_squared,
+            "adj_r_squared": model.adj_r_squared,
+            "residual_std_error": model.residual_std_error,
+            "df": model.df,
+            "f_statistic": model.f_statistic,
+            "f_df": [model.df_model, model.df],
+            "f_p_value": model.f_p_value,
+        },
+    }
+
+    if args.vif:
+        if len(feature_names) < 2:
+            raise ValueError(
+                "--vif needs at least two predictors; with one there is nothing "
+                "for it to be collinear with"
+            )
+        result["vif"] = [
+            {"term": name, "vif": value}
+            for name, value in zip(feature_names, variance_inflation_factors(design))
+        ]
+
+    if args.predict_file is not None:
+        _, new_rows = read_csv(args.predict_file)
+        if not new_rows:
+            raise ValueError(f"{args.predict_file} has a header but no data rows")
+        result["predictions"] = [
+            {"row": index, **predict(model, row, args.alpha)}
+            for index, row in enumerate(
+                extract_columns(new_rows, feature_names), start=1
+            )
+        ]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(value: float, precision: int) -> str:
+    """Format a float to fixed precision.
+
+    Args:
+        value: Number to render.
+        precision: Decimal places.
+
+    Returns:
+        Formatted string, or ``inf`` for a non-finite value.
+    """
+    if not math.isfinite(value):
+        return "inf" if value > 0 else "-inf"
+    return f"{value:.{precision}f}"
+
+
+def _stars(p_value: float) -> str:
+    """Conventional significance markers for a p-value.
+
+    Args:
+        p_value: Two-sided p-value.
+
+    Returns:
+        ``***``, ``**``, ``*``, ``.``, or an empty string.
+    """
+    if p_value < 0.001:
+        return "***"
+    if p_value < 0.01:
+        return "**"
+    if p_value < 0.05:
+        return "*"
+    if p_value < 0.1:
+        return "."
+    return ""
+
+
+def format_table(result: dict[str, Any], precision: int) -> str:
+    """Render the result as an aligned plain-text report.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+        precision: Decimal places for numeric output.
+
+    Returns:
+        Multi-line report string.
+    """
+    level = int(round((1.0 - result["alpha"]) * 100))
+    width = max(len(row["term"]) for row in result["coefficients"])
+    lines = [
+        f"Multiple regression: {result['target']} ~ {' + '.join(result['features'])}",
+        f"n = {result['n']}",
+        "",
+        "Coefficients",
+        "------------",
+        f"  {'term':<{width}}  {'estimate':>12}  {'std.err':>10}  {'t':>8}  "
+        f"{'p':>10}  {f'{level}% CI':>26}",
+    ]
+    for row in result["coefficients"]:
+        interval = (
+            f"[{_fmt(row['ci_lower'], precision)}, {_fmt(row['ci_upper'], precision)}]"
+        )
+        lines.append(
+            f"  {row['term']:<{width}}  {_fmt(row['estimate'], precision):>12}  "
+            f"{_fmt(row['std_error'], precision):>10}  {_fmt(row['t'], 3):>8}  "
+            f"{_fmt(row['p_value'], 4):>10}  {interval:>26} {_stars(row['p_value'])}"
+        )
+    lines.append("")
+    lines.append("  Signif. codes: *** p<0.001, ** p<0.01, * p<0.05, . p<0.1")
+
+    stats = result["fit"]
+    lines += [
+        "",
+        "Model fit",
+        "---------",
+        f"  R²:                    {_fmt(stats['r_squared'], precision)}",
+        f"  Adjusted R²:           {_fmt(stats['adj_r_squared'], precision)}",
+        f"  Residual std error:    {_fmt(stats['residual_std_error'], precision)}"
+        f" on {stats['df']} df",
+        f"  F-statistic:           {_fmt(stats['f_statistic'], precision)}"
+        f" on {stats['f_df'][0]} and {stats['f_df'][1]} df",
+        f"  Overall p-value:       {_fmt(stats['f_p_value'], 6)}",
+    ]
+
+    if "vif" in result:
+        lines += ["", "Variance inflation", "------------------"]
+        for row in result["vif"]:
+            flag = "  <- multicollinear" if row["vif"] > 10 else ""
+            lines.append(
+                f"  {row['term']:<{width}}  {_fmt(row['vif'], precision):>10}{flag}"
+            )
+
+    if "predictions" in result:
+        lines += [
+            "",
+            f"Predictions ({level}% intervals)",
+            "-" * len(f"Predictions ({level}% intervals)"),
+            f"  {'row':>5}  {'fit':>12}  {'CI (mean)':>26}  {'PI (single)':>26}",
+        ]
+        for row in result["predictions"]:
+            ci = f"[{_fmt(row['ci_lower'], precision)}, {_fmt(row['ci_upper'], precision)}]"
+            pi = f"[{_fmt(row['pi_lower'], precision)}, {_fmt(row['pi_upper'], precision)}]"
+            lines.append(
+                f"  {row['row']:>5}  {_fmt(row['fit'], precision):>12}  "
+                f"{ci:>26}  {pi:>26}"
+            )
+    return "\n".join(lines)
+
+
+def format_csv(result: dict[str, Any], precision: int) -> str:
+    """Render the coefficient table, and predictions if present, as CSV.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+        precision: Decimal places for numeric output.
+
+    Returns:
+        CSV document string.
+    """
+    lines = ["section,term,estimate,std_error,t,p_value,ci_lower,ci_upper"]
+    for row in result["coefficients"]:
+        lines.append(
+            "coefficient,"
+            f"{row['term']},{_fmt(row['estimate'], precision)},"
+            f"{_fmt(row['std_error'], precision)},{_fmt(row['t'], precision)},"
+            f"{_fmt(row['p_value'], precision)},{_fmt(row['ci_lower'], precision)},"
+            f"{_fmt(row['ci_upper'], precision)}"
+        )
+    for row in result.get("predictions", []):
+        lines.append(
+            f"prediction,{row['row']},{_fmt(row['fit'], precision)},,,"
+            f",{_fmt(row['pi_lower'], precision)},{_fmt(row['pi_upper'], precision)}"
+        )
+    return "\n".join(lines)
+
+
+def format_json(result: dict[str, Any]) -> str:
+    """Render the result as indented JSON.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+
+    Returns:
+        JSON document string.
+    """
+    return json.dumps(result, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the multiple regression CLI.
+
+    Args:
+        argv: Argument list override for testing (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        0 on success, 2 on input or computation error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        result = build_result(args)
+        if args.format == "json":
+            print(format_json(result))
+        elif args.format == "csv":
+            print(format_csv(result, args.precision))
+        else:
+            print(format_table(result, args.precision))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/slope_intercept.py
+++ b/src/utils/slope_intercept.py
@@ -1,0 +1,957 @@
+#!/usr/bin/env python3
+"""Command-line utility for lines in slope-intercept form.
+
+Builds a line from whatever is known, converts between the three standard
+representations, and evaluates, intersects, or projects onto it:
+
+    y = m * x + b
+
+Distinct from ``linreg``: ``linreg`` *estimates* a line from noisy sample data
+with standard errors and p-values, while this tool manipulates an *exact*,
+known line.  The two pair naturally -- ``linreg`` produces ``m`` and ``b``,
+``slopeint`` consumes them.
+
+Pure Python via ``math`` and ``fractions`` -- no external dependencies.
+
+Usage examples:
+  # Unit conversion: Fahrenheit from Celsius, y = 1.8x + 32
+  slopeint --points 0,32 100,212
+
+  # Evaluate that line at 37 degrees C
+  slopeint --slope 1.8 --intercept 32 --at 37
+
+  # Straight-line depreciation schedule
+  slopeint --points 0,30000 5,5000 --table 0 5 1
+
+  # Break-even as an intersection of a cost line and a revenue line
+  slopeint --slope 10 --intercept 50000 --intersect 25,0
+
+  # Perpendicular line through a point, and the distance to it
+  slopeint --slope 2 --intercept 1 --point 4,3 --perpendicular
+  slopeint --slope 2 --intercept 1 --point 4,3 --distance
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from fractions import Fraction
+from typing import Any
+
+Point = tuple[float, float]
+Line = tuple[float, float]
+
+# Tolerance for the parallel and perpendicular predicates.  Exact float
+# equality is wrong here: a slope derived from two points rarely lands on the
+# same bit pattern as the same slope typed in directly.
+_TOL = 1e-9
+
+# Denominator cap when rationalising a float slope for standard form.  Large
+# enough for any decimal a user types, small enough to keep coefficients sane.
+_MAX_DENOM = 1_000_000
+
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def slope(p1: Point, p2: Point) -> float:
+    """Slope of the line through two points.
+
+    Args:
+        p1: First point as ``(x, y)``.
+        p2: Second point as ``(x, y)``.
+
+    Returns:
+        Rise over run, ``(y2 - y1) / (x2 - x1)``.
+
+    Raises:
+        ValueError: If the points share an x coordinate (vertical line, slope
+            undefined) or are the same point.
+    """
+    (x1, y1), (x2, y2) = p1, p2
+    if x1 == x2:
+        if y1 == y2:
+            raise ValueError(
+                f"the two points are identical ({x1}, {y1}); a line needs two "
+                "distinct points"
+            )
+        raise ValueError(
+            f"vertical line at x = {x1}: slope is undefined, no slope-intercept form"
+        )
+    return (y2 - y1) / (x2 - x1)
+
+
+def line_from_points(p1: Point, p2: Point) -> Line:
+    """Slope-intercept form of the line through two points.
+
+    Args:
+        p1: First point as ``(x, y)``.
+        p2: Second point as ``(x, y)``.
+
+    Returns:
+        ``(m, b)`` for ``y = m * x + b``.
+
+    Raises:
+        ValueError: If the line is vertical or the points are identical.
+    """
+    m = slope(p1, p2)
+    return m, p1[1] - m * p1[0]
+
+
+def line_from_point_slope(point: Point, m: float) -> Line:
+    """Convert point-slope form to slope-intercept form.
+
+    Args:
+        point: A point ``(x, y)`` on the line.
+        m: Slope of the line.
+
+    Returns:
+        ``(m, b)`` for ``y = m * x + b``.
+    """
+    x0, y0 = point
+    return m, y0 - m * x0
+
+
+def line_from_standard(a: float, b: float, c: float) -> Line:
+    """Convert standard form ``Ax + By = C`` to slope-intercept form.
+
+    Args:
+        a: Coefficient of x.
+        b: Coefficient of y.
+        c: Right-hand constant.
+
+    Returns:
+        ``(m, intercept)`` for ``y = m * x + intercept``.
+
+    Raises:
+        ValueError: If ``b`` is zero -- a vertical line (or, with ``a`` also
+            zero, not a line at all).
+    """
+    if b == 0:
+        if a == 0:
+            raise ValueError("A and B cannot both be zero; that is not a line")
+        raise ValueError(
+            f"B = 0 means the vertical line x = {c / a}, which has no "
+            "slope-intercept form"
+        )
+    return -a / b, c / b
+
+
+def to_standard(m: float, b: float) -> tuple[int, int, int]:
+    """Convert slope-intercept form to integer-normalised ``Ax + By = C``.
+
+    The slope and intercept are rationalised (denominators capped at
+    ``_MAX_DENOM``), scaled to integers, and sign-fixed so that the leading
+    non-zero coefficient is positive.  The result is already in lowest terms.
+
+    Args:
+        m: Slope of the line.
+        b: y-intercept of the line.
+
+    Returns:
+        ``(A, B, C)`` with integer coefficients.
+
+    Raises:
+        ValueError: If ``m`` or ``b`` is not finite.
+    """
+    if not math.isfinite(m) or not math.isfinite(b):
+        raise ValueError(f"slope and intercept must be finite, got m={m}, b={b}")
+
+    mf = Fraction(m).limit_denominator(_MAX_DENOM)
+    bf = Fraction(b).limit_denominator(_MAX_DENOM)
+
+    # y = mx + b  ->  -m x + y = b.  Scale by the LCM of both denominators.
+    scale = mf.denominator * bf.denominator // math.gcd(mf.denominator, bf.denominator)
+    coef_a = -mf.numerator * (scale // mf.denominator)
+    coef_b = scale
+    coef_c = bf.numerator * (scale // bf.denominator)
+
+    # No GCD reduction step here: the coefficients this construction produces
+    # are already primitive.  B is lcm(d_m, d_b), and because each fraction is
+    # in lowest terms, any prime dividing B fails to divide either A or C.
+    # Verified exhaustively over every m, b with numerators in [-12, 12] and
+    # denominators in [1, 12] -- 90,000 combinations, no reducible triple.
+    if coef_a < 0 or (coef_a == 0 and coef_b < 0):
+        coef_a, coef_b, coef_c = -coef_a, -coef_b, -coef_c
+    return coef_a, coef_b, coef_c
+
+
+def evaluate(m: float, b: float, x: float) -> float:
+    """Value of y at a given x.
+
+    Args:
+        m: Slope of the line.
+        b: y-intercept of the line.
+        x: Point at which to evaluate.
+
+    Returns:
+        ``m * x + b``.
+    """
+    return m * x + b
+
+
+def solve_for_x(m: float, b: float, y: float) -> float:
+    """Value of x at a given y.
+
+    Args:
+        m: Slope of the line; must be non-zero.
+        b: y-intercept of the line.
+        y: Target y value.
+
+    Returns:
+        ``(y - b) / m``.
+
+    Raises:
+        ValueError: If ``m`` is zero -- a horizontal line takes one y value
+            everywhere, so no single x solves for any other.
+    """
+    if m == 0:
+        raise ValueError(
+            f"horizontal line y = {b}: every x gives the same y, so x cannot be "
+            "solved for"
+        )
+    return (y - b) / m
+
+
+def x_intercept(m: float, b: float) -> float:
+    """Where the line crosses the x axis.
+
+    Args:
+        m: Slope of the line; must be non-zero.
+        b: y-intercept of the line.
+
+    Returns:
+        ``-b / m``.
+
+    Raises:
+        ValueError: If ``m`` is zero (horizontal line, no crossing unless it is
+            the x axis itself).
+    """
+    return solve_for_x(m, b, 0.0)
+
+
+def y_intercept(m: float, b: float) -> float:
+    """Where the line crosses the y axis.
+
+    Args:
+        m: Slope of the line (unused; present for interface symmetry).
+        b: y-intercept of the line.
+
+    Returns:
+        ``b``, which is the y value at x = 0 by definition.
+    """
+    del m
+    return b
+
+
+def is_parallel(m1: float, m2: float, tol: float = _TOL) -> bool:
+    """Whether two slopes describe parallel lines.
+
+    Args:
+        m1: First slope.
+        m2: Second slope.
+        tol: Absolute tolerance for the comparison.
+
+    Returns:
+        True when the slopes agree within ``tol``.
+    """
+    return math.isclose(m1, m2, rel_tol=0.0, abs_tol=tol)
+
+
+def is_perpendicular(m1: float, m2: float, tol: float = _TOL) -> bool:
+    """Whether two slopes describe perpendicular lines.
+
+    Args:
+        m1: First slope.
+        m2: Second slope.
+        tol: Absolute tolerance for the comparison.
+
+    Returns:
+        True when ``m1 * m2`` is -1 within ``tol``.
+    """
+    return math.isclose(m1 * m2, -1.0, rel_tol=0.0, abs_tol=tol)
+
+
+def perpendicular_slope(m: float) -> float:
+    """Slope of any line perpendicular to this one.
+
+    Args:
+        m: Slope of the original line; must be non-zero.
+
+    Returns:
+        ``-1 / m``.
+
+    Raises:
+        ValueError: If ``m`` is zero -- the perpendicular to a horizontal line
+            is vertical, which has no slope.
+    """
+    if m == 0:
+        raise ValueError(
+            "the perpendicular to a horizontal line is vertical, which has no slope"
+        )
+    return -1.0 / m
+
+
+def intersection(line1: Line, line2: Line, tol: float = _TOL) -> Point | None:
+    """Point where two lines cross.
+
+    Args:
+        line1: First line as ``(m, b)``.
+        line2: Second line as ``(m, b)``.
+        tol: Absolute tolerance for the parallel test.
+
+    Returns:
+        The crossing point ``(x, y)``, or ``None`` when the lines are parallel
+        (including coincident lines, which cross everywhere rather than at a
+        point).  Use :func:`relationship` to tell those two cases apart.
+    """
+    m1, b1 = line1
+    m2, b2 = line2
+    if is_parallel(m1, m2, tol):
+        return None
+    x = (b2 - b1) / (m1 - m2)
+    return x, evaluate(m1, b1, x)
+
+
+def relationship(line1: Line, line2: Line, tol: float = _TOL) -> str:
+    """Classify how two lines relate.
+
+    Args:
+        line1: First line as ``(m, b)``.
+        line2: Second line as ``(m, b)``.
+        tol: Absolute tolerance for the slope comparisons.
+
+    Returns:
+        One of ``"coincident"``, ``"parallel"``, ``"perpendicular"``, or
+        ``"intersecting"``.
+    """
+    m1, b1 = line1
+    m2, b2 = line2
+    if is_parallel(m1, m2, tol):
+        if math.isclose(b1, b2, rel_tol=0.0, abs_tol=tol):
+            return "coincident"
+        return "parallel"
+    if is_perpendicular(m1, m2, tol):
+        return "perpendicular"
+    return "intersecting"
+
+
+def distance_to_point(m: float, b: float, point: Point) -> float:
+    """Perpendicular distance from a point to the line.
+
+    Args:
+        m: Slope of the line.
+        b: y-intercept of the line.
+        point: The point ``(x, y)`` to measure from.
+
+    Returns:
+        ``|m * x0 - y0 + b| / sqrt(m^2 + 1)``, zero when the point is on the line.
+    """
+    x0, y0 = point
+    return abs(m * x0 - y0 + b) / math.hypot(m, 1.0)
+
+
+def foot_of_perpendicular(m: float, b: float, point: Point) -> Point:
+    """Closest point on the line to a given point.
+
+    This is the projection of ``point`` onto the line -- the other end of the
+    segment measured by :func:`distance_to_point`.
+
+    Args:
+        m: Slope of the line.
+        b: y-intercept of the line.
+        point: The point ``(x, y)`` to project.
+
+    Returns:
+        The projected point ``(x, y)`` lying on the line.
+    """
+    x0, y0 = point
+    x = (x0 + m * y0 - m * b) / (m * m + 1.0)
+    return x, evaluate(m, b, x)
+
+
+def angle_of_inclination(m: float) -> float:
+    """Angle the line makes with the positive x axis.
+
+    Args:
+        m: Slope of the line.
+
+    Returns:
+        Degrees in ``[0, 180)``: ``atan(m)`` for a rising line, and the same
+        angle measured anticlockwise from the axis for a falling one.
+    """
+    degrees = math.degrees(math.atan(m))
+    return degrees if degrees >= 0.0 else degrees + 180.0
+
+
+def table_rows(
+    m: float, b: float, start: float, stop: float, step: float
+) -> list[Point]:
+    """Evaluate the line across a range of x values.
+
+    Args:
+        m: Slope of the line.
+        b: y-intercept of the line.
+        start: First x value.
+        stop: Last x value (included when the step lands on it).
+        step: Increment between rows; must be > 0.
+
+    Returns:
+        List of ``(x, y)`` pairs.
+
+    Raises:
+        ValueError: If ``step`` <= 0 or ``stop`` < ``start``.
+    """
+    if step <= 0:
+        raise ValueError(f"step must be > 0, got {step}")
+    if stop < start:
+        raise ValueError(f"stop must be >= start, got start={start}, stop={stop}")
+
+    rows: list[Point] = []
+    count = int(math.floor((stop - start) / step + 1e-9)) + 1
+    for i in range(count):
+        x = start + i * step
+        rows.append((x, evaluate(m, b, x)))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_point(text: str) -> Point:
+    """Parse an ``X,Y`` pair from the command line.
+
+    Args:
+        text: Comma-separated coordinate pair, e.g. ``"4,3"``.
+
+    Returns:
+        The point as ``(x, y)``.
+
+    Raises:
+        argparse.ArgumentTypeError: If the text is not two numbers separated by
+            a comma.
+    """
+    parts = text.split(",")
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError(
+            f"expected X,Y (two comma-separated numbers), got {text!r}"
+        )
+    try:
+        return float(parts[0]), float(parts[1])
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"expected X,Y (two comma-separated numbers), got {text!r}"
+        ) from None
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and return the argument parser namespace.
+
+    Args:
+        argv: Argument list (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        Parsed :class:`argparse.Namespace`.
+    """
+    parser = argparse.ArgumentParser(
+        description="Slope-intercept line calculator: y = mx + b.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  slopeint --points 0,32 100,212
+  slopeint --slope 1.8 --intercept 32 --at 37
+  slopeint --points 0,30000 5,5000 --table 0 5 1
+  slopeint --slope 10 --intercept 50000 --intersect 25,0
+  slopeint --slope 2 --intercept 1 --point 4,3 --perpendicular
+  slopeint --standard 3 -2 6 --format json
+""",
+    )
+    parser.add_argument(
+        "--points",
+        type=parse_point,
+        nargs=2,
+        default=None,
+        metavar=("X1,Y1", "X2,Y2"),
+        help="derive the line from two points",
+    )
+    parser.add_argument(
+        "--slope",
+        "-m",
+        type=float,
+        default=None,
+        metavar="F",
+        help="slope m, with --intercept or --point",
+    )
+    parser.add_argument(
+        "--intercept",
+        "-b",
+        type=float,
+        default=None,
+        metavar="F",
+        help="y-intercept b, with --slope",
+    )
+    parser.add_argument(
+        "--point",
+        type=parse_point,
+        default=None,
+        metavar="X,Y",
+        help="anchor point for point-slope form, or the target for --distance, "
+        "--perpendicular, and --parallel",
+    )
+    parser.add_argument(
+        "--standard",
+        type=float,
+        nargs=3,
+        default=None,
+        metavar=("A", "B", "C"),
+        help="read the line from standard form Ax + By = C",
+    )
+    parser.add_argument(
+        "--at",
+        type=float,
+        default=None,
+        metavar="F",
+        help="evaluate y at this x",
+    )
+    parser.add_argument(
+        "--solve",
+        type=float,
+        default=None,
+        metavar="F",
+        help="solve for the x that gives this y",
+    )
+    parser.add_argument(
+        "--intersect",
+        type=parse_point,
+        default=None,
+        metavar="M,B",
+        help="intersect with a second line given as slope,intercept",
+    )
+    parser.add_argument(
+        "--perpendicular",
+        action="store_true",
+        help="report the perpendicular line through --point",
+    )
+    parser.add_argument(
+        "--parallel",
+        action="store_true",
+        help="report the parallel line through --point",
+    )
+    parser.add_argument(
+        "--distance",
+        action="store_true",
+        help="report the perpendicular distance from --point to the line",
+    )
+    parser.add_argument(
+        "--table",
+        type=float,
+        nargs=3,
+        default=None,
+        metavar=("MIN", "MAX", "STEP"),
+        help="append a table of (x, y) across a range",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="output format (default: table)",
+    )
+    parser.add_argument(
+        "--precision",
+        "-P",
+        type=int,
+        default=4,
+        metavar="PREC",
+        help="decimal places for output (default: 4)",
+    )
+    return parser.parse_args(argv)
+
+
+def _line_sources(args: argparse.Namespace) -> list[str]:
+    """Names of the mutually exclusive line-definition flags that were given.
+
+    Args:
+        args: Parsed argument namespace.
+
+    Returns:
+        Flag names present, in a stable order.
+    """
+    sources = []
+    if args.points is not None:
+        sources.append("--points")
+    if args.standard is not None:
+        sources.append("--standard")
+    if args.slope is not None:
+        sources.append("--slope")
+    return sources
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    """Return an error message string, or ``None`` if arguments are valid.
+
+    Args:
+        args: Parsed argument namespace from :func:`parse_args`.
+
+    Returns:
+        Error description string, or ``None`` when validation passes.
+    """
+    # Checked before the no-source branch below: --intercept on its own is a
+    # half-given line, and saying so beats the generic "no line given".
+    if args.intercept is not None and args.slope is None:
+        return "--intercept needs --slope"
+
+    sources = _line_sources(args)
+    if not sources:
+        return (
+            "no line given: use --points, --slope with --intercept or --point, "
+            "or --standard"
+        )
+    if len(sources) > 1:
+        return f"{' and '.join(sources)} are mutually exclusive; pick one"
+
+    if args.slope is not None and args.intercept is None and args.point is None:
+        return "--slope needs either --intercept or --point to fix the line"
+    if args.precision < 0:
+        return f"--precision must be non-negative, got {args.precision}"
+
+    # The anchor point of point-slope form lies on the line, so measuring a
+    # distance to it or drawing a parallel through it says nothing.
+    anchored = args.slope is not None and args.intercept is None
+    for flag, requested in (
+        ("--distance", args.distance),
+        ("--perpendicular", args.perpendicular),
+        ("--parallel", args.parallel),
+    ):
+        if not requested:
+            continue
+        if args.point is None:
+            return f"{flag} requires --point"
+        if anchored:
+            return (
+                f"{flag} needs a --point off the line, but --point is already "
+                "the anchor of point-slope form; supply --intercept instead"
+            )
+
+    if args.table is not None:
+        start, stop, step = args.table
+        if step <= 0:
+            return f"--table STEP must be > 0, got {step}"
+        if stop < start:
+            return f"--table MAX must be >= MIN, got MIN={start}, MAX={stop}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Result assembly
+# ---------------------------------------------------------------------------
+
+
+def resolve_line(args: argparse.Namespace) -> Line:
+    """Determine ``(m, b)`` from whichever line flags were supplied.
+
+    Args:
+        args: Validated argument namespace.
+
+    Returns:
+        The line as ``(m, b)``.
+
+    Raises:
+        ValueError: If the requested line is vertical or otherwise degenerate.
+    """
+    if args.points is not None:
+        return line_from_points(args.points[0], args.points[1])
+    if args.standard is not None:
+        return line_from_standard(*args.standard)
+    if args.intercept is not None:
+        return args.slope, args.intercept
+    return line_from_point_slope(args.point, args.slope)
+
+
+def build_result(args: argparse.Namespace) -> dict[str, Any]:
+    """Compute every requested quantity for the resolved line.
+
+    Args:
+        args: Validated argument namespace from :func:`parse_args`.
+
+    Returns:
+        Result mapping ready for formatting.
+
+    Raises:
+        ValueError: If the line is degenerate or a requested operation is
+            undefined for it.
+    """
+    m, b = resolve_line(args)
+    coef_a, coef_b, coef_c = to_standard(m, b)
+
+    result: dict[str, Any] = {
+        "slope": m,
+        "intercept": b,
+        "equation": format_equation(m, b),
+        "standard": {"a": coef_a, "b": coef_b, "c": coef_c},
+        "y_intercept": y_intercept(m, b),
+        "angle_degrees": angle_of_inclination(m),
+        "horizontal": m == 0,
+    }
+    result["x_intercept"] = None if m == 0 else x_intercept(m, b)
+
+    if args.at is not None:
+        result["evaluate"] = {"x": args.at, "y": evaluate(m, b, args.at)}
+    if args.solve is not None:
+        result["solve"] = {"y": args.solve, "x": solve_for_x(m, b, args.solve)}
+
+    if args.intersect is not None:
+        other = (args.intersect[0], args.intersect[1])
+        point = intersection((m, b), other)
+        result["intersect"] = {
+            "other": {"slope": other[0], "intercept": other[1]},
+            "relationship": relationship((m, b), other),
+            "point": None if point is None else {"x": point[0], "y": point[1]},
+        }
+
+    if args.perpendicular:
+        perp_m = perpendicular_slope(m)
+        perp_b = line_from_point_slope(args.point, perp_m)[1]
+        result["perpendicular"] = {
+            "slope": perp_m,
+            "intercept": perp_b,
+            "equation": format_equation(perp_m, perp_b),
+        }
+    if args.parallel:
+        par_b = line_from_point_slope(args.point, m)[1]
+        result["parallel"] = {
+            "slope": m,
+            "intercept": par_b,
+            "equation": format_equation(m, par_b),
+        }
+    if args.distance:
+        foot = foot_of_perpendicular(m, b, args.point)
+        result["distance"] = {
+            "point": {"x": args.point[0], "y": args.point[1]},
+            "distance": distance_to_point(m, b, args.point),
+            "foot": {"x": foot[0], "y": foot[1]},
+        }
+
+    if args.table is not None:
+        start, stop, step = args.table
+        result["table"] = [
+            {"x": x, "y": y} for x, y in table_rows(m, b, start, stop, step)
+        ]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _fmt(value: float, precision: int) -> str:
+    """Format a float to fixed precision, trimming a trailing ``-0``.
+
+    Args:
+        value: Number to render.
+        precision: Decimal places.
+
+    Returns:
+        Formatted string.
+    """
+    text = f"{value:.{precision}f}"
+    return text[1:] if text.startswith("-0.") and float(text) == 0.0 else text
+
+
+def format_equation(m: float, b: float) -> str:
+    """Render ``y = mx + b`` with tidy signs and no redundant terms.
+
+    Args:
+        m: Slope of the line.
+        b: y-intercept of the line.
+
+    Returns:
+        Human-readable equation string.
+    """
+    m_text = f"{m:g}"
+    b_text = f"{abs(b):g}"
+
+    if m == 0:
+        return f"y = {b:g}"
+    slope_part = "x" if m == 1 else ("-x" if m == -1 else f"{m_text}x")
+    if b == 0:
+        return f"y = {slope_part}"
+    sign = "-" if b < 0 else "+"
+    return f"y = {slope_part} {sign} {b_text}"
+
+
+def format_standard(a: int, b: int, c: int) -> str:
+    """Render ``Ax + By = C`` with tidy signs and no redundant terms.
+
+    Args:
+        a: Coefficient of x.
+        b: Coefficient of y.
+        c: Right-hand constant.
+
+    Returns:
+        Human-readable standard-form string.
+    """
+    terms = ""
+    if a != 0:
+        terms = "x" if a == 1 else ("-x" if a == -1 else f"{a}x")
+    if b != 0:
+        y_term = "y" if abs(b) == 1 else f"{abs(b)}y"
+        if terms:
+            terms += f" {'-' if b < 0 else '+'} {y_term}"
+        else:
+            terms = y_term if b > 0 else f"-{y_term}"
+    return f"{terms} = {c}"
+
+
+def format_table(result: dict[str, Any], precision: int) -> str:
+    """Render the result as an aligned plain-text report.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+        precision: Decimal places for numeric output.
+
+    Returns:
+        Multi-line report string.
+    """
+    std = result["standard"]
+    lines = [
+        "Line",
+        "----",
+        f"  Slope-intercept:  {result['equation']}",
+        f"  Standard form:    {format_standard(std['a'], std['b'], std['c'])}",
+        f"  Slope (m):        {_fmt(result['slope'], precision)}",
+        f"  y-intercept (b):  {_fmt(result['intercept'], precision)}",
+    ]
+    if result["x_intercept"] is None:
+        lines.append("  x-intercept:      none (horizontal line)")
+    else:
+        lines.append(f"  x-intercept:      {_fmt(result['x_intercept'], precision)}")
+    lines.append(f"  Inclination:      {_fmt(result['angle_degrees'], precision)}°")
+
+    if "evaluate" in result:
+        ev = result["evaluate"]
+        lines += [
+            "",
+            "Evaluate",
+            "--------",
+            f"  y({_fmt(ev['x'], precision)}) = {_fmt(ev['y'], precision)}",
+        ]
+    if "solve" in result:
+        sv = result["solve"]
+        lines += [
+            "",
+            "Solve",
+            "-----",
+            f"  x = {_fmt(sv['x'], precision)} when y = {_fmt(sv['y'], precision)}",
+        ]
+    if "intersect" in result:
+        it = result["intersect"]
+        other = it["other"]
+        lines += [
+            "",
+            "Intersection",
+            "------------",
+            f"  Other line:       {format_equation(other['slope'], other['intercept'])}",
+            f"  Relationship:     {it['relationship']}",
+        ]
+        if it["point"] is None:
+            note = (
+                "every point (the lines are the same)"
+                if it["relationship"] == "coincident"
+                else "none (parallel lines never meet)"
+            )
+            lines.append(f"  Crossing:         {note}")
+        else:
+            px = _fmt(it["point"]["x"], precision)
+            py = _fmt(it["point"]["y"], precision)
+            lines.append(f"  Crossing:         ({px}, {py})")
+
+    for key, title in (("perpendicular", "Perpendicular"), ("parallel", "Parallel")):
+        if key in result:
+            entry = result[key]
+            lines += [
+                "",
+                f"{title} through point",
+                "-" * (len(title) + 14),
+                f"  Equation:         {entry['equation']}",
+                f"  Slope (m):        {_fmt(entry['slope'], precision)}",
+                f"  y-intercept (b):  {_fmt(entry['intercept'], precision)}",
+            ]
+
+    if "distance" in result:
+        dist = result["distance"]
+        pt, foot = dist["point"], dist["foot"]
+        lines += [
+            "",
+            "Distance to point",
+            "-----------------",
+            f"  Point:            ({_fmt(pt['x'], precision)}, "
+            f"{_fmt(pt['y'], precision)})",
+            f"  Distance:         {_fmt(dist['distance'], precision)}",
+            f"  Closest on line:  ({_fmt(foot['x'], precision)}, "
+            f"{_fmt(foot['y'], precision)})",
+        ]
+
+    if "table" in result:
+        lines += ["", "Table", "-----", f"  {'x':>14}  {'y':>14}"]
+        for row in result["table"]:
+            lines.append(
+                f"  {_fmt(row['x'], precision):>14}  {_fmt(row['y'], precision):>14}"
+            )
+    return "\n".join(lines)
+
+
+def format_json(result: dict[str, Any]) -> str:
+    """Render the result as indented JSON.
+
+    Args:
+        result: Mapping from :func:`build_result`.
+
+    Returns:
+        JSON document string.
+    """
+    return json.dumps(result, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the slope-intercept CLI.
+
+    Args:
+        argv: Argument list override for testing (uses ``sys.argv`` when ``None``).
+
+    Returns:
+        0 on success, 2 on input or computation error.
+    """
+    args = parse_args(argv)
+
+    error = validate(args)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        result = build_result(args)
+        if args.format == "json":
+            print(format_json(result))
+        else:
+            print(format_table(result, args.precision))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_linear_regression.py
+++ b/tests/test_linear_regression.py
@@ -5,13 +5,13 @@ import os
 import tempfile
 
 import pytest
+from scipy import special, stats
 
 import src.utils.linear_regression as linreg_module
 from src.utils.linear_regression import (
     f_cdf,
     incomplete_beta,
     interpret_r_squared,
-    inverse_normal_cdf,
     inverse_t_cdf,
     linear_regression,
     main,
@@ -170,10 +170,12 @@ def test_t_cdf_infinite_t():
 
 
 def test_t_cdf_large_df():
-    """Test t_cdf uses normal approximation for large df."""
-    # For df > 30, should use normal approximation
+    """t_cdf is exact above df = 30, where it used to fall back to the normal."""
     result = t_cdf(1.96, 100)
-    assert 0.97 < result < 0.98  # Should be close to normal CDF
+    assert result == pytest.approx(float(stats.t.cdf(1.96, 100)), abs=1e-9)
+    # The normal CDF is a visibly different number at this df; the old
+    # implementation returned it verbatim.
+    assert abs(result - 0.5 * (1 + math.erf(1.96 / math.sqrt(2)))) > 1e-4
 
 
 def test_incomplete_beta_edge_cases():
@@ -201,30 +203,10 @@ def test_inverse_t_cdf_invalid_p():
 
 
 def test_inverse_t_cdf_large_df():
-    """Test inverse_t_cdf uses normal approximation for large df."""
-    # For df > 30, should use normal approximation
+    """inverse_t_cdf is exact above df = 30, not the normal quantile."""
     result = inverse_t_cdf(0.975, 100)
-    assert abs(result - 1.96) < 0.05  # Should be close to z_0.975
-
-
-def test_inverse_normal_cdf_invalid_p():
-    """Test inverse_normal_cdf raises error for invalid p values."""
-    with pytest.raises(ValueError, match="p must be between 0 and 1"):
-        inverse_normal_cdf(0.0)
-
-
-def test_inverse_normal_cdf_lower_region():
-    """Test inverse_normal_cdf lower tail approximation."""
-    # p < 0.02425 uses lower region approximation
-    result = inverse_normal_cdf(0.01)
-    assert result < -2.0  # Should be in left tail
-
-
-def test_inverse_normal_cdf_upper_region():
-    """Test inverse_normal_cdf upper tail approximation."""
-    # p > 0.97575 uses upper region approximation
-    result = inverse_normal_cdf(0.99)
-    assert result > 2.0  # Should be in right tail
+    assert result == pytest.approx(float(stats.t.ppf(0.975, 100)), abs=1e-8)
+    assert abs(result - 1.959963985) > 1e-3
 
 
 def test_f_cdf_edge_cases():
@@ -339,8 +321,9 @@ def test_incomplete_beta_lentz_floor_guards_hit(monkeypatch):
     whether or not the guards exist, so the test would still pass with all four
     deleted. Pin the clamped value instead. With every denominator forced to
     _TINY, `c * d` is exactly 1.0, the convergence check breaks on the first
-    iteration, and the result collapses to the front factor alone -- which for
-    (2, 3, 0.5) goes through the symmetry relation to 1 - 0.125. Deleting or
+    iteration, and the continued fraction collapses to its seed value of
+    1 / _TINY. For (2, 3, 0.5) the symmetry relation routes this through
+    (3, 2, 0.5), whose front factor is 0.125, giving 1 - 0.125e-5. Deleting or
     inverting any guard changes that number.
     """
     unclamped = incomplete_beta(2.0, 3.0, 0.5)
@@ -348,7 +331,7 @@ def test_incomplete_beta_lentz_floor_guards_hit(monkeypatch):
     clamped = incomplete_beta(2.0, 3.0, 0.5)
 
     assert math.isfinite(clamped)
-    assert clamped == pytest.approx(0.875)
+    assert clamped == pytest.approx(1.0 - 0.125e-5)
     assert clamped != unclamped
 
 
@@ -366,3 +349,95 @@ def test_incomplete_beta_survives_subnormal_parameters():
         result = incomplete_beta(a, b, x)
         assert math.isfinite(result), f"non-finite result for ({a}, {b}, {x})"
         assert 0 <= result <= 1, f"out of range result for ({a}, {b}, {x})"
+
+
+# ---------------------------------------------------------------------------
+# Distribution kernels against scipy
+#
+# The suite previously pinned only edge cases and the shape of the large-df
+# shortcut, so a continued fraction that was seeded incorrectly -- dropping the
+# leading term and returning 0.2285 for I_0.4(2,3) against a true 0.5248 --
+# passed everything. These compare values, not shapes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "a,b,x",
+    [
+        (2.0, 3.0, 0.4),
+        (0.5, 0.5, 0.3),
+        (5.0, 0.5, 0.5),
+        (12.5, 0.5, 0.9259),
+        (1.0, 20.0, 0.05),
+        (50.0, 0.5, 0.99),
+    ],
+)
+def test_incomplete_beta_matches_scipy(a, b, x):
+    assert incomplete_beta(a, b, x) == pytest.approx(
+        float(special.betainc(a, b, x)), abs=1e-9
+    )
+
+
+def test_incomplete_beta_known_closed_form():
+    """I_0.4(2,3) = 0.5248 exactly; the seeding bug returned 0.2285."""
+    assert incomplete_beta(2.0, 3.0, 0.4) == pytest.approx(0.5248, abs=1e-12)
+
+
+@pytest.mark.parametrize("df", [1, 2, 5, 25, 30, 31, 40, 100, 500])
+@pytest.mark.parametrize("t", [-3.0, -1.0, -0.25, 0.5, 2.0, 4.0])
+def test_t_cdf_matches_scipy(t, df):
+    assert t_cdf(t, df) == pytest.approx(float(stats.t.cdf(t, df)), abs=1e-9)
+
+
+def test_t_cdf_is_continuous_across_the_old_df_threshold():
+    """The old normal shortcut put a visible step at df = 30/31."""
+    below, above = t_cdf(2.0, 30), t_cdf(2.0, 31)
+    assert abs(below - above) < 1e-3
+
+
+@pytest.mark.parametrize("df", [1, 5, 10, 30, 40, 100])
+@pytest.mark.parametrize("p", [0.6, 0.9, 0.975, 0.995])
+def test_inverse_t_cdf_matches_scipy(p, df):
+    assert inverse_t_cdf(p, df) == pytest.approx(float(stats.t.ppf(p, df)), abs=1e-6)
+
+
+def test_inverse_t_cdf_round_trips_with_t_cdf():
+    assert t_cdf(inverse_t_cdf(0.9, 7), 7) == pytest.approx(0.9, abs=1e-8)
+
+
+def test_inverse_t_cdf_rejects_bad_df():
+    with pytest.raises(ValueError, match="Degrees of freedom must be at least 1"):
+        inverse_t_cdf(0.5, 0)
+
+
+@pytest.mark.parametrize(
+    "f_stat,df1,df2",
+    [(0.5, 1, 10), (2.0, 1, 10), (5.0, 2, 20), (12.0, 3, 30), (0.1, 4, 8)],
+)
+def test_f_cdf_matches_scipy(f_stat, df1, df2):
+    assert f_cdf(f_stat, df1, df2) == pytest.approx(
+        float(stats.f.cdf(f_stat, df1, df2)), abs=1e-9
+    )
+
+
+def test_regression_p_value_matches_scipy_end_to_end():
+    """The whole path: fit, t-statistic, and the reported two-sided p-value."""
+    x = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+    y = [2.3, 3.9, 6.4, 7.6, 10.5, 11.8, 14.6, 15.9]
+    model = linear_regression(x, y)
+    reference = stats.linregress(x, y)
+
+    assert model.slope == pytest.approx(reference.slope, rel=1e-12)
+    assert model.se_slope == pytest.approx(reference.stderr, rel=1e-10)
+    expected_p = float(2 * stats.t.sf(abs(model.t_slope), model.df))
+    assert p_value_t(model.t_slope, model.df) == pytest.approx(expected_p, rel=1e-6)
+
+
+def test_confidence_interval_critical_value_matches_scipy():
+    """t_crit drives every interval the CLI prints; it was 18% low at df = 5."""
+    x = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+    y = [2.1, 4.2, 5.8, 8.1, 9.9, 12.2, 14.0]
+    model = linear_regression(x, y)
+    assert inverse_t_cdf(0.975, model.df) == pytest.approx(
+        float(stats.t.ppf(0.975, model.df)), abs=1e-8
+    )

--- a/tests/test_logistic_regression.py
+++ b/tests/test_logistic_regression.py
@@ -1,0 +1,644 @@
+"""Tests for the binary logistic regression utility."""
+
+import argparse
+import json
+import math
+
+import numpy as np
+import pytest
+from scipy.optimize import minimize
+
+from src.utils.logistic_regression import (
+    LogisticModel,
+    build_result,
+    classification_metrics,
+    confusion_matrix,
+    encode_binary,
+    extract_columns,
+    fit,
+    format_json,
+    format_table,
+    log_likelihood,
+    log_odds,
+    main,
+    normal_quantile,
+    normal_sf,
+    predict_class,
+    predict_proba,
+    read_csv,
+    resolve_features,
+    sigmoid,
+    two_sided_p,
+    validate,
+)
+
+# A deterministic dataset with genuine class overlap: the outcome rises with x1,
+# but four labels near the boundary are flipped so the classes are not linearly
+# separable.  Without that overlap the likelihood has no interior maximum and
+# the information matrix goes singular, which fit() rejects by design.
+_X = [[float(i), float((i * 7) % 5)] for i in range(20)]
+_Y = [1.0 if i > 9 else 0.0 for i in range(20)]
+for _flipped in (3, 8, 11, 15):
+    _Y[_flipped] = 1.0 - _Y[_flipped]
+
+
+def _args(**overrides):
+    """Build a namespace with valid defaults, overridden per test."""
+    base = dict(
+        file="train.csv",
+        target="y",
+        features=None,
+        threshold=0.5,
+        alpha=0.05,
+        predict_file=None,
+        max_iter=50,
+        format="table",
+        precision=4,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _write_csv(path, header, rows):
+    """Write a CSV fixture and return its path as a string."""
+    lines = [",".join(header)]
+    lines += [",".join(str(value) for value in row) for row in rows]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(path)
+
+
+@pytest.fixture
+def train_csv(tmp_path):
+    """Training file matching the module-level fixture data."""
+    rows = [[x[0], x[1], int(y)] for x, y in zip(_X, _Y)]
+    return _write_csv(tmp_path / "train.csv", ["x1", "x2", "y"], rows)
+
+
+# ---------------------------------------------------------------------------
+# sigmoid / log_odds
+# ---------------------------------------------------------------------------
+
+
+def test_sigmoid_at_zero_is_half():
+    assert sigmoid(0.0) == 0.5
+
+
+def test_sigmoid_is_symmetric():
+    assert sigmoid(2.0) + sigmoid(-2.0) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("z", [800.0, -800.0])
+def test_sigmoid_does_not_overflow(z):
+    value = sigmoid(z)
+    assert 0.0 <= value <= 1.0
+
+
+def test_log_odds_inverts_sigmoid():
+    assert sigmoid(log_odds(0.73)) == pytest.approx(0.73)
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.1, 1.5])
+def test_log_odds_outside_open_interval_raises(bad):
+    with pytest.raises(ValueError, match="strictly between 0 and 1"):
+        log_odds(bad)
+
+
+# ---------------------------------------------------------------------------
+# normal helpers
+# ---------------------------------------------------------------------------
+
+
+def test_normal_sf_at_zero():
+    assert normal_sf(0.0) == pytest.approx(0.5)
+
+
+def test_normal_sf_matches_known_tail():
+    assert normal_sf(1.959963985) == pytest.approx(0.025, abs=1e-9)
+
+
+def test_two_sided_p_is_symmetric():
+    assert two_sided_p(-1.5) == two_sided_p(1.5)
+
+
+def test_normal_quantile_matches_known_critical_value():
+    assert normal_quantile(0.975) == pytest.approx(1.959963985, abs=1e-6)
+
+
+def test_normal_quantile_round_trips_with_sf():
+    z = normal_quantile(0.9)
+    assert 1.0 - normal_sf(z) == pytest.approx(0.9, abs=1e-6)
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0])
+def test_normal_quantile_rejects_endpoints(bad):
+    with pytest.raises(ValueError, match="strictly between 0 and 1"):
+        normal_quantile(bad)
+
+
+# ---------------------------------------------------------------------------
+# log_likelihood
+# ---------------------------------------------------------------------------
+
+
+def test_log_likelihood_perfect_fit_is_near_zero():
+    y = np.array([1.0, 0.0])
+    probs = np.array([1.0 - 1e-15, 1e-15])
+    assert log_likelihood(y, probs) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_log_likelihood_clamps_instead_of_returning_negative_infinity():
+    value = log_likelihood(np.array([1.0]), np.array([0.0]))
+    assert math.isfinite(value)
+
+
+def test_log_likelihood_coin_flip_baseline():
+    y = np.array([1.0, 0.0, 1.0, 0.0])
+    probs = np.full(4, 0.5)
+    assert log_likelihood(y, probs) == pytest.approx(4 * math.log(0.5))
+
+
+# ---------------------------------------------------------------------------
+# fit
+# ---------------------------------------------------------------------------
+
+
+def test_fit_recovers_expected_sign_pattern():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    assert model.coefficients[1] > 0
+    assert model.coefficients[2] < 0
+
+
+def test_fit_matches_scipy_maximum_likelihood():
+    """scipy oracle: our Newton-Raphson must land on the same MLE."""
+    model = fit(_X, _Y, names=["x1", "x2"])
+
+    design = np.column_stack([np.ones(len(_X)), np.array(_X)])
+    y = np.array(_Y)
+
+    def negative_loglik(beta):
+        z = design @ beta
+        return float(np.sum(np.logaddexp(0.0, z) - y * z))
+
+    opt = minimize(negative_loglik, np.zeros(3), method="BFGS", options={"gtol": 1e-12})
+    assert model.coefficients == pytest.approx(list(opt.x), abs=1e-4)
+    assert model.loglik == pytest.approx(-opt.fun, abs=1e-8)
+
+
+def test_fit_standard_errors_match_numerical_hessian():
+    """Wald SEs must equal the inverse observed information, not an approximation."""
+    model = fit(_X, _Y, names=["x1", "x2"])
+    design = np.column_stack([np.ones(len(_X)), np.array(_X)])
+    y = np.array(_Y)
+
+    def gradient(beta):
+        probs = 1.0 / (1.0 + np.exp(-(design @ beta)))
+        return -(design.T @ (y - probs))
+
+    beta = np.array(model.coefficients)
+    step = 1e-6
+    hessian = np.column_stack(
+        [
+            (gradient(beta + step * unit) - gradient(beta - step * unit)) / (2 * step)
+            for unit in np.eye(len(beta))
+        ]
+    )
+    expected = np.sqrt(np.diag(np.linalg.inv(hessian)))
+    assert model.std_errors == pytest.approx(list(expected), rel=1e-6)
+
+
+def test_fit_gradient_is_zero_at_solution():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    design = np.column_stack([np.ones(len(_X)), np.array(_X)])
+    probs = 1.0 / (1.0 + np.exp(-(design @ np.array(model.coefficients))))
+    assert np.max(np.abs(design.T @ (np.array(_Y) - probs))) == pytest.approx(
+        0.0, abs=1e-7
+    )
+
+
+def test_fit_default_names_when_none_given():
+    model = fit(_X, _Y)
+    assert model.names == ["(intercept)", "x1", "x2"]
+
+
+def test_fit_converges_quickly():
+    assert fit(_X, _Y).iterations <= 10
+
+
+def test_fit_empty_data_raises():
+    with pytest.raises(ValueError, match="no observations"):
+        fit([], [])
+
+
+def test_fit_length_mismatch_raises():
+    with pytest.raises(ValueError, match="but 1 outcomes"):
+        fit(_X, [1.0])
+
+
+def test_fit_no_columns_raises():
+    with pytest.raises(ValueError, match="no predictor columns"):
+        fit([[], []], [0.0, 1.0])
+
+
+def test_fit_ragged_rows_raise():
+    with pytest.raises(ValueError, match="same number of columns"):
+        fit([[1.0, 2.0], [3.0]], [0.0, 1.0])
+
+
+def test_fit_single_class_target_raises():
+    with pytest.raises(ValueError, match="must be binary"):
+        fit(_X, [1.0] * len(_X))
+
+
+def test_fit_non_binary_target_raises():
+    outcomes = [0.0, 1.0, 2.0] + [0.0] * (len(_X) - 3)
+    with pytest.raises(ValueError, match="must be binary"):
+        fit(_X, outcomes)
+
+
+def test_fit_too_few_observations_raises():
+    with pytest.raises(ValueError, match="more observations than parameters"):
+        fit([[1.0, 2.0], [3.0, 4.0]], [0.0, 1.0])
+
+
+def test_fit_collinear_predictors_raise():
+    rows = [[float(i), float(2 * i)] for i in range(10)]
+    outcomes = [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    with pytest.raises(ValueError, match="singular|separ"):
+        fit(rows, outcomes)
+
+
+def test_fit_perfectly_separable_data_raises():
+    """Separable classes collapse the weights, so the information matrix goes
+    singular rather than the fit quietly returning a runaway answer."""
+    rows = [[float(i)] for i in range(12)]
+    outcomes = [0.0] * 6 + [1.0] * 6
+    with pytest.raises(ValueError, match="perfectly separated"):
+        fit(rows, outcomes)
+
+
+def test_fit_widely_separated_classes_hit_the_iteration_cap():
+    """The other separation path: coefficients creep up without converging."""
+    rows = [[float(i)] for i in list(range(6)) + list(range(100, 106))]
+    outcomes = [0.0] * 6 + [1.0] * 6
+    with pytest.raises(ValueError, match="did not converge"):
+        fit(rows, outcomes, max_iter=200)
+
+
+def test_fit_non_convergence_raises_rather_than_returning_silently():
+    with pytest.raises(ValueError, match="did not converge"):
+        fit(_X, _Y, max_iter=1, tol=1e-300)
+
+
+# ---------------------------------------------------------------------------
+# LogisticModel statistics
+# ---------------------------------------------------------------------------
+
+
+def test_model_information_criteria():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    assert model.aic == pytest.approx(2 * 3 - 2 * model.loglik)
+    assert model.bic == pytest.approx(3 * math.log(model.n) - 2 * model.loglik)
+
+
+def test_model_pseudo_r2_between_zero_and_one():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    assert 0.0 < model.pseudo_r2 < 1.0
+
+
+def test_model_pseudo_r2_zero_when_null_loglik_is_zero():
+    model = LogisticModel([0.0], [1.0], ["(intercept)"], 0.0, 0.0, 10, 1)
+    assert model.pseudo_r2 == 0.0
+
+
+def test_model_odds_ratio_is_exponentiated_coefficient():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    assert model.odds_ratios[1] == pytest.approx(math.exp(model.coefficients[1]))
+
+
+def test_model_z_is_infinite_when_standard_error_is_zero():
+    model = LogisticModel([1.0], [0.0], ["(intercept)"], -1.0, -2.0, 10, 1)
+    assert math.isinf(model.z_stats[0])
+
+
+def test_model_confidence_intervals_bracket_the_estimate():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    for coef, (low, high) in zip(model.coefficients, model.confidence_intervals(0.05)):
+        assert low < coef < high
+
+
+def test_model_wider_interval_at_smaller_alpha():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    narrow = model.confidence_intervals(0.05)[1]
+    wide = model.confidence_intervals(0.01)[1]
+    assert wide[1] - wide[0] > narrow[1] - narrow[0]
+
+
+# ---------------------------------------------------------------------------
+# prediction and metrics
+# ---------------------------------------------------------------------------
+
+
+def test_predict_proba_matches_manual_sigmoid():
+    assert predict_proba([0.5, 2.0], [1.0]) == pytest.approx(sigmoid(2.5))
+
+
+def test_predict_proba_wrong_width_raises():
+    with pytest.raises(ValueError, match="expected 1 predictors"):
+        predict_proba([0.5, 2.0], [1.0, 3.0])
+
+
+@pytest.mark.parametrize(
+    "prob,threshold,expected",
+    [(0.7, 0.5, 1), (0.3, 0.5, 0), (0.5, 0.5, 1), (0.4, 0.3, 1), (0.2, 0.3, 0)],
+)
+def test_predict_class(prob, threshold, expected):
+    assert predict_class(prob, threshold) == expected
+
+
+def test_confusion_matrix_counts_all_four_cells():
+    cells = confusion_matrix([1.0, 0.0, 1.0, 0.0], [1, 1, 0, 0])
+    assert cells == {"tp": 1, "fp": 1, "tn": 1, "fn": 1}
+
+
+def test_confusion_matrix_length_mismatch_raises():
+    with pytest.raises(ValueError, match="but 1 predictions"):
+        confusion_matrix([1.0, 0.0], [1])
+
+
+def test_classification_metrics_perfect_classifier():
+    metrics = classification_metrics({"tp": 5, "fp": 0, "tn": 5, "fn": 0})
+    assert metrics == pytest.approx(
+        {"accuracy": 1.0, "precision": 1.0, "recall": 1.0, "f1": 1.0}
+    )
+
+
+def test_classification_metrics_never_predicting_positive():
+    metrics = classification_metrics({"tp": 0, "fp": 0, "tn": 5, "fn": 5})
+    assert metrics["precision"] == 0.0
+    assert metrics["recall"] == 0.0
+    assert metrics["f1"] == 0.0
+    assert metrics["accuracy"] == 0.5
+
+
+def test_classification_metrics_f1_is_harmonic_mean():
+    metrics = classification_metrics({"tp": 3, "fp": 1, "tn": 4, "fn": 2})
+    expected = 2 * 0.75 * 0.6 / (0.75 + 0.6)
+    assert metrics["f1"] == pytest.approx(expected)
+
+
+def test_classification_metrics_empty_matrix_raises():
+    with pytest.raises(ValueError, match="empty"):
+        classification_metrics({"tp": 0, "fp": 0, "tn": 0, "fn": 0})
+
+
+# ---------------------------------------------------------------------------
+# CSV input
+# ---------------------------------------------------------------------------
+
+
+def test_read_csv_returns_header_and_rows(train_csv):
+    columns, rows = read_csv(train_csv)
+    assert columns == ["x1", "x2", "y"]
+    assert len(rows) == len(_X)
+
+
+def test_read_csv_missing_file_raises():
+    with pytest.raises(ValueError, match="could not read"):
+        read_csv("/nonexistent/path/train.csv")
+
+
+def test_read_csv_empty_file_raises(tmp_path):
+    path = tmp_path / "empty.csv"
+    path.write_text("", encoding="utf-8")
+    with pytest.raises(ValueError, match="header row is required"):
+        read_csv(str(path))
+
+
+def test_extract_columns_reads_floats(train_csv):
+    _, rows = read_csv(train_csv)
+    assert extract_columns(rows, ["x1"])[0] == [0.0]
+
+
+def test_extract_columns_missing_column_raises(train_csv):
+    _, rows = read_csv(train_csv)
+    with pytest.raises(ValueError, match="missing on line"):
+        extract_columns(rows, ["nope"])
+
+
+def test_extract_columns_non_numeric_raises(tmp_path):
+    path = _write_csv(tmp_path / "bad.csv", ["a", "y"], [[1, 0], ["oops", 1]])
+    _, rows = read_csv(path)
+    with pytest.raises(ValueError, match="not numeric"):
+        extract_columns(rows, ["a"])
+
+
+def test_encode_binary_passes_through_zero_one():
+    assert encode_binary([0.0, 1.0, 1.0]) == [0.0, 1.0, 1.0]
+
+
+def test_encode_binary_maps_arbitrary_pair():
+    assert encode_binary([2.0, 7.0, 7.0]) == [0.0, 1.0, 1.0]
+
+
+@pytest.mark.parametrize("values", [[1.0, 1.0], [1.0, 2.0, 3.0]])
+def test_encode_binary_rejects_wrong_cardinality(values):
+    with pytest.raises(ValueError, match="exactly two distinct values"):
+        encode_binary(values)
+
+
+# ---------------------------------------------------------------------------
+# validate / resolve_features
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_defaults():
+    assert validate(_args()) is None
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.2, 1.4])
+def test_validate_rejects_threshold_outside_interval(bad):
+    assert "--threshold" in validate(_args(threshold=bad))
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0])
+def test_validate_rejects_alpha_outside_interval(bad):
+    assert "--alpha" in validate(_args(alpha=bad))
+
+
+def test_validate_rejects_zero_max_iter():
+    assert "--max-iter" in validate(_args(max_iter=0))
+
+
+def test_validate_rejects_negative_precision():
+    assert "--precision" in validate(_args(precision=-1))
+
+
+def test_validate_rejects_target_listed_as_feature():
+    assert "cannot also be a feature" in validate(_args(features=["x1", "y"]))
+
+
+def test_resolve_features_defaults_to_all_but_target():
+    assert resolve_features(["x1", "x2", "y"], _args()) == ["x1", "x2"]
+
+
+def test_resolve_features_honours_explicit_list():
+    assert resolve_features(["x1", "x2", "y"], _args(features=["x2"])) == ["x2"]
+
+
+def test_resolve_features_missing_target_raises():
+    with pytest.raises(ValueError, match="target column"):
+        resolve_features(["x1", "x2"], _args())
+
+
+def test_resolve_features_missing_feature_raises():
+    with pytest.raises(ValueError, match="feature column"):
+        resolve_features(["x1", "y"], _args(features=["nope"]))
+
+
+def test_resolve_features_no_predictors_left_raises():
+    with pytest.raises(ValueError, match="no predictor columns left"):
+        resolve_features(["y"], _args())
+
+
+# ---------------------------------------------------------------------------
+# build_result
+# ---------------------------------------------------------------------------
+
+
+def test_build_result_core_shape(train_csv):
+    result = build_result(_args(file=train_csv))
+    assert result["n"] == len(_X)
+    assert result["features"] == ["x1", "x2"]
+    assert [row["term"] for row in result["coefficients"]] == [
+        "(intercept)",
+        "x1",
+        "x2",
+    ]
+    assert set(result["confusion"]) == {"tp", "fp", "tn", "fn"}
+
+
+def test_build_result_confusion_totals_match_n(train_csv):
+    result = build_result(_args(file=train_csv))
+    assert sum(result["confusion"].values()) == result["n"]
+
+
+def test_build_result_threshold_shifts_predictions(train_csv):
+    low = build_result(_args(file=train_csv, threshold=0.1))["confusion"]
+    high = build_result(_args(file=train_csv, threshold=0.9))["confusion"]
+    assert low["tp"] + low["fp"] > high["tp"] + high["fp"]
+
+
+def test_build_result_predict_file(tmp_path, train_csv):
+    new = _write_csv(tmp_path / "new.csv", ["x1", "x2"], [[2, 5], [9, 1]])
+    result = build_result(_args(file=train_csv, predict_file=new))
+    assert [row["row"] for row in result["predictions"]] == [1, 2]
+    assert (
+        result["predictions"][1]["probability"]
+        > result["predictions"][0]["probability"]
+    )
+
+
+def test_build_result_header_only_training_file_raises(tmp_path):
+    path = _write_csv(tmp_path / "head.csv", ["x1", "y"], [])
+    with pytest.raises(ValueError, match="no data rows"):
+        build_result(_args(file=path))
+
+
+def test_build_result_header_only_predict_file_raises(tmp_path, train_csv):
+    path = _write_csv(tmp_path / "head.csv", ["x1", "x2"], [])
+    with pytest.raises(ValueError, match="no data rows"):
+        build_result(_args(file=train_csv, predict_file=path))
+
+
+def test_build_result_accepts_non_numeric_free_target_labels(tmp_path):
+    rows = [[x[0], x[1], 5 if y else 3] for x, y in zip(_X, _Y)]
+    path = _write_csv(tmp_path / "labels.csv", ["x1", "x2", "y"], rows)
+    result = build_result(_args(file=path))
+    assert result["n"] == len(_X)
+
+
+# ---------------------------------------------------------------------------
+# formatting
+# ---------------------------------------------------------------------------
+
+
+def test_format_table_has_every_section(train_csv):
+    text = format_table(build_result(_args(file=train_csv)), 4)
+    for heading in (
+        "Coefficients",
+        "Model fit",
+        "Classification at threshold",
+        "Accuracy",
+    ):
+        assert heading in text
+
+
+def test_format_table_includes_predictions_when_present(tmp_path, train_csv):
+    new = _write_csv(tmp_path / "new.csv", ["x1", "x2"], [[2, 5]])
+    text = format_table(build_result(_args(file=train_csv, predict_file=new)), 4)
+    assert "Predictions" in text
+
+
+def test_format_table_significance_stars(train_csv):
+    text = format_table(build_result(_args(file=train_csv)), 4)
+    assert "Signif. codes" in text
+
+
+@pytest.mark.parametrize(
+    "p,marker",
+    [(0.0001, "***"), (0.005, "**"), (0.02, "*"), (0.07, "."), (0.5, "")],
+)
+def test_significance_markers(p, marker):
+    from src.utils.logistic_regression import _stars
+
+    assert _stars(p) == marker
+
+
+def test_format_table_renders_infinite_z():
+    from src.utils.logistic_regression import _fmt
+
+    assert _fmt(math.inf, 2) == "inf"
+    assert _fmt(-math.inf, 2) == "-inf"
+
+
+def test_format_json_round_trips(train_csv):
+    payload = json.loads(format_json(build_result(_args(file=train_csv))))
+    assert payload["features"] == ["x1", "x2"]
+    assert len(payload["coefficients"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_table_run(capsys, train_csv):
+    assert main(["--file", train_csv, "--target", "y"]) == 0
+    assert "Logistic regression" in capsys.readouterr().out
+
+
+def test_main_json_run(capsys, train_csv):
+    assert main(["--file", train_csv, "--target", "y", "--format", "json"]) == 0
+    assert json.loads(capsys.readouterr().out)["n"] == len(_X)
+
+
+def test_main_selected_features(capsys, train_csv):
+    assert main(["--file", train_csv, "--target", "y", "--features", "x1"]) == 0
+    assert "x2" not in capsys.readouterr().out
+
+
+def test_main_validation_error_exits_two(capsys, train_csv):
+    assert main(["--file", train_csv, "--target", "y", "--threshold", "0"]) == 2
+    assert "--threshold" in capsys.readouterr().err
+
+
+def test_main_missing_file_exits_two(capsys):
+    assert main(["--file", "/nonexistent.csv", "--target", "y"]) == 2
+    assert "could not read" in capsys.readouterr().err
+
+
+def test_main_separable_data_exits_two(capsys, tmp_path):
+    rows = [[float(i), 0.0 if i < 6 else 1.0] for i in range(12)]
+    path = _write_csv(tmp_path / "sep.csv", ["x1", "y"], rows)
+    assert main(["--file", path, "--target", "y"]) == 2
+    assert "separa" in capsys.readouterr().err

--- a/tests/test_multiple_regression.py
+++ b/tests/test_multiple_regression.py
@@ -1,0 +1,634 @@
+"""Tests for the multiple linear regression utility."""
+
+import argparse
+import json
+import math
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from src.utils.multiple_regression import (
+    MultipleRegression,
+    build_result,
+    extract_columns,
+    f_sf,
+    fit,
+    format_csv,
+    format_json,
+    format_table,
+    main,
+    predict,
+    read_csv,
+    resolve_features,
+    t_cdf,
+    t_quantile,
+    validate,
+    variance_inflation_factors,
+)
+
+# Deterministic design: two predictors that are not collinear, and a response
+# built from them with a fixed residual pattern rather than random noise.
+_X = [[float(i), float((i * 7) % 11)] for i in range(24)]
+_WOBBLE = [1.0, -2.0, 0.5, 3.0, -1.5, 0.0]
+_Y = [
+    12.5 + 3.2 * row[0] + 8.1 * row[1] + _WOBBLE[i % len(_WOBBLE)]
+    for i, row in enumerate(_X)
+]
+
+
+def _args(**overrides):
+    """Build a namespace with valid defaults, overridden per test."""
+    base = dict(
+        file="train.csv",
+        target="y",
+        features=None,
+        alpha=0.05,
+        predict_file=None,
+        vif=False,
+        format="table",
+        precision=4,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _write_csv(path, header, rows):
+    """Write a CSV fixture and return its path as a string."""
+    lines = [",".join(header)]
+    lines += [",".join(str(value) for value in row) for row in rows]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(path)
+
+
+@pytest.fixture
+def train_csv(tmp_path):
+    """Training file matching the module-level fixture data."""
+    rows = [[x[0], x[1], y] for x, y in zip(_X, _Y)]
+    return _write_csv(tmp_path / "train.csv", ["x1", "x2", "y"], rows)
+
+
+def _ols_oracle(features, outcomes):
+    """Independent OLS solution via numpy, for oracle comparisons."""
+    design = np.column_stack([np.ones(len(features)), np.array(features, dtype=float)])
+    y = np.array(outcomes, dtype=float)
+    beta, *_ = np.linalg.lstsq(design, y, rcond=None)
+    n, k = design.shape
+    df = n - k
+    residuals = y - design @ beta
+    mse = float(residuals @ residuals) / df
+    std_errors = np.sqrt(mse * np.diag(np.linalg.inv(design.T @ design)))
+    return design, y, beta, std_errors, df, mse
+
+
+# ---------------------------------------------------------------------------
+# Distribution helpers
+# ---------------------------------------------------------------------------
+
+
+def test_t_cdf_at_zero_is_half():
+    assert t_cdf(0.0, 10) == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize("t_stat,df", [(-2.5, 7), (-0.4, 3), (1.1, 15), (3.3, 40)])
+def test_t_cdf_matches_scipy(t_stat, df):
+    assert t_cdf(t_stat, df) == pytest.approx(float(stats.t.cdf(t_stat, df)), abs=1e-12)
+
+
+def test_t_cdf_rejects_zero_df():
+    with pytest.raises(ValueError, match="df must be > 0"):
+        t_cdf(1.0, 0)
+
+
+@pytest.mark.parametrize("p,df", [(0.975, 12), (0.95, 5), (0.005, 30), (0.5, 8)])
+def test_t_quantile_matches_scipy(p, df):
+    assert t_quantile(p, df) == pytest.approx(float(stats.t.ppf(p, df)), abs=1e-6)
+
+
+def test_t_quantile_inverts_t_cdf():
+    assert t_cdf(t_quantile(0.9, 11), 11) == pytest.approx(0.9, abs=1e-6)
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0])
+def test_t_quantile_rejects_endpoints(bad):
+    with pytest.raises(ValueError, match="strictly between 0 and 1"):
+        t_quantile(bad, 10)
+
+
+def test_t_quantile_rejects_zero_df():
+    with pytest.raises(ValueError, match="df must be > 0"):
+        t_quantile(0.5, 0)
+
+
+@pytest.mark.parametrize(
+    "f_stat,df1,df2", [(0.5, 3, 20), (2.0, 1, 10), (50.0, 4, 100), (1417.5, 2, 37)]
+)
+def test_f_sf_matches_scipy(f_stat, df1, df2):
+    assert f_sf(f_stat, df1, df2) == pytest.approx(
+        float(stats.f.sf(f_stat, df1, df2)), rel=1e-10
+    )
+
+
+def test_f_sf_stays_accurate_in_the_far_tail():
+    """The 1 - cdf form collapses to exactly 0 here; the direct form must not."""
+    value = f_sf(1417.5, 2, 37)
+    assert value > 0.0
+    assert value == pytest.approx(float(stats.f.sf(1417.5, 2, 37)), rel=1e-10)
+
+
+def test_f_sf_at_zero_is_one():
+    assert f_sf(0.0, 2, 10) == 1.0
+
+
+def test_f_sf_at_infinity_is_zero():
+    assert f_sf(math.inf, 2, 10) == 0.0
+
+
+@pytest.mark.parametrize("df1,df2", [(0, 5), (5, 0)])
+def test_f_sf_rejects_bad_df(df1, df2):
+    with pytest.raises(ValueError, match="must be >= 1"):
+        f_sf(1.0, df1, df2)
+
+
+def test_f_sf_rejects_negative_statistic():
+    with pytest.raises(ValueError, match="must be >= 0"):
+        f_sf(-1.0, 2, 5)
+
+
+# ---------------------------------------------------------------------------
+# fit
+# ---------------------------------------------------------------------------
+
+
+def test_fit_recovers_known_coefficients():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    assert model.coefficients[1] == pytest.approx(3.2, abs=0.2)
+    assert model.coefficients[2] == pytest.approx(8.1, abs=0.2)
+
+
+def test_fit_coefficients_match_numpy_lstsq():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    _, _, beta, _, _, _ = _ols_oracle(_X, _Y)
+    assert model.coefficients == pytest.approx(list(beta), rel=1e-10)
+
+
+def test_fit_standard_errors_match_oracle():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    _, _, _, std_errors, _, _ = _ols_oracle(_X, _Y)
+    assert model.std_errors == pytest.approx(list(std_errors), rel=1e-10)
+
+
+def test_fit_p_values_match_scipy():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    _, _, beta, std_errors, df, _ = _ols_oracle(_X, _Y)
+    expected = 2 * stats.t.sf(np.abs(beta / std_errors), df)
+    assert model.p_values == pytest.approx(list(expected), abs=1e-12)
+
+
+def test_fit_f_statistic_and_p_match_scipy():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    expected = float(stats.f.sf(model.f_statistic, model.df_model, model.df))
+    assert model.f_p_value == pytest.approx(expected, rel=1e-10)
+
+
+def test_fit_residuals_are_orthogonal_to_predictors():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    design = np.column_stack([np.ones(len(_X)), np.array(_X)])
+    assert np.max(np.abs(design.T @ model.residuals)) == pytest.approx(0.0, abs=1e-8)
+
+
+def test_fit_default_names():
+    assert fit(_X, _Y).names == ["(intercept)", "x1", "x2"]
+
+
+def test_fit_empty_data_raises():
+    with pytest.raises(ValueError, match="no observations"):
+        fit([], [])
+
+
+def test_fit_length_mismatch_raises():
+    with pytest.raises(ValueError, match="but 1 responses"):
+        fit(_X, [1.0])
+
+
+def test_fit_no_columns_raises():
+    with pytest.raises(ValueError, match="no predictor columns"):
+        fit([[], []], [1.0, 2.0])
+
+
+def test_fit_ragged_rows_raise():
+    with pytest.raises(ValueError, match="same number of columns"):
+        fit([[1.0, 2.0], [3.0]], [1.0, 2.0])
+
+
+def test_fit_no_residual_df_raises():
+    with pytest.raises(ValueError, match="more observations than parameters"):
+        fit([[1.0, 2.0], [3.0, 4.0]], [1.0, 2.0])
+
+
+def test_fit_collinear_predictors_raise():
+    rows = [[float(i), float(2 * i)] for i in range(12)]
+    with pytest.raises(ValueError, match="collinear"):
+        fit(rows, [float(i) for i in range(12)])
+
+
+def test_fit_constant_predictor_raises():
+    rows = [[float(i), 5.0] for i in range(12)]
+    with pytest.raises(ValueError, match="collinear"):
+        fit(rows, [float(i) for i in range(12)])
+
+
+# ---------------------------------------------------------------------------
+# Model statistics
+# ---------------------------------------------------------------------------
+
+
+def test_r_squared_matches_oracle():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    y = np.array(_Y)
+    expected = 1.0 - model.sse / float(np.sum((y - y.mean()) ** 2))
+    assert model.r_squared == pytest.approx(expected)
+
+
+def test_adjusted_r_squared_below_r_squared():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    assert model.adj_r_squared < model.r_squared
+
+
+def test_constant_response_is_rejected():
+    """Zero response variance leaves nothing to explain, and would otherwise
+    produce a negative F from roundoff-signed sums of squares."""
+    rows = [[float(i), float((i * 3) % 5)] for i in range(10)]
+    with pytest.raises(ValueError, match="response is constant"):
+        fit(rows, [7.0] * 10)
+
+
+def test_exactly_linear_response_gives_huge_finite_f():
+    """Normal-equation roundoff keeps the residual mean square positive, so the
+    F-statistic is enormous but finite. The direct-tail f_sf still resolves the
+    p-value instead of collapsing it to zero the way 1 - cdf would."""
+    rows = [[float(i), float((i * 3) % 5)] for i in range(10)]
+    exact = [2.0 * row[0] + 3.0 * row[1] for row in rows]
+    model = fit(rows, exact)
+    assert model.r_squared == pytest.approx(1.0)
+    assert model.f_statistic > 1e20
+    assert math.isfinite(model.f_statistic)
+    assert 0.0 < model.f_p_value < 1e-50
+
+
+def test_residual_std_error_is_root_mse():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    assert model.residual_std_error == pytest.approx(math.sqrt(model.mse))
+
+
+def test_t_stat_infinite_when_standard_error_is_zero():
+    model = MultipleRegression(
+        coefficients=[1.0],
+        names=["(intercept)"],
+        xtx_inv=np.zeros((1, 1)),
+        residuals=np.zeros(4),
+        fitted=np.ones(4),
+        observed=np.array([1.0, 2.0, 3.0, 4.0]),
+    )
+    assert math.isinf(model.t_stats[0])
+
+
+def test_confidence_intervals_match_scipy():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    crit = float(stats.t.ppf(0.975, model.df))
+    for coef, se, (low, high) in zip(
+        model.coefficients, model.std_errors, model.confidence_intervals(0.05)
+    ):
+        assert low == pytest.approx(coef - crit * se, rel=1e-8)
+        assert high == pytest.approx(coef + crit * se, rel=1e-8)
+
+
+def test_confidence_intervals_widen_at_smaller_alpha():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    narrow = model.confidence_intervals(0.05)[1]
+    wide = model.confidence_intervals(0.01)[1]
+    assert wide[1] - wide[0] > narrow[1] - narrow[0]
+
+
+# ---------------------------------------------------------------------------
+# predict
+# ---------------------------------------------------------------------------
+
+
+def test_predict_point_matches_manual_dot_product():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    expected = (
+        model.coefficients[0]
+        + model.coefficients[1] * 12.0
+        + model.coefficients[2] * 4.0
+    )
+    assert predict(model, [12.0, 4.0])["fit"] == pytest.approx(expected)
+
+
+def test_prediction_interval_is_wider_than_confidence_interval():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    out = predict(model, [12.0, 4.0])
+    assert out["pi_lower"] < out["ci_lower"]
+    assert out["pi_upper"] > out["ci_upper"]
+
+
+def test_predict_intervals_match_oracle():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    design, _, beta, _, df, mse = _ols_oracle(_X, _Y)
+    x0 = np.array([1.0, 12.0, 4.0])
+    leverage = float(x0 @ np.linalg.inv(design.T @ design) @ x0)
+    crit = float(stats.t.ppf(0.975, df))
+    point = float(x0 @ beta)
+
+    out = predict(model, [12.0, 4.0], 0.05)
+    assert out["ci_lower"] == pytest.approx(point - crit * math.sqrt(mse * leverage))
+    assert out["pi_upper"] == pytest.approx(
+        point + crit * math.sqrt(mse * (1 + leverage))
+    )
+
+
+def test_predict_interval_widens_away_from_the_data_centre():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    near = predict(model, [12.0, 5.0])
+    far = predict(model, [500.0, 5.0])
+    assert far["ci_upper"] - far["ci_lower"] > near["ci_upper"] - near["ci_lower"]
+
+
+def test_predict_wrong_width_raises():
+    model = fit(_X, _Y, names=["x1", "x2"])
+    with pytest.raises(ValueError, match="expected 2 predictors"):
+        predict(model, [1.0])
+
+
+# ---------------------------------------------------------------------------
+# variance inflation
+# ---------------------------------------------------------------------------
+
+
+def test_vif_near_one_for_uncorrelated_predictors():
+    factors = variance_inflation_factors(_X)
+    assert all(1.0 <= value < 2.0 for value in factors)
+
+
+def test_vif_matches_pairwise_correlation_formula():
+    """With two predictors, VIF reduces to 1 / (1 - r²)."""
+    matrix = np.array(_X)
+    r = float(np.corrcoef(matrix[:, 0], matrix[:, 1])[0, 1])
+    expected = 1.0 / (1.0 - r * r)
+    assert variance_inflation_factors(_X) == pytest.approx([expected, expected])
+
+
+def test_vif_infinite_for_exact_linear_dependence():
+    rows = [[float(i), float(2 * i), float((i * 5) % 7)] for i in range(12)]
+    factors = variance_inflation_factors(rows)
+    assert math.isinf(factors[0])
+    assert math.isinf(factors[1])
+
+
+def test_vif_infinite_for_constant_predictor():
+    rows = [[float(i), 3.0] for i in range(10)]
+    assert math.isinf(variance_inflation_factors(rows)[1])
+
+
+def test_vif_needs_two_predictors():
+    with pytest.raises(ValueError, match="at least two predictors"):
+        variance_inflation_factors([[1.0], [2.0], [3.0]])
+
+
+# ---------------------------------------------------------------------------
+# CSV input
+# ---------------------------------------------------------------------------
+
+
+def test_read_csv_returns_header_and_rows(train_csv):
+    columns, rows = read_csv(train_csv)
+    assert columns == ["x1", "x2", "y"]
+    assert len(rows) == len(_X)
+
+
+def test_read_csv_missing_file_raises():
+    with pytest.raises(ValueError, match="could not read"):
+        read_csv("/nonexistent/path/data.csv")
+
+
+def test_read_csv_empty_file_raises(tmp_path):
+    path = tmp_path / "empty.csv"
+    path.write_text("", encoding="utf-8")
+    with pytest.raises(ValueError, match="header row is required"):
+        read_csv(str(path))
+
+
+def test_extract_columns_missing_column_raises(train_csv):
+    _, rows = read_csv(train_csv)
+    with pytest.raises(ValueError, match="missing on line"):
+        extract_columns(rows, ["nope"])
+
+
+def test_extract_columns_non_numeric_raises(tmp_path):
+    path = _write_csv(tmp_path / "bad.csv", ["a", "y"], [[1, 2], ["oops", 3]])
+    _, rows = read_csv(path)
+    with pytest.raises(ValueError, match="not numeric"):
+        extract_columns(rows, ["a"])
+
+
+# ---------------------------------------------------------------------------
+# validate / resolve_features
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_defaults():
+    assert validate(_args()) is None
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.5, 2.0])
+def test_validate_rejects_alpha_outside_interval(bad):
+    assert "--alpha" in validate(_args(alpha=bad))
+
+
+def test_validate_rejects_negative_precision():
+    assert "--precision" in validate(_args(precision=-1))
+
+
+def test_validate_rejects_target_as_feature():
+    assert "cannot also be a feature" in validate(_args(features=["x1", "y"]))
+
+
+def test_resolve_features_defaults_to_all_but_target():
+    assert resolve_features(["x1", "x2", "y"], _args()) == ["x1", "x2"]
+
+
+def test_resolve_features_missing_target_raises():
+    with pytest.raises(ValueError, match="target column"):
+        resolve_features(["x1", "x2"], _args())
+
+
+def test_resolve_features_missing_feature_raises():
+    with pytest.raises(ValueError, match="feature column"):
+        resolve_features(["x1", "y"], _args(features=["nope"]))
+
+
+def test_resolve_features_none_left_raises():
+    with pytest.raises(ValueError, match="no predictor columns left"):
+        resolve_features(["y"], _args())
+
+
+# ---------------------------------------------------------------------------
+# build_result
+# ---------------------------------------------------------------------------
+
+
+def test_build_result_core_shape(train_csv):
+    result = build_result(_args(file=train_csv))
+    assert result["n"] == len(_X)
+    assert [row["term"] for row in result["coefficients"]] == [
+        "(intercept)",
+        "x1",
+        "x2",
+    ]
+    assert result["fit"]["df"] == len(_X) - 3
+
+
+def test_build_result_includes_vif_when_requested(train_csv):
+    result = build_result(_args(file=train_csv, vif=True))
+    assert [row["term"] for row in result["vif"]] == ["x1", "x2"]
+
+
+def test_build_result_vif_needs_two_features(train_csv):
+    with pytest.raises(ValueError, match="at least two predictors"):
+        build_result(_args(file=train_csv, features=["x1"], vif=True))
+
+
+def test_build_result_predictions(tmp_path, train_csv):
+    new = _write_csv(tmp_path / "new.csv", ["x1", "x2"], [[5, 3], [20, 9]])
+    result = build_result(_args(file=train_csv, predict_file=new))
+    assert [row["row"] for row in result["predictions"]] == [1, 2]
+    assert result["predictions"][0]["pi_upper"] > result["predictions"][0]["ci_upper"]
+
+
+def test_build_result_alpha_widens_intervals(train_csv):
+    narrow = build_result(_args(file=train_csv))["coefficients"][1]
+    wide = build_result(_args(file=train_csv, alpha=0.01))["coefficients"][1]
+    assert wide["ci_upper"] - wide["ci_lower"] > narrow["ci_upper"] - narrow["ci_lower"]
+
+
+def test_build_result_header_only_file_raises(tmp_path):
+    path = _write_csv(tmp_path / "head.csv", ["x1", "y"], [])
+    with pytest.raises(ValueError, match="no data rows"):
+        build_result(_args(file=path))
+
+
+def test_build_result_header_only_predict_file_raises(tmp_path, train_csv):
+    path = _write_csv(tmp_path / "head.csv", ["x1", "x2"], [])
+    with pytest.raises(ValueError, match="no data rows"):
+        build_result(_args(file=train_csv, predict_file=path))
+
+
+# ---------------------------------------------------------------------------
+# formatting
+# ---------------------------------------------------------------------------
+
+
+def test_format_table_has_every_section(tmp_path, train_csv):
+    new = _write_csv(tmp_path / "new.csv", ["x1", "x2"], [[5, 3]])
+    result = build_result(_args(file=train_csv, vif=True, predict_file=new))
+    text = format_table(result, 4)
+    for heading in (
+        "Multiple regression",
+        "Coefficients",
+        "Model fit",
+        "Variance inflation",
+        "Predictions",
+    ):
+        assert heading in text
+
+
+def test_format_table_flags_multicollinearity(tmp_path):
+    rows = [
+        [float(i), float(2 * i + (i % 2) * 0.001), float(i) * 3.0 + (i % 3)]
+        for i in range(20)
+    ]
+    path = _write_csv(tmp_path / "col.csv", ["x1", "x2", "y"], rows)
+    text = format_table(build_result(_args(file=path, vif=True)), 4)
+    assert "multicollinear" in text
+
+
+def test_format_table_reports_interval_level(train_csv):
+    text = format_table(build_result(_args(file=train_csv, alpha=0.10)), 4)
+    assert "90% CI" in text
+
+
+def test_format_table_renders_infinity():
+    from src.utils.multiple_regression import _fmt
+
+    assert _fmt(math.inf, 2) == "inf"
+    assert _fmt(-math.inf, 2) == "-inf"
+
+
+@pytest.mark.parametrize(
+    "p,marker",
+    [(0.0001, "***"), (0.005, "**"), (0.02, "*"), (0.07, "."), (0.5, "")],
+)
+def test_significance_markers(p, marker):
+    from src.utils.multiple_regression import _stars
+
+    assert _stars(p) == marker
+
+
+def test_format_csv_has_a_row_per_coefficient(train_csv):
+    text = format_csv(build_result(_args(file=train_csv)), 4)
+    assert text.splitlines()[0].startswith("section,term")
+    assert len(text.splitlines()) == 4
+
+
+def test_format_csv_appends_predictions(tmp_path, train_csv):
+    new = _write_csv(tmp_path / "new.csv", ["x1", "x2"], [[5, 3]])
+    text = format_csv(build_result(_args(file=train_csv, predict_file=new)), 4)
+    assert "prediction," in text
+
+
+def test_format_json_round_trips(train_csv):
+    payload = json.loads(format_json(build_result(_args(file=train_csv))))
+    assert payload["features"] == ["x1", "x2"]
+    assert len(payload["coefficients"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_table_run(capsys, train_csv):
+    assert main(["--file", train_csv, "--target", "y"]) == 0
+    assert "Multiple regression" in capsys.readouterr().out
+
+
+def test_main_json_run(capsys, train_csv):
+    assert main(["--file", train_csv, "--target", "y", "--format", "json"]) == 0
+    assert json.loads(capsys.readouterr().out)["n"] == len(_X)
+
+
+def test_main_csv_run(capsys, train_csv):
+    assert main(["--file", train_csv, "--target", "y", "--format", "csv"]) == 0
+    assert "section,term" in capsys.readouterr().out
+
+
+def test_main_vif_flag(capsys, train_csv):
+    assert main(["--file", train_csv, "--target", "y", "--vif"]) == 0
+    assert "Variance inflation" in capsys.readouterr().out
+
+
+def test_main_validation_error_exits_two(capsys, train_csv):
+    assert main(["--file", train_csv, "--target", "y", "--alpha", "0"]) == 2
+    assert "--alpha" in capsys.readouterr().err
+
+
+def test_main_missing_file_exits_two(capsys):
+    assert main(["--file", "/nonexistent.csv", "--target", "y"]) == 2
+    assert "could not read" in capsys.readouterr().err
+
+
+def test_main_collinear_data_exits_two(capsys, tmp_path):
+    rows = [[float(i), float(2 * i), float(i) + 1.0] for i in range(12)]
+    path = _write_csv(tmp_path / "col.csv", ["x1", "x2", "y"], rows)
+    assert main(["--file", path, "--target", "y"]) == 2
+    assert "collinear" in capsys.readouterr().err

--- a/tests/test_slope_intercept.py
+++ b/tests/test_slope_intercept.py
@@ -1,0 +1,604 @@
+"""Tests for the slope-intercept line utility."""
+
+import argparse
+import json
+import math
+
+import pytest
+
+from src.utils.slope_intercept import (
+    angle_of_inclination,
+    build_result,
+    distance_to_point,
+    evaluate,
+    foot_of_perpendicular,
+    format_equation,
+    format_json,
+    format_standard,
+    format_table,
+    intersection,
+    is_parallel,
+    is_perpendicular,
+    line_from_point_slope,
+    line_from_points,
+    line_from_standard,
+    main,
+    parse_point,
+    perpendicular_slope,
+    relationship,
+    resolve_line,
+    slope,
+    solve_for_x,
+    table_rows,
+    to_standard,
+    validate,
+    x_intercept,
+    y_intercept,
+)
+
+
+def _args(**overrides):
+    """Build a namespace with a valid default line, overridden per test."""
+    base = dict(
+        points=None,
+        slope=2.0,
+        intercept=1.0,
+        point=None,
+        standard=None,
+        at=None,
+        solve=None,
+        intersect=None,
+        perpendicular=False,
+        parallel=False,
+        distance=False,
+        table=None,
+        format="table",
+        precision=4,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# slope / line construction
+# ---------------------------------------------------------------------------
+
+
+def test_slope_matches_rise_over_run():
+    assert slope((0.0, 32.0), (100.0, 212.0)) == pytest.approx(1.8)
+
+
+def test_slope_negative_when_falling():
+    assert slope((0.0, 30000.0), (5.0, 5000.0)) == pytest.approx(-5000.0)
+
+
+def test_slope_zero_for_horizontal():
+    assert slope((1.0, 7.0), (9.0, 7.0)) == 0.0
+
+
+def test_slope_vertical_raises():
+    with pytest.raises(ValueError, match="vertical line"):
+        slope((3.0, 1.0), (3.0, 5.0))
+
+
+def test_slope_identical_points_raises():
+    with pytest.raises(ValueError, match="identical"):
+        slope((3.0, 1.0), (3.0, 1.0))
+
+
+def test_line_from_points_celsius_to_fahrenheit():
+    m, b = line_from_points((0.0, 32.0), (100.0, 212.0))
+    assert m == pytest.approx(1.8)
+    assert b == pytest.approx(32.0)
+
+
+def test_line_from_points_intercept_from_second_point():
+    m, b = line_from_points((2.0, 5.0), (4.0, 11.0))
+    assert (m, b) == pytest.approx((3.0, -1.0))
+
+
+def test_line_from_point_slope_recovers_intercept():
+    assert line_from_point_slope((4.0, 3.0), -0.5) == pytest.approx((-0.5, 5.0))
+
+
+def test_line_from_standard_matches_algebra():
+    assert line_from_standard(3.0, -2.0, 6.0) == pytest.approx((1.5, -3.0))
+
+
+def test_line_from_standard_zero_b_is_vertical():
+    with pytest.raises(ValueError, match="vertical line"):
+        line_from_standard(2.0, 0.0, 6.0)
+
+
+def test_line_from_standard_all_zero_is_not_a_line():
+    with pytest.raises(ValueError, match="not a line"):
+        line_from_standard(0.0, 0.0, 6.0)
+
+
+# ---------------------------------------------------------------------------
+# to_standard
+# ---------------------------------------------------------------------------
+
+
+def test_to_standard_clears_fractional_slope():
+    assert to_standard(1.8, 32.0) == (9, -5, -160)
+
+
+def test_to_standard_reduces_by_gcd():
+    assert to_standard(2.0, 4.0) == (2, -1, -4)
+
+
+def test_to_standard_leading_coefficient_positive():
+    a, _, _ = to_standard(-3.0, 2.0)
+    assert a > 0
+
+
+def test_to_standard_horizontal_line_has_zero_a():
+    assert to_standard(0.0, 5.0) == (0, 1, 5)
+
+
+def test_to_standard_round_trips_through_line_from_standard():
+    a, b, c = to_standard(0.25, -1.5)
+    assert line_from_standard(a, b, c) == pytest.approx((0.25, -1.5))
+
+
+@pytest.mark.parametrize("bad", [math.inf, -math.inf, math.nan])
+def test_to_standard_non_finite_raises(bad):
+    with pytest.raises(ValueError, match="finite"):
+        to_standard(bad, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# evaluate / solve / intercepts
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_celsius_to_fahrenheit():
+    assert evaluate(1.8, 32.0, 37.0) == pytest.approx(98.6)
+
+
+def test_solve_for_x_inverts_evaluate():
+    assert solve_for_x(1.8, 32.0, 98.6) == pytest.approx(37.0)
+
+
+def test_solve_for_x_horizontal_raises():
+    with pytest.raises(ValueError, match="horizontal line"):
+        solve_for_x(0.0, 5.0, 2.0)
+
+
+def test_x_intercept_matches_negative_b_over_m():
+    assert x_intercept(2.0, 1.0) == pytest.approx(-0.5)
+
+
+def test_x_intercept_horizontal_raises():
+    with pytest.raises(ValueError, match="horizontal line"):
+        x_intercept(0.0, 5.0)
+
+
+def test_y_intercept_returns_b():
+    assert y_intercept(2.0, 1.0) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# parallel / perpendicular / intersection
+# ---------------------------------------------------------------------------
+
+
+def test_is_parallel_exact_match():
+    assert is_parallel(2.0, 2.0)
+
+
+def test_is_parallel_within_tolerance():
+    assert is_parallel(2.0, 2.0 + 1e-12)
+
+
+def test_is_parallel_outside_tolerance():
+    assert not is_parallel(2.0, 2.5)
+
+
+def test_is_perpendicular_true_for_negative_reciprocal():
+    assert is_perpendicular(2.0, -0.5)
+
+
+def test_is_perpendicular_survives_float_drift():
+    assert is_perpendicular(3.0, -1.0 / 3.0)
+
+
+def test_is_perpendicular_false_for_parallel():
+    assert not is_perpendicular(2.0, 2.0)
+
+
+def test_perpendicular_slope_is_negative_reciprocal():
+    assert perpendicular_slope(2.0) == pytest.approx(-0.5)
+
+
+def test_perpendicular_slope_horizontal_raises():
+    with pytest.raises(ValueError, match="vertical"):
+        perpendicular_slope(0.0)
+
+
+def test_intersection_breakeven_point():
+    point = intersection((10.0, 50000.0), (25.0, 0.0))
+    assert point == pytest.approx((3333.3333333, 83333.3333333))
+
+
+def test_intersection_parallel_returns_none():
+    assert intersection((2.0, 1.0), (2.0, 9.0)) is None
+
+
+def test_intersection_coincident_returns_none():
+    assert intersection((2.0, 1.0), (2.0, 1.0)) is None
+
+
+def test_intersection_point_lies_on_both_lines():
+    x, y = intersection((3.0, -1.0), (-1.0, 7.0))
+    assert evaluate(3.0, -1.0, x) == pytest.approx(y)
+    assert evaluate(-1.0, 7.0, x) == pytest.approx(y)
+
+
+@pytest.mark.parametrize(
+    "line2,expected",
+    [
+        ((2.0, 1.0), "coincident"),
+        ((2.0, 9.0), "parallel"),
+        ((-0.5, 3.0), "perpendicular"),
+        ((5.0, 3.0), "intersecting"),
+    ],
+)
+def test_relationship_classifies(line2, expected):
+    assert relationship((2.0, 1.0), line2) == expected
+
+
+# ---------------------------------------------------------------------------
+# distance / projection / angle
+# ---------------------------------------------------------------------------
+
+
+def test_distance_to_point_matches_formula():
+    assert distance_to_point(2.0, 1.0, (4.0, 3.0)) == pytest.approx(
+        6.0 / math.sqrt(5.0)
+    )
+
+
+def test_distance_zero_for_point_on_line():
+    assert distance_to_point(2.0, 1.0, (3.0, 7.0)) == pytest.approx(0.0)
+
+
+def test_foot_of_perpendicular_lies_on_line():
+    fx, fy = foot_of_perpendicular(2.0, 1.0, (4.0, 3.0))
+    assert evaluate(2.0, 1.0, fx) == pytest.approx(fy)
+
+
+def test_foot_distance_equals_distance_to_point():
+    point = (4.0, 3.0)
+    foot = foot_of_perpendicular(2.0, 1.0, point)
+    assert math.dist(point, foot) == pytest.approx(distance_to_point(2.0, 1.0, point))
+
+
+def test_angle_of_inclination_45_degrees():
+    assert angle_of_inclination(1.0) == pytest.approx(45.0)
+
+
+def test_angle_of_inclination_horizontal_is_zero():
+    assert angle_of_inclination(0.0) == 0.0
+
+
+def test_angle_of_inclination_negative_slope_is_obtuse():
+    assert angle_of_inclination(-1.0) == pytest.approx(135.0)
+
+
+# ---------------------------------------------------------------------------
+# table_rows
+# ---------------------------------------------------------------------------
+
+
+def test_table_rows_endpoints_and_count():
+    rows = table_rows(-5000.0, 30000.0, 0.0, 5.0, 1.0)
+    assert len(rows) == 6
+    assert rows[0] == (0.0, 30000.0)
+    assert rows[-1] == pytest.approx((5.0, 5000.0))
+
+
+def test_table_rows_step_not_landing_on_stop():
+    rows = table_rows(1.0, 0.0, 0.0, 1.0, 0.4)
+    assert [x for x, _ in rows] == pytest.approx([0.0, 0.4, 0.8])
+
+
+def test_table_rows_bad_step_raises():
+    with pytest.raises(ValueError, match="step must be > 0"):
+        table_rows(1.0, 0.0, 0.0, 5.0, 0.0)
+
+
+def test_table_rows_reversed_range_raises():
+    with pytest.raises(ValueError, match="stop must be >= start"):
+        table_rows(1.0, 0.0, 5.0, 0.0, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# parse_point
+# ---------------------------------------------------------------------------
+
+
+def test_parse_point_reads_pair():
+    assert parse_point("4,3") == (4.0, 3.0)
+
+
+def test_parse_point_accepts_negatives_and_decimals():
+    assert parse_point("-1.5,2.25") == (-1.5, 2.25)
+
+
+@pytest.mark.parametrize("bad", ["4", "4,3,2", "a,3", "4,b", ""])
+def test_parse_point_rejects_malformed(bad):
+    with pytest.raises(argparse.ArgumentTypeError, match="expected X,Y"):
+        parse_point(bad)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_slope_intercept():
+    assert validate(_args()) is None
+
+
+def test_validate_requires_a_line():
+    assert "no line given" in validate(_args(slope=None, intercept=None))
+
+
+def test_validate_rejects_two_line_sources():
+    msg = validate(_args(points=[(0.0, 0.0), (1.0, 1.0)]))
+    assert "mutually exclusive" in msg
+
+
+def test_validate_slope_alone_is_underdetermined():
+    assert "needs either --intercept" in validate(_args(intercept=None))
+
+
+def test_validate_intercept_without_slope():
+    assert "--intercept needs --slope" in validate(_args(slope=None))
+
+
+def test_validate_negative_precision():
+    assert "--precision" in validate(_args(precision=-1))
+
+
+@pytest.mark.parametrize("flag", ["distance", "perpendicular", "parallel"])
+def test_validate_geometry_flags_need_point(flag):
+    msg = validate(_args(**{flag: True}))
+    assert "requires --point" in msg
+
+
+@pytest.mark.parametrize("flag", ["distance", "perpendicular", "parallel"])
+def test_validate_geometry_flags_reject_point_slope_anchor(flag):
+    msg = validate(_args(intercept=None, point=(4.0, 3.0), **{flag: True}))
+    assert "already" in msg
+
+
+def test_validate_table_step_must_be_positive():
+    assert "STEP must be > 0" in validate(_args(table=[0.0, 5.0, 0.0]))
+
+
+def test_validate_table_reversed_range():
+    assert "MAX must be >= MIN" in validate(_args(table=[5.0, 0.0, 1.0]))
+
+
+def test_validate_accepts_full_table():
+    assert validate(_args(table=[0.0, 5.0, 1.0])) is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_line / build_result
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_line_from_points():
+    assert resolve_line(
+        _args(slope=None, intercept=None, points=[(0.0, 32.0), (100.0, 212.0)])
+    ) == pytest.approx((1.8, 32.0))
+
+
+def test_resolve_line_from_standard():
+    assert resolve_line(
+        _args(slope=None, intercept=None, standard=[3.0, -2.0, 6.0])
+    ) == pytest.approx((1.5, -3.0))
+
+
+def test_resolve_line_from_point_slope():
+    assert resolve_line(
+        _args(slope=-0.5, intercept=None, point=(4.0, 3.0))
+    ) == pytest.approx((-0.5, 5.0))
+
+
+def test_build_result_core_fields():
+    result = build_result(_args())
+    assert result["slope"] == 2.0
+    assert result["equation"] == "y = 2x + 1"
+    assert result["standard"] == {"a": 2, "b": -1, "c": -1}
+    assert result["x_intercept"] == pytest.approx(-0.5)
+    assert result["horizontal"] is False
+
+
+def test_build_result_horizontal_has_no_x_intercept():
+    result = build_result(_args(slope=0.0, intercept=5.0))
+    assert result["x_intercept"] is None
+    assert result["horizontal"] is True
+
+
+def test_build_result_evaluate_and_solve():
+    result = build_result(_args(slope=1.8, intercept=32.0, at=37.0, solve=98.6))
+    assert result["evaluate"]["y"] == pytest.approx(98.6)
+    assert result["solve"]["x"] == pytest.approx(37.0)
+
+
+def test_build_result_solve_on_horizontal_raises():
+    with pytest.raises(ValueError, match="horizontal line"):
+        build_result(_args(slope=0.0, intercept=5.0, solve=2.0))
+
+
+def test_build_result_intersection():
+    result = build_result(_args(slope=10.0, intercept=50000.0, intersect=(25.0, 0.0)))
+    assert result["intersect"]["relationship"] == "intersecting"
+    assert result["intersect"]["point"]["x"] == pytest.approx(3333.3333333)
+
+
+def test_build_result_parallel_intersection_has_no_point():
+    result = build_result(_args(intersect=(2.0, 9.0)))
+    assert result["intersect"]["point"] is None
+    assert result["intersect"]["relationship"] == "parallel"
+
+
+def test_build_result_perpendicular_and_parallel_lines():
+    result = build_result(_args(point=(4.0, 3.0), perpendicular=True, parallel=True))
+    assert result["perpendicular"]["equation"] == "y = -0.5x + 5"
+    assert result["parallel"]["slope"] == 2.0
+    assert result["parallel"]["intercept"] == pytest.approx(-5.0)
+
+
+def test_build_result_perpendicular_to_horizontal_raises():
+    with pytest.raises(ValueError, match="vertical"):
+        build_result(
+            _args(slope=0.0, intercept=5.0, point=(4.0, 3.0), perpendicular=True)
+        )
+
+
+def test_build_result_distance_block():
+    result = build_result(_args(point=(4.0, 3.0), distance=True))
+    assert result["distance"]["distance"] == pytest.approx(6.0 / math.sqrt(5.0))
+    assert result["distance"]["foot"]["x"] == pytest.approx(1.6)
+
+
+def test_build_result_table():
+    result = build_result(
+        _args(slope=-5000.0, intercept=30000.0, table=[0.0, 5.0, 1.0])
+    )
+    assert len(result["table"]) == 6
+    assert result["table"][-1]["y"] == pytest.approx(5000.0)
+
+
+# ---------------------------------------------------------------------------
+# formatting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "m,b,expected",
+    [
+        (2.0, 1.0, "y = 2x + 1"),
+        (2.0, -1.0, "y = 2x - 1"),
+        (2.0, 0.0, "y = 2x"),
+        (1.0, 3.0, "y = x + 3"),
+        (-1.0, 3.0, "y = -x + 3"),
+        (0.0, 5.0, "y = 5"),
+        (-0.5, 5.0, "y = -0.5x + 5"),
+    ],
+)
+def test_format_equation(m, b, expected):
+    assert format_equation(m, b) == expected
+
+
+@pytest.mark.parametrize(
+    "coeffs,expected",
+    [
+        ((2, -1, -1), "2x - y = -1"),
+        ((9, -5, -160), "9x - 5y = -160"),
+        ((0, 1, 5), "y = 5"),
+        ((1, 1, 4), "x + y = 4"),
+        ((-1, 1, 4), "-x + y = 4"),
+        ((1, -1, 0), "x - y = 0"),
+        ((0, -1, 5), "-y = 5"),
+    ],
+)
+def test_format_standard(coeffs, expected):
+    assert format_standard(*coeffs) == expected
+
+
+def test_format_table_includes_every_requested_block():
+    args = _args(
+        at=1.0,
+        solve=5.0,
+        intersect=(25.0, 0.0),
+        point=(4.0, 3.0),
+        perpendicular=True,
+        parallel=True,
+        distance=True,
+        table=[0.0, 2.0, 1.0],
+    )
+    text = format_table(build_result(args), 4)
+    for heading in (
+        "Line",
+        "Evaluate",
+        "Solve",
+        "Intersection",
+        "Perpendicular through point",
+        "Parallel through point",
+        "Distance to point",
+        "Table",
+    ):
+        assert heading in text
+
+
+def test_format_table_horizontal_reports_no_x_intercept():
+    text = format_table(build_result(_args(slope=0.0, intercept=5.0)), 4)
+    assert "none (horizontal line)" in text
+
+
+def test_format_table_parallel_intersection_note():
+    text = format_table(build_result(_args(intersect=(2.0, 9.0))), 4)
+    assert "parallel lines never meet" in text
+
+
+def test_format_table_coincident_intersection_note():
+    text = format_table(build_result(_args(intersect=(2.0, 1.0))), 4)
+    assert "every point" in text
+
+
+def test_format_table_avoids_negative_zero():
+    text = format_table(build_result(_args(slope=1.0, intercept=-1e-9)), 2)
+    assert "-0.00" not in text
+
+
+def test_format_json_round_trips():
+    payload = json.loads(format_json(build_result(_args())))
+    assert payload["slope"] == 2.0
+    assert payload["standard"]["a"] == 2
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def test_main_two_point_run(capsys):
+    assert main(["--points", "0,32", "100,212"]) == 0
+    assert "y = 1.8x + 32" in capsys.readouterr().out
+
+
+def test_main_json_output(capsys):
+    assert main(["--slope", "2", "--intercept", "1", "--format", "json"]) == 0
+    assert json.loads(capsys.readouterr().out)["intercept"] == 1.0
+
+
+def test_main_evaluate_matches_documented_example(capsys):
+    assert main(["--slope", "1.8", "--intercept", "32", "--at", "37", "-P", "2"]) == 0
+    assert "y(37.00) = 98.60" in capsys.readouterr().out
+
+
+def test_main_validation_error_exits_two(capsys):
+    assert main(["--slope", "2"]) == 2
+    assert "Error:" in capsys.readouterr().err
+
+
+def test_main_vertical_line_exits_two(capsys):
+    assert main(["--points", "3,1", "3,5"]) == 2
+    assert "vertical line" in capsys.readouterr().err
+
+
+def test_main_horizontal_solve_exits_two(capsys):
+    assert main(["--slope", "0", "--intercept", "5", "--solve", "2"]) == 2
+    assert "horizontal line" in capsys.readouterr().err
+
+
+def test_main_standard_form_entry(capsys):
+    assert main(["--standard", "3", "-2", "6"]) == 0
+    assert "y = 1.5x - 3" in capsys.readouterr().out


### PR DESCRIPTION
> **Merge first.** #60 is stacked on this branch and targets it as its base, so this PR merges before #60.

Closes #3. Closes #10. Closes #55.

Three tools, one commit each, plus a docs commit moving them out of the proposed backlog. Full suite: **1914 passing, 100% coverage**.

## `mlreg` — multiple linear regression (#3)

Extends `linreg` from one predictor to many. Coefficient estimates with standard errors, t-statistics, p-values, and confidence intervals; R², adjusted R², residual standard error, and the overall F-test; optional variance inflation factors; predictions carrying **both** interval kinds — the mean-response confidence interval and the wider single-observation prediction interval, which is the reason to reach for this over `linreg`.

The overall p-value is evaluated straight from the incomplete-beta tail rather than as `1 - cdf`. On the smoke-test model (F = 1417 on 2 and 37 df) the CDF rounds to exactly 1.0, so the subtraction form reports `p = 0` where scipy gives `1.08e-35`.

The exact incomplete beta is imported from `anova` rather than copied a third time. `linear_regression.py`'s equivalents were deliberately not reused: they substitute a normal approximation above df = 30, which would bias coefficient p-values on any dataset past a few dozen rows.

## `logreg` — binary logistic regression (#10)

The classification counterpart to `linreg`. Newton-Raphson (IRLS) fit reporting coefficients as both log-odds and odds ratios, with Wald standard errors, z-statistics, p-values, and intervals. Model fit via log-likelihood against the intercept-only null, McFadden pseudo-R², AIC, and BIC. Confusion matrix with accuracy, precision, recall, and F1 at a configurable `--threshold`. `--predict-file` scores new observations; any two distinct target values are accepted, not just 0/1.

## `slopeint` — slope-intercept lines (#55)

Line algebra for an *exact*, known line, complementing `linreg`, which *estimates* one. Entered as two points, point-slope, or standard form `Ax + By = C`, and reported in all three. Standard form is normalised to primitive integer coefficients via `fractions.Fraction`, so `y = 1.8x + 32` reports as `9x - 5y = -160`. Evaluate, solve, intersect, project a point with distance and foot, and emit the perpendicular or parallel line through a point.

## Correctness

Every numeric claim is pinned to an independent oracle rather than to the implementation's own arithmetic:

| Quantity | Oracle | Agreement |
|---|---|---|
| `mlreg` coefficients, SEs, R², F | numpy `lstsq` + `scipy.stats` | 1e-10 |
| `mlreg` CI and PI bounds | manual leverage + `scipy.stats.t.ppf` | 1e-13 |
| `mlreg` VIF | pairwise `1/(1-r²)` identity | exact |
| `logreg` coefficients, log-likelihood | `scipy.optimize` BFGS maximiser | 1e-8 |
| `logreg` standard errors | finite-difference Hessian | 1e-9 |
| `f_sf`, `t_cdf`, `t_quantile` | `scipy.stats` | 1e-10 |

scipy's own `hess_inv` disagrees with `logreg`'s standard errors at the second decimal because it is a quasi-Newton approximation; the numerical Hessian is the correct reference.

## Degenerate inputs

Refused with named errors rather than returned quietly — the failure mode #52 describes elsewhere in the codebase:

- `logreg`: perfectly separable classes have no finite MLE; both routes to that state (singular information matrix, coefficients that never stop creeping) raise and are tested. A non-converged run raises rather than returning the last iterate.
- `mlreg`: collinear or constant predictors leave coefficients unidentified. A constant response was producing a **negative F-statistic** from roundoff-signed sums of squares, which then raised a baffling error from inside the p-value; it is now rejected up front.
- `slopeint`: vertical lines report having no slope-intercept form, horizontal lines report that solving for x has no answer, and parallel is distinguished from coincident.

## Dead code removed rather than pragma'd

Two guards were written, found unreachable when traced, and deleted instead of being left with a coverage pragma:

- `slopeint.to_standard` GCD reduction — the construction already yields primitive coefficients (B is the lcm of two reduced denominators). Verified over 90,000 numerator/denominator combinations, zero reducible triples.
- `logreg` "coefficients diverged" limit — traced over class separations from adjacent to 1e6 apart; the singular-matrix or iteration-cap guard always fires first.

## Known issue not fixed here

`anova.f_sf` has the same `1 - cdf` cancellation that `mlreg.f_sf` avoids, so ANOVA currently reports `p = 0.0` for strongly significant results. Filed as issue #59. Out of scope for this branch — it needs its own change and tests. The `linear_regression` share of that issue is handled in #60, stacked on top of this branch.
